### PR TITLE
Add MemoryInfoStat to Process and fill it while reading /proc/<pid>/status

### DIFF
--- a/process.go
+++ b/process.go
@@ -12,6 +12,7 @@ type Process struct {
 	uids           []int32
 	gids           []int32
 	numThreads     int32
+	memInfo        *MemoryInfoStat
 }
 
 type OpenFilesStat struct {
@@ -20,8 +21,9 @@ type OpenFilesStat struct {
 }
 
 type MemoryInfoStat struct {
-	RSS uint64 `json:"rss"` // bytes
-	VMS uint64 `json:"vms"` // bytes
+	RSS  uint64 `json:"rss"`  // bytes
+	VMS  uint64 `json:"vms"`  // bytes
+	Swap uint64 `json:"swap"` // bytes
 }
 
 type RlimitStat struct {

--- a/process_linux.go
+++ b/process_linux.go
@@ -150,11 +150,7 @@ func (p *Process) CPUAffinity() ([]int32, error) {
 	return nil, NotImplementedError
 }
 func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	memInfo, _, err := p.fillFromStatm()
-	if err != nil {
-		return nil, err
-	}
-	return memInfo, nil
+	return p.memInfo, nil
 }
 func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
 	_, memInfoEx, err := p.fillFromStatm()
@@ -433,6 +429,7 @@ func (p *Process) fillFromStatus() error {
 	}
 	lines := strings.Split(string(contents), "\n")
 	p.numCtxSwitches = &NumCtxSwitchesStat{}
+	p.memInfo = &MemoryInfoStat{}
 	for _, line := range lines {
 		tabParts := strings.SplitN(line, "\t", 2)
 		if len(tabParts) < 2 {
@@ -483,7 +480,29 @@ func (p *Process) fillFromStatus() error {
 				return err
 			}
 			p.numCtxSwitches.Involuntary = v
+		case "VmRSS":
+			value := strings.Trim(value, " kB") // remove last "kB"
+			v, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return err
+			}
+			p.memInfo.RSS = v * 1024
+		case "VmSize":
+			value := strings.Trim(value, " kB") // remove last "kB"
+			v, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return err
+			}
+			p.memInfo.VMS = v * 1024
+		case "VmSwap":
+			value := strings.Trim(value, " kB") // remove last "kB"
+			v, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return err
+			}
+			p.memInfo.Swap = v * 1024
 		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
Main reason: add swap stats per process.
- added MemoryInfoStat to Process as *memInfo
- fill MemoryInfoStat from /proc/<pid>/status , we read it anyway
- it's faster than smaps when quering many processes
- /proc/<pid>/smaps are not always present, it requires CONFIG_PROC_PAGE_MONITOR option to be set
