### PR TITLE
Fix panics with docker stats

### DIFF
--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -109,7 +109,10 @@ func CgroupMem(containerid string, base string) (*CgroupMemStat, error) {
 	if len(containerid) == 0 {
 		containerid = "all"
 	}
-	lines, _ := common.ReadLines(path)
+	lines, err := common.ReadLines(path)
+	if err != nil {
+		return nil, err
+	}
 	ret := &CgroupMemStat{ContainerID: containerid}
 	for _, line := range lines {
 		fields := strings.Split(line, " ")

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -71,7 +71,10 @@ func CgroupCPU(containerid string, base string) (*cpu.CPUTimesStat, error) {
 	}
 	path := path.Join(base, containerid, "cpuacct.stat")
 
-	lines, _ := common.ReadLines(path)
+	lines, err := common.ReadLines(path)
+	if err != nil {
+		return nil, err
+	}
 	// empty containerid means all cgroup
 	if len(containerid) == 0 {
 		containerid = "all"

--- a/docker/docker_linux_test.go
+++ b/docker/docker_linux_test.go
@@ -31,6 +31,13 @@ func TestCgroupCPU(t *testing.T) {
 	}
 }
 
+func TestCgroupCPUInvalidId(t *testing.T) {
+	_, err := CgroupCPUDocker("bad id")
+	if err == nil {
+		t.Error("Expected path does not exist error")
+	}
+}
+
 func TestCgroupMem(t *testing.T) {
 	v, _ := GetDockerIDList()
 	for _, id := range v {

--- a/docker/docker_linux_test.go
+++ b/docker/docker_linux_test.go
@@ -44,3 +44,10 @@ func TestCgroupMem(t *testing.T) {
 		}
 	}
 }
+
+func TestCgroupMemInvalidId(t *testing.T) {
+	_, err := CgroupMemDocker("bad id")
+	if err == nil {
+		t.Error("Expected path does not exist error")
+	}
+}


### PR DESCRIPTION
Fixes two panic in CgroupMem and CgroupCPU that can occur if you pass an invalid container ID.   The stat file may not exist and the error returned from reading it was being ignored.  This fix returns the error and does not try to continue reading the contents of the file.