### PR TITLE
[net] fix panic on freebsd (netstat error with exit code 0)

### DIFF
--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -32,6 +32,9 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 		}
 		exists = append(exists, values[0])
 
+		if len(values) < 12 {
+			continue
+		}
 		base := 1
 		// sometimes Address is ommitted
 		if len(values) < 13 {


### PR DESCRIPTION
From freebsd jail netstat returns error message, but exit code is 0:
```
# netstat -ibdn && echo $?
netstat: kvm not available: /dev/mem: No such file or directory
ifnet: symbol not defined
0
```

