### PR TITLE
Add nf_conntrack counter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 #*
 _obj
 *.tmp
+.idea

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,11 @@ Several methods have been added which are not present in psutil, but will provid
   - system wide stats on network protocols (i.e IP, TCP, UDP, etc.)
   - sourced from /proc/net/snmp
 
+- iptables nf_conntrack (linux only)
+
+  - system wide stats on netfilter conntrack module
+  - sourced from /proc/sys/net/netfilter/nf_conntrack_count
+
 Some codes are ported from Ohai. many thanks.
 
 
@@ -153,6 +158,7 @@ net_connections      x             x
 net_protocols        x
 net_if_addrs
 net_if_stats
+netfilter_conntrack  x
 ================= ====== ======= ====== =======
 
 Process class

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -141,6 +141,33 @@ func ByteToString(orig []byte) string {
 	return string(orig[l:n])
 }
 
+// ReadInts reads contents from single line file and returns them as []int32.
+func ReadInts(filename string) ([]int64, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return []int64{}, err
+	}
+	defer f.Close()
+
+	var ret []int64
+
+	r := bufio.NewReader(f)
+
+	// The int files that this is concerned with should only be one liners.
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return []int64{}, err
+	}
+
+	i, err := strconv.ParseInt(strings.Trim(line, "\n"), 10, 32)
+	if err != nil {
+		return []int64{}, err
+	}
+	ret = append(ret, i)
+
+	return ret, nil
+}
+
 // Parse to int32 without error
 func mustParseInt32(val string) int32 {
 	vv, _ := strconv.ParseInt(val, 10, 32)

--- a/net/net.go
+++ b/net/net.go
@@ -65,8 +65,8 @@ type NetInterfaceStat struct {
 }
 
 type NetFilterStat struct {
-	ConnTrackCount	int32	`json:"conntrackcount"`
-	ConnTrackMax	int32	`json:"conntrackmax"`
+	ConnTrackCount	int64	`json:"conntrackcount"`
+	ConnTrackMax	int64	`json:"conntrackmax"`
 }
 
 var constMap = map[string]int{

--- a/net/net.go
+++ b/net/net.go
@@ -65,8 +65,8 @@ type NetInterfaceStat struct {
 }
 
 type NetFilterStat struct {
-	ConnTrackCount	int64	`json:"conntrackcount"`
-	ConnTrackMax	int64	`json:"conntrackmax"`
+	ConnTrackCount	int64	`json:"conn_track_count"`
+	ConnTrackMax	int64	`json:"conn_track_max"`
 }
 
 var constMap = map[string]int{

--- a/net/net.go
+++ b/net/net.go
@@ -65,8 +65,8 @@ type NetInterfaceStat struct {
 }
 
 type NetFilterStat struct {
-	ConnTrackCount	int64	`json:"conn_track_count"`
-	ConnTrackMax	int64	`json:"conn_track_max"`
+	ConnTrackCount	int64	`json:"conntrack_count"`
+	ConnTrackMax	int64	`json:"conntrack_max"`
 }
 
 var constMap = map[string]int{

--- a/net/net.go
+++ b/net/net.go
@@ -64,6 +64,11 @@ type NetInterfaceStat struct {
 	Addrs        []NetInterfaceAddr `json:"addrs"`
 }
 
+type NetFilterStat struct {
+	ConnTrackCount	int32	`json:"conntrackcount"`
+	ConnTrackMax	int32	`json:"conntrackmax"`
+}
+
 var constMap = map[string]int{
 	"TCP":  syscall.SOCK_STREAM,
 	"UDP":  syscall.SOCK_DGRAM,

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -165,8 +165,8 @@ func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
 // the currently in use conntrack count and the max.
 // If the file does not exist or is invalid it will return nil.
 func NetFilterCounters() ([]NetFilterStat, error) {
-	countfile := "/proc/sys/net/netfilter/nf_conntrack_count"
-	maxfile := "/proc/sys/net/netfilter/nf_conntrack_max"
+    countfile := common.HostProc("sys/net/netfilter/nf_conntrack_count")
+    maxfile := common.HostProc("sys/net/netfilter/nf_conntrack_max")
 
 	count, err := common.ReadInts(countfile)
 

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -160,3 +160,33 @@ func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
 	}
 	return stats, nil
 }
+
+// NetFilterCounters returns iptables conntrack statistics
+// the currently in use conntrack count and the max.
+// If the file does not exist or is invalid it will return nil.
+func NetFilterCounters() (NetFilterStat, error) {
+	countfile := "/proc/sys/net/netfilter/nf_conntrack_count"
+	count, err := common.ReadLines(count)
+	if err != nil {
+		return nil, err
+	}
+
+	maxfile := "/proc/sys/net/netfilter/nf_conntrack_max"
+	max, err := common.ReadLines(maxfile)
+	if err != nil {
+		return nil, err
+	}
+	if len(count) != 1 {
+		// format of file has changed
+		return nil, err
+	}
+	if len(max) != 1 {
+		// format of file has changed
+		return nil, err
+	}
+	stats := NetFilterStat{
+		ConnTrackCount: count,
+		ConnTrackMax:   max,
+	}
+	return stats, nil
+}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -164,29 +164,27 @@ func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
 // NetFilterCounters returns iptables conntrack statistics
 // the currently in use conntrack count and the max.
 // If the file does not exist or is invalid it will return nil.
-func NetFilterCounters() (NetFilterStat, error) {
+func NetFilterCounters() ([]NetFilterStat, error) {
 	countfile := "/proc/sys/net/netfilter/nf_conntrack_count"
-	count, err := common.ReadLines(count)
+	maxfile := "/proc/sys/net/netfilter/nf_conntrack_max"
+
+	count, err := common.ReadInts(countfile)
+
+	if err != nil {
+		return nil, err
+	}
+	stats := make([]NetFilterStat, 0, 1)
+	
+	max, err := common.ReadInts(maxfile)
 	if err != nil {
 		return nil, err
 	}
 
-	maxfile := "/proc/sys/net/netfilter/nf_conntrack_max"
-	max, err := common.ReadLines(maxfile)
-	if err != nil {
-		return nil, err
+	payload := NetFilterStat{
+		ConnTrackCount: count[0],
+		ConnTrackMax:   max[0],
 	}
-	if len(count) != 1 {
-		// format of file has changed
-		return nil, err
-	}
-	if len(max) != 1 {
-		// format of file has changed
-		return nil, err
-	}
-	stats := NetFilterStat{
-		ConnTrackCount: count,
-		ConnTrackMax:   max,
-	}
+
+	stats = append(stats, payload)
 	return stats, nil
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -196,3 +196,23 @@ func TestNetConnections(t *testing.T) {
 	}
 
 }
+
+func TestNetFilterCounters(t *testing.T) {
+	if ci := os.Getenv("CI"); ci != "" { // skip if test on drone.io
+		return
+	}
+
+	v, err := NetFilterCounters()
+	if err != nil {
+		t.Errorf("could not get NetConnections: %v", err)
+	}
+	if len(v) == 0 {
+		t.Errorf("could not get NetConnections: %v", v)
+	}
+	for _, vv := range v {
+		if vv.ConnTrackMax == 0 {
+			t.Errorf("nf_conntrack_max needs to be greater than zero: %v", vv)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds support to read in the current count and the max count settings from the netfilter files in /proc. This is useful for people who need to query statistics iptables based NAT boxes.