### PR TITLE
process[linux,freebsd,darwin]: implements Children using pgrep.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ cpu_percent         x            x
 cpu_affinity
 memory_percent
 parent              x            x
-children
+children            x     x      x
 connections         x            x
 is_running
 ================ ===== ======= ====== =======

--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -38,3 +38,29 @@ func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
 	}
 	return ret, nil
 }
+
+func CallPgrep(invoke Invoker, pid int32) ([]int32, error) {
+	var cmd []string
+	cmd = []string{"-P", strconv.Itoa(int(pid))}
+	pgrep, err := exec.LookPath("pgrep")
+	if err != nil {
+		return []int32{}, err
+	}
+	out, err := invoke.Command(pgrep, cmd...)
+	if err != nil {
+		return []int32{}, err
+	}
+	lines := strings.Split(string(out), "\n")
+	ret := make([]int32, 0, len(lines))
+	for _, l := range lines {
+		if len(l) == 0 {
+			continue
+		}
+		i, err := strconv.Atoi(l)
+		if err != nil {
+			continue
+		}
+		ret = append(ret, int32(i))
+	}
+	return ret, nil
+}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/net"
 )
 
@@ -278,7 +278,19 @@ func (p *Process) MemoryPercent() (float32, error) {
 }
 
 func (p *Process) Children() ([]*Process, error) {
-	return nil, common.NotImplementedError
+	pids, err := common.CallPgrep(invoke, p.Pid)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*Process, 0, len(pids))
+	for _, pid := range pids {
+		np, err := NewProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, np)
+	}
+	return ret, nil
 }
 
 func (p *Process) OpenFiles() ([]OpenFilesStat, error) {

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -7,8 +7,8 @@ import (
 	"encoding/binary"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
 	cpu "github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/internal/common"
 	net "github.com/shirou/gopsutil/net"
 )
 
@@ -168,7 +168,19 @@ func (p *Process) MemoryPercent() (float32, error) {
 }
 
 func (p *Process) Children() ([]*Process, error) {
-	return nil, common.NotImplementedError
+	pids, err := common.CallPgrep(invoke, p.Pid)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*Process, 0, len(pids))
+	for _, pid := range pids {
+		np, err := NewProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, np)
+	}
+	return ret, nil
 }
 
 func (p *Process) OpenFiles() ([]OpenFilesStat, error) {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -203,7 +203,19 @@ func (p *Process) MemoryPercent() (float32, error) {
 }
 
 func (p *Process) Children() ([]*Process, error) {
-	return nil, common.NotImplementedError
+	pids, err := common.CallPgrep(invoke, p.Pid)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*Process, 0, len(pids))
+	for _, pid := range pids {
+		np, err := NewProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, np)
+	}
+	return ret, nil
 }
 
 func (p *Process) OpenFiles() ([]OpenFilesStat, error) {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -312,3 +312,19 @@ func Test_Connections(t *testing.T) {
 		t.Fatalf("wrong connections")
 	}
 }
+
+func Test_Children(t *testing.T) {
+	p, err := NewProcess(1)
+	if err != nil {
+		t.Fatalf("new process error %v", err)
+	}
+
+	c, err := p.Children()
+	if err != nil {
+		t.Fatalf("error %v", err)
+	}
+	if len(c) == 0 {
+		t.Fatalf("children is empty")
+	}
+
+}


### PR DESCRIPTION
refs. #111 

Implements Process.Chidlren by using `pgrep`.
At least linux, freebsd, and darin, pgrep can be used with `-P` option.