### PR TITLE
Fix docker on Centos 7

### DIFF
--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -46,9 +46,13 @@ func CgroupCPU(containerid string, base string) (*cpu.CPUTimesStat, error) {
 	if len(base) == 0 {
 		base = "/sys/fs/cgroup/cpuacct/docker"
 	}
-	path := path.Join(base, containerid, "cpuacct.stat")
+	statfile := path.Join(base, containerid, "cpuacct.stat")
 
-	lines, err := common.ReadLines(path)
+        if _, err := os.Stat(statfile); os.IsNotExist(err) {
+            statfile = path.Join("/sys/fs/cgroup/cpuacct/system.slice",  "docker-" + containerid + ".scope", "cpuacct.stat")
+        }
+
+	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return nil, err
 	}
@@ -84,12 +88,17 @@ func CgroupMem(containerid string, base string) (*CgroupMemStat, error) {
 	if len(base) == 0 {
 		base = "/sys/fs/cgroup/memory/docker"
 	}
-	path := path.Join(base, containerid, "memory.stat")
+	statfile := path.Join(base, containerid, "memory.stat")
+
+        if _, err := os.Stat(statfile); os.IsNotExist(err) {
+            statfile = path.Join("/sys/fs/cgroup/memory/system.slice",  "docker-" + containerid + ".scope", "memory.stat")
+        }
+
 	// empty containerid means all cgroup
 	if len(containerid) == 0 {
 		containerid = "all"
 	}
-	lines, err := common.ReadLines(path)
+	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -4,6 +4,7 @@ package docker
 
 import (
 	"encoding/json"
+        "os"
 	"os/exec"
 	"path"
 	"strconv"


### PR DESCRIPTION
Fixes this error:

    error getting docker info: open /sys/fs/cgroup/cpuacct/docker/05a087a0d8b88c706493d28de9c911a62a513dae5dd19bb76a50b6c7ed39e5ab/cpuacct.stat: no such file or directory

On Centos 7 docker control groups are /sys/fs/cgroup/cpuacct/system.slice/docker-....

Please pull.