### PR TITLE
Detect error in CPUTimes fails on callPs, and modify comments on ReadLines

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -17,7 +17,7 @@ import (
 
 var NotImplementedError = errors.New("not implemented yet")
 
-// ReadLines reads contents from file and splits them by new line.
+// ReadLines reads contents from a file and splits them by new lines.
 // A convenience wrapper to ReadLinesOffsetN(filename, 0, -1).
 func ReadLines(filename string) ([]string, error) {
 	return ReadLinesOffsetN(filename, 0, -1)

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -215,6 +215,10 @@ func convertCpuTimes(s string) (ret float64, err error) {
 func (p *Process) CPUTimes() (*cpu.CPUTimesStat, error) {
 	r, err := callPs("utime,stime", p.Pid, false)
 
+	if err != nil {
+		return nil, err
+	}
+
 	utime, err := convertCpuTimes(r[0][0])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hi~, This is my first pr on github.
I've made two modifications.
One is just small change for comment.
The other is error processing on CPUTimes().

On MacOSX code like below fails on last PID in CPUTimes()

```
  pids, _ := process.Pids();
  for i := 0 ; i < len(pids) ; i++ {
    p, _ := process.NewProcess(pids[i])
    e, _ := p.Cmdline()
    fmt.Printf("process:%d",p.Pid)
    t, err := p.CPUTimes()
    if err != nil {
        fmt.Println("error %s",err)
    } else {
      fmt.Printf("process %s, %f, %f, %f, %f %s\n",t.CPU,t.User, t.System, t.Nice, t.Idle, e)
    }
  }
```
Thanks, 