### PR TITLE
return value of "sysctl hw.memsize" is memory size in bytes.

### DIFF
--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -53,7 +53,7 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 	}
 
 	ret := &VirtualMemoryStat{
-		Total: parsed[0] * p,
+		Total: parsed[0],
 		Free:  parsed[1] * p,
 	}
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/758324/9292454/cb817a38-4434-11e5-8d30-269ff6188630.png)
