### PR TITLE
Fix net stat reporting for Darwin

### DIFF
--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -38,11 +38,14 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 			base = 0
 		}
 
-		parsed := make([]uint64, 0, 3)
+		parsed := make([]uint64, 0, 6)
 		vv := []string{
-			values[base+3], // PacketsRecv
-			values[base+4], // Errin
-			values[base+5], // Dropin
+			values[base+3], // Ipkts == PacketsRecv
+			values[base+4], // Ierrs == Errin
+			values[base+5], // Ibytes == BytesRecv
+			values[base+6], // Opkts == PacketsSent
+			values[base+7], // Oerrs == Errout
+			values[base+8], // Obytes == BytesSent
 		}
 		for _, target := range vv {
 			if target == "-" {
@@ -61,7 +64,10 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 			Name:        values[0],
 			PacketsRecv: parsed[0],
 			Errin:       parsed[1],
-			Dropin:      parsed[2],
+			BytesRecv:   parsed[2],
+			PacketsSent: parsed[3],
+			Errout:      parsed[4],
+			BytesSent:   parsed[5],
 		}
 		ret = append(ret, n)
 	}


### PR DESCRIPTION
netstat columns in darwin are a little different than what is found here, see output from a command below

```
$ netstat -ibdn
Name  Mtu   Network       Address            Ipkts Ierrs     Ibytes    Opkts Oerrs     Obytes  Coll Drop
en0   1500  <Link#4>    98:5a:eb:e2:a7:0f  9895174     2 11902425614  9250217     0 2354022366     0   0
en0   1500  fe80::9a5a: fe80:4::9a5a:ebff  9895174     - 11902425614  9250217     - 2354022366     -   -
en0   1500  10.0.1/24     10.0.1.13        9895174     - 11902425614  9250217     - 2354022366     -   -
en1   1500  <Link#5>    d0:03:4b:cb:73:79        0     0          0        0     0          0     0   3
en2   1500  <Link#6>    0a:00:00:ae:7a:70        0     0          0        0     0          0     0   0
en3   1500  <Link#7>    0a:00:00:ae:7a:71        0     0          0        0     0          0     0   0

```