### PR TITLE
When MemAvailable is in /proc/meminfo, use it (kernel 3.14+)

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -13,6 +13,8 @@ import (
 func VirtualMemory() (*VirtualMemoryStat, error) {
 	filename := "/proc/meminfo"
 	lines, _ := common.ReadLines(filename)
+	// flag if MemAvailable is in /proc/meminfo (kernel 3.14+)
+	memavail := false
 
 	ret := &VirtualMemoryStat{}
 	for _, line := range lines {
@@ -33,6 +35,9 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 			ret.Total = t * 1024
 		case "MemFree":
 			ret.Free = t * 1024
+		case "MemAvailable":
+			memavail = true
+			ret.Available = t * 1024
 		case "Buffers":
 			ret.Buffers = t * 1024
 		case "Cached":
@@ -43,7 +48,9 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 			ret.Inactive = t * 1024
 		}
 	}
-	ret.Available = ret.Free + ret.Buffers + ret.Cached
+	if !memavail {
+		ret.Available = ret.Free + ret.Buffers + ret.Cached
+	}
 	ret.Used = ret.Total - ret.Free
 	ret.UsedPercent = float64(ret.Total-ret.Available) / float64(ret.Total) * 100.0
 


### PR DESCRIPTION
MemAvailable is now officially tracked in the linux kernel! They did this to try to fix some of the confusion around used/actual_used memory. In my experience, the number the kernel is reporting is a little bit lower than what you get when you just do `Free + Cache + Buffered`.
