### PR TITLE
using HostProc for protocounters in linux

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -116,7 +116,7 @@ func NetProtoCounters(protocols []string) ([]NetProtoCountersStat, error) {
 		protos[p] = true
 	}
 
-	filename := "/proc/net/snmp"
+	filename := common.HostProc("net/snmp")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using ENV variables for host /proc location when parsing protocol counters.