### PR TITLE
Fix cpu percent on windows

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -99,7 +99,7 @@ func CPUPercent(interval time.Duration, percpu bool) ([]float64, error) {
 		if l.LoadPercentage == nil {
 			continue
 		}
-		ret = append(ret, float64(*l.LoadPercentage)/100.0)
+		ret = append(ret, float64(*l.LoadPercentage))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Tested on windows 7:

When divided by 100 you get cpu percentage of  %0.14 when task manager shows %14. Once this is removed they match.