### PR TITLE
CreateTime() on linux returning an incorrect timestamp

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -596,8 +596,8 @@ func (p *Process) fillFromStat() (string, int32, *cpu.CPUTimesStat, int64, int32
 	if err != nil {
 		return "", 0, nil, 0, 0, err
 	}
-	ctime := (t / uint64(ClockTicks)) + uint64(bootTime)*1000
-	createTime := int64(ctime)
+	ctime := (t / uint64(ClockTicks)) + uint64(bootTime)
+	createTime := int64(ctime * 1000)
 
 	//	p.Nice = mustParseInt32(fields[18])
 	// use syscall instead of parse Stat file

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -270,8 +270,16 @@ func Test_Process_CreateTime(t *testing.T) {
 	if err != nil {
 		t.Errorf("error %v", err)
 	}
+
 	if c < 1420000000 {
 		t.Errorf("process created time is wrong.")
+	}
+
+	gotElapsed := time.Since(time.Unix(int64(c/1000), 0))
+	maxElapsed := time.Duration(5 * time.Second)
+
+	if gotElapsed >= maxElapsed {
+		t.Errorf("this process has not been running for %v", gotElapsed)
 	}
 }
 


### PR DESCRIPTION
CreateTime() on linux seems a few hours out - looks like it is converting the bootTime to microseconds before adding the elapsed time in seconds instead of adding them and then converting the total to microseconds