### PR TITLE
Add system wide network protocol stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,11 @@ Several methods have been added which are not present in psutil, but will provid
 
   - various status
 
+- net_protocols (linux only)
+
+  - system wide stats on network protocols (i.e IP, TCP, UDP, etc.)
+  - sourced from /proc/net/snmp
+
 Some codes are ported from Ohai. many thanks.
 
 
@@ -145,6 +150,7 @@ users                x      x      x       x
 pids                 x      x      x       x
 pid_exists           x      x      x       x
 net_connections      x             x
+net_protocols        x
 net_if_addrs
 net_if_stats
 ================= ====== ======= ====== =======

--- a/net/net.go
+++ b/net/net.go
@@ -45,6 +45,12 @@ type NetConnectionStat struct {
 	Pid    int32  `json:"pid"`
 }
 
+// System wide stats about different network protocols
+type NetProtoCountersStat struct {
+	Protocol string           `json:"protocol"`
+	Stats    map[string]int64 `json:"stats"`
+}
+
 // NetInterfaceAddr is designed for represent interface addresses
 type NetInterfaceAddr struct {
 	Addr string `json:"addr"`
@@ -71,6 +77,11 @@ func (n NetIOCountersStat) String() string {
 }
 
 func (n NetConnectionStat) String() string {
+	s, _ := json.Marshal(n)
+	return string(s)
+}
+
+func (n NetProtoCountersStat) String() string {
 	s, _ := json.Marshal(n)
 	return string(s)
 }

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -89,4 +90,12 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	}
 
 	return ret, nil
+}
+
+// NetProtoCounters returns network statistics for the entire system
+// If protocols is empty then all protocols are returned, otherwise
+// just the protocols in the list are returned.
+// Not Implemented for Darwin
+func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
+	return nil, errors.New("NetProtoCounters not implemented for darwin")
 }

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -80,4 +81,12 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	}
 
 	return ret, nil
+}
+
+// NetProtoCounters returns network statistics for the entire system
+// If protocols is empty then all protocols are returned, otherwise
+// just the protocols in the list are returned.
+// Not Implemented for FreeBSD
+func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
+	return nil, errors.New("NetProtoCounters not implemented for freebsd")
 }

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -88,4 +89,74 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	}
 
 	return ret, nil
+}
+
+var netProtocols = []string{
+	"ip",
+	"icmp",
+	"icmpmsg",
+	"tcp",
+	"udp",
+	"udplite",
+}
+
+// NetProtoCounters returns network statistics for the entire system
+// If protocols is empty then all protocols are returned, otherwise
+// just the protocols in the list are returned.
+// Available protocols:
+//   ip,icmp,icmpmsg,tcp,udp,udplite
+func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
+	if len(protocols) == 0 {
+		protocols = netProtocols
+	}
+
+	stats := make([]NetProtoCountersStat, 0, len(protocols))
+	protos := make(map[string]bool, len(protocols))
+	for _, p := range protocols {
+		protos[p] = true
+	}
+
+	filename := "/proc/net/snmp"
+	lines, err := common.ReadLines(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	linecount := len(lines)
+	for i := 0; i < linecount; i++ {
+		line := lines[i]
+		r := strings.IndexRune(line, ':')
+		if r == -1 {
+			return nil, errors.New(filename + " is not fomatted correctly, expected ':'.")
+		}
+		proto := strings.ToLower(line[:r])
+		if !protos[proto] {
+			// skip protocol and data line
+			i++
+			continue
+		}
+
+		// Read header line
+		statNames := strings.Split(line[r+2:], " ")
+
+		// Read data line
+		i++
+		statValues := strings.Split(lines[i][r+2:], " ")
+		if len(statNames) != len(statValues) {
+			return nil, errors.New(filename + " is not fomatted correctly, expected same number of columns.")
+		}
+		stat := NetProtoCountersStat{
+			Protocol: proto,
+			Stats:    make(map[string]int64, len(statNames)),
+		}
+		for j := range statNames {
+			value, err := strconv.ParseInt(statValues[j], 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			stat.Stats[statNames[j]] = value
+		}
+		stats = append(stats, stat)
+	}
+	return stats, nil
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -26,6 +26,22 @@ func TestNetIOCountersStatString(t *testing.T) {
 	}
 }
 
+func TestNetProtoCountersStatString(t *testing.T) {
+	v := NetProtoCountersStat{
+		Protocol: "tcp",
+		Stats: map[string]int64{
+			"MaxConn":      -1,
+			"ActiveOpens":  4000,
+			"PassiveOpens": 3000,
+		},
+	}
+	e := `{"protocol":"tcp","stats":{"ActiveOpens":4000,"MaxConn":-1,"PassiveOpens":3000}}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("NetProtoCountersStat string is invalid: %v", v)
+	}
+
+}
+
 func TestNetConnectionStatString(t *testing.T) {
 	v := NetConnectionStat{
 		Fd:     10,
@@ -118,6 +134,45 @@ func TestNetInterfaces(t *testing.T) {
 	for _, vv := range v {
 		if vv.Name == "" {
 			t.Errorf("Invalid NetInterface: %v", vv)
+		}
+	}
+}
+
+func TestNetProtoCountersStatsAll(t *testing.T) {
+	v, err := NetProtoCounters(nil)
+	if err != nil {
+		t.Fatalf("Could not get NetProtoCounters: %v", err)
+	}
+	if len(v) == 0 {
+		t.Fatalf("Could not get NetProtoCounters: %v", err)
+	}
+	for _, vv := range v {
+		if vv.Protocol == "" {
+			t.Errorf("Invalid NetProtoCountersStat: %v", vv)
+		}
+		if len(vv.Stats) == 0 {
+			t.Errorf("Invalid NetProtoCountersStat: %v", vv)
+		}
+	}
+}
+
+func TestNetProtoCountersStats(t *testing.T) {
+	v, err := NetProtoCounters([]string{"tcp", "ip"})
+	if err != nil {
+		t.Fatalf("Could not get NetProtoCounters: %v", err)
+	}
+	if len(v) == 0 {
+		t.Fatalf("Could not get NetProtoCounters: %v", err)
+	}
+	if len(v) != 2 {
+		t.Fatalf("Go incorrect number of NetProtoCounters: %v", err)
+	}
+	for _, vv := range v {
+		if vv.Protocol != "tcp" && vv.Protocol != "ip" {
+			t.Errorf("Invalid NetProtoCountersStat: %v", vv)
+		}
+		if len(vv.Stats) == 0 {
+			t.Errorf("Invalid NetProtoCountersStat: %v", vv)
 		}
 	}
 }

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"errors"
 	"net"
 	"os"
 	"syscall"
@@ -95,4 +96,12 @@ func getAdapterList() (*syscall.IpAdapterInfo, error) {
 		return nil, os.NewSyscallError("GetAdaptersInfo", err)
 	}
 	return a, nil
+}
+
+// NetProtoCounters returns network statistics for the entire system
+// If protocols is empty then all protocols are returned, otherwise
+// just the protocols in the list are returned.
+// Not Implemented for Windows
+func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
+	return nil, errors.New("NetProtoCounters not implemented for windows")
 }


### PR DESCRIPTION
A new method `NetProtoCounters`  has been added that returns a list of `NetProtoCountersStat` objects.
A map is used in `NetProtoCountersStat` since the stat names are different per protocol.

Typical contents of `/proc/net/snmp`
The file contains system wide counters about different network protocols.

```
Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
Ip: 1 64 145831951 0 4 420174 0 0 145410079 138817441 3718096 285 0 0 0 0 0 0 0
Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
Tcp: 1 200 120000 -1 441395 303349 29634 9431 66 14558102 12577486 14364 676 53622 0
Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
Udp: 67688650 3723361 58108572 124599763 58108572 0 0 318767
```

Only linux support has been added. Other OSes have been give an implementation that returns a not implemented error.

Fixes #108 