### PR TITLE
Ensure that process.MemoryInfo returns a up-to-date value.

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -153,6 +153,10 @@ func (p *Process) CPUAffinity() ([]int32, error) {
 	return nil, common.NotImplementedError
 }
 func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
+	_, _, err := p.fillFromStatm()
+	if err != nil {
+		return nil, err
+	}
 	return p.memInfo, nil
 }
 func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {


### PR DESCRIPTION
process.MemoryInfo in process_linux.go returns directly process.memInfo, which might be outdated. This patch calls fillFromStatm before returning p.memInfo so that p.memInfo becomes up-to-date.