### PR TITLE
Add -W flag to netstat on BSD systems

### DIFF
--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -17,7 +17,7 @@ import (
 // lo0   16384 ::1/128     ::1                 869107     -  169411755   869107     -  169411755     -   -
 // lo0   16384 127           127.0.0.1         869107     -  169411755   869107     -  169411755     -   -
 func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
-	out, err := exec.Command("/usr/sbin/netstat", "-ibdn").Output()
+	out, err := exec.Command("/usr/sbin/netstat", "-ibdnW").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
-	out, err := exec.Command("/usr/bin/netstat", "-ibdn").Output()
+	out, err := exec.Command("/usr/bin/netstat", "-ibdnW").Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This prevents netstat from truncating the interface name to 5
characters. See https://github.com/influxdb/telegraf/issues/438