### PR TITLE
[WIP] net,process[linux]: add process.NetIOCounter and net.NetIOCounterByFile.

### DIFF
--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -92,6 +92,15 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	return ret, nil
 }
 
+// NetIOCountersByFile is an method which is added just a compatibility for linux.
+func NetIOCountersByFile(pernic bool, filename string) ([]NetIOCountersStat, error) {
+	return NetIOCounters(pernic)
+}
+
+func NetFilterCounters() ([]NetFilterStat, error) {
+	return nil, errors.New("NetFilterCounters not implemented for darwin")
+}
+
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -86,6 +86,15 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	return ret, nil
 }
 
+// NetIOCountersByFile is an method which is added just a compatibility for linux.
+func NetIOCountersByFile(pernic bool, filename string) ([]NetIOCountersStat, error) {
+	return NetIOCounters(pernic)
+}
+
+func NetFilterCounters() ([]NetFilterStat, error) {
+	return nil, errors.New("NetFilterCounters not implemented for freebsd")
+}
+
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -17,6 +17,10 @@ import (
 // separately.
 func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	filename := common.HostProc("net/dev")
+	return NetIOCountersByFile(pernic, filename)
+}
+
+func NetIOCountersByFile(pernic bool, filename string) ([]NetIOCountersStat, error) {
 	lines, err := common.ReadLines(filename)
 	if err != nil {
 		return nil, err

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -74,6 +74,11 @@ func NetIOCounters(pernic bool) ([]NetIOCountersStat, error) {
 	return ret, nil
 }
 
+// NetIOCountersByFile is an method which is added just a compatibility for linux.
+func NetIOCountersByFile(pernic bool, filename string) ([]NetIOCountersStat, error) {
+	return NetIOCounters(pernic)
+}
+
 // Return a list of network connections opened by a process
 func NetConnections(kind string) ([]NetConnectionStat, error) {
 	var ret []NetConnectionStat
@@ -96,6 +101,10 @@ func getAdapterList() (*syscall.IpAdapterInfo, error) {
 		return nil, os.NewSyscallError("GetAdaptersInfo", err)
 	}
 	return a, nil
+}
+
+func NetFilterCounters() ([]NetFilterStat, error) {
+	return nil, errors.New("NetFilterCounters not implemented for windows")
 }
 
 // NetProtoCounters returns network statistics for the entire system

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -301,6 +301,10 @@ func (p *Process) Connections() ([]net.NetConnectionStat, error) {
 	return net.NetConnectionsPid("all", p.Pid)
 }
 
+func (p *Process) NetIOCounters(pernic bool) ([]net.NetIOCountersStat, error) {
+	return nil, common.NotImplementedError
+}
+
 func (p *Process) IsRunning() (bool, error) {
 	return true, common.NotImplementedError
 }

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -223,6 +223,10 @@ func (p *Process) Connections() ([]net.NetConnectionStat, error) {
 	return nil, common.NotImplementedError
 }
 
+func (p *Process) NetIOCounters(pernic bool) ([]net.NetIOCountersStat, error) {
+	return nil, common.NotImplementedError
+}
+
 func (p *Process) IsRunning() (bool, error) {
 	return true, common.NotImplementedError
 }

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -235,6 +235,11 @@ func (p *Process) Connections() ([]net.NetConnectionStat, error) {
 	return net.NetConnectionsPid("all", p.Pid)
 }
 
+func (p *Process) NetIOCounters(pernic bool) ([]net.NetIOCountersStat, error) {
+	filename := common.HostProc(strconv.Itoa(int(p.Pid)), "net/dev")
+	return net.NetIOCountersByFile(pernic, filename)
+}
+
 func (p *Process) IsRunning() (bool, error) {
 	return true, common.NotImplementedError
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -243,6 +243,10 @@ func (p *Process) Connections() ([]net.NetConnectionStat, error) {
 	return nil, common.NotImplementedError
 }
 
+func (p *Process) NetIOCounters(pernic bool) ([]net.NetIOCountersStat, error) {
+	return nil, common.NotImplementedError
+}
+
 func (p *Process) IsRunning() (bool, error) {
 	return true, common.NotImplementedError
 }


### PR DESCRIPTION
add `net.NetIOCounterByFile()` and use it from `process.NetIOCounter()`.

Only Linux, NetIOCounter can get from file. A research about get NetIOCounter per process on the other platform is required to determine more better method name.