### PR TITLE
Add a godoc badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,11 @@ gopsutil: psutil for golang
 .. image:: https://drone.io/github.com/shirou/gopsutil/status.png
         :target: https://drone.io/github.com/shirou/gopsutil
 
-.. image:: https://coveralls.io/repos/shirou/gopsutil/badge.png?branch=master
+.. image:: https://coveralls.io/repos/shirou/gopsutil/badge.svg?branch=master
         :target: https://coveralls.io/r/shirou/gopsutil?branch=master
 
+.. image:: https://godoc.org/github.com/shirou/gopsutil?status.svg
+        :target: http://godoc.org/github.com/shirou/gopsutil
 
 This is a port of psutil (http://pythonhosted.org/psutil/). The challenge is porting all
 psutil functions on some architectures...


### PR DESCRIPTION
Change coveralls badge to svg and put in a godoc badge.

drone.io should be supporting svg badges soon (see https://github.com/badges/shields/issues/150 and https://github.com/badges/shields/issues/294), which look much better, especially on 4K screens :-)