### PR TITLE
cpu: support ARM CPUs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ The output is below.
   {"total":3179569152,"available":492572672,"used":2895335424,"usedPercent":84.50819439828305, (snip)}
 
 You can set an alternative location to /proc by setting the HOST_PROC environment variable.
+You can set an alternative location to /sys by setting the HOST_SYS environment variable.
 
 Documentation
 ------------------------


### PR DESCRIPTION
ARM CPUs don't include the same fields as  x86 and amd64 CPUs in
the /proc/cpuinfo list. Pull information from the /sys/...
device tree as well as updating when a CPU is done in cpuinfo.

Tested on an ARMv7 A20.

Fixes #88 
