### PR TITLE
Fix memory reporting for linux systems

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -26,10 +26,9 @@ var (
 
 const WaitMSec = 500
 
-func DiskUsage(path string) (DiskUsageStat, error) {
+func DiskUsage(path string) (*DiskUsageStat, error) {
 	ret := DiskUsageStat{}
 
-	ret.Path = path
 	lpFreeBytesAvailable := int64(0)
 	lpTotalNumberOfBytes := int64(0)
 	lpTotalNumberOfFreeBytes := int64(0)
@@ -39,19 +38,19 @@ func DiskUsage(path string) (DiskUsageStat, error) {
 		uintptr(unsafe.Pointer(&lpTotalNumberOfBytes)),
 		uintptr(unsafe.Pointer(&lpTotalNumberOfFreeBytes)))
 	if diskret == 0 {
-		return ret, err
+		return nil, err
 	}
-	ret.Total = uint64(lpTotalNumberOfBytes)
-	//	ret.Free = uint64(lpFreeBytesAvailable) // python psutil does not use this
-	ret.Free = uint64(lpTotalNumberOfFreeBytes)
-	ret.Used = ret.Total - ret.Free
-	ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
-
-	//TODO: implement inodes stat
-	ret.InodesTotal = 0
-	ret.InodesUsed = 0
-	ret.InodesFree = 0
-	ret.InodesUsedPercent = 0.0
+	ret := &DiskUsageStat{
+		Path:  path,
+		Total: uint64(lpTotalNumberOfBytes),
+		Free:  uint64(lpTotalNumberOfFreeBytes),
+		// Used: uint64(lpTotalNumberOfBytes) - uint64(lpTotalNumberOfFreeBytes)
+		// UsedPercent: (float64(lpTotalNumberOfBytes) - float64(lpTotalNumberOfFreeBytes)) / float64(lpTotalNumberOfBytes) * 100
+		// InodesTotal: 0,
+		// InodesFree: 0,
+		// InodesUsed: 0,
+		// InodesUsedPercent: 0,
+	}
 	return ret, nil
 }
 

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -30,17 +30,17 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 		}
 		switch key {
 		case "MemTotal":
-			ret.Total = t * 1000
+			ret.Total = t * 1024
 		case "MemFree":
-			ret.Free = t * 1000
+			ret.Free = t * 1024
 		case "Buffers":
-			ret.Buffers = t * 1000
+			ret.Buffers = t * 1024
 		case "Cached":
-			ret.Cached = t * 1000
+			ret.Cached = t * 1024
 		case "Active":
-			ret.Active = t * 1000
+			ret.Active = t * 1024
 		case "Inactive":
-			ret.Inactive = t * 1000
+			ret.Inactive = t * 1024
 		}
 	}
 	ret.Available = ret.Free + ret.Buffers + ret.Cached


### PR DESCRIPTION
/proc/meminfo reports memory in KiloBytes and so needs a multiplier of
1024 instead of 1000.
The kernel reports in terms of pages and the proc filesystem is left
shifting by 2 for 4KB pages to get KB. Since this is a binary shift,
Bytes will need to shift by 10 and so get multiplied by 1024.

From the kernel code. PAGE_SHIFT = 12 for 4KB pages
"MemTotal:       %8lu kB\n", K(i.totalram)

Thanks to @subhachandrachandra!