### PR TITLE
host_linux: Skip everything that isn't a normal process.

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -17,6 +17,9 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
+// from utmpx.h
+const USER_PROCESS = 7
+
 func HostInfo() (*HostInfoStat, error) {
 	ret := &HostInfoStat{
 		OS:             runtime.GOOS,
@@ -103,7 +106,7 @@ func Users() ([]UserStat, error) {
 		if err != nil {
 			continue
 		}
-		if u.Type != 7 { // skip if not USERPROCESS
+		if u.Type != USER_PROCESS {
 			continue
 		}
 		user := UserStat{

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -26,6 +26,9 @@ type LSB struct {
 	Description string
 }
 
+// from utmp.h
+const USER_PROCESS = 7
+
 func HostInfo() (*HostInfoStat, error) {
 	ret := &HostInfoStat{
 		OS: runtime.GOOS,
@@ -118,6 +121,9 @@ func Users() ([]UserStat, error) {
 		br := bytes.NewReader(b)
 		err := binary.Read(br, binary.LittleEndian, &u)
 		if err != nil {
+			continue
+		}
+		if u.Type != USER_PROCESS {
 			continue
 		}
 		user := UserStat{


### PR DESCRIPTION
host_darwin does the same filtering. Not doing this gives us some rather strange
entries that likely aren't what we want.

Before:
    {"user":"reboot","terminal":"~","host":"3.10.0-327.4.5.el7.x86_64","started":1454378260}
    {"user":"LOGIN","terminal":"ttyS0","host":"","started":1454378270}
    {"user":"LOGIN","terminal":"tty1","host":"","started":1454378270}
    {"user":"runlevel","terminal":"~","host":"3.10.0-327.4.5.el7.x86_64","started":1454378276}
    {"user":"root","terminal":"pts/0","host":"vpn","started":1454404513}

After:
    {"user":"root","terminal":"pts/0","host":"vpn","started":1454404513}