### PR TITLE
There are two possible error scenarios for CallPgrep.  

### DIFF
--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -3,10 +3,13 @@
 package common
 
 import (
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
 )
+
+var ErrorNoChildren = errors.New("Process does not have children or does not exist")
 
 func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
 	var cmd []string
@@ -48,7 +51,7 @@ func CallPgrep(invoke Invoker, pid int32) ([]int32, error) {
 	}
 	out, err := invoke.Command(pgrep, cmd...)
 	if err != nil {
-		return []int32{}, err
+		return []int32{}, ErrorNoChildren
 	}
 	lines := strings.Split(string(out), "\n")
 	ret := make([]int32, 0, len(lines))

--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -3,13 +3,10 @@
 package common
 
 import (
-	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
 )
-
-var ErrorNoChildren = errors.New("Process does not have children or does not exist")
 
 func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
 	var cmd []string
@@ -51,7 +48,7 @@ func CallPgrep(invoke Invoker, pid int32) ([]int32, error) {
 	}
 	out, err := invoke.Command(pgrep, cmd...)
 	if err != nil {
-		return []int32{}, ErrorNoChildren
+		return []int32{}, err
 	}
 	lines := strings.Split(string(out), "\n")
 	ret := make([]int32, 0, len(lines))

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -4,6 +4,7 @@ package process
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,6 +18,8 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/net"
 )
+
+var ErrorNoChildren = errors.New("Process does not have children or does not exist")
 
 const (
 	PrioProcess = 0 // linux/resource.h
@@ -205,6 +208,9 @@ func (p *Process) MemoryPercent() (float32, error) {
 func (p *Process) Children() ([]*Process, error) {
 	pids, err := common.CallPgrep(invoke, p.Pid)
 	if err != nil {
+		if err == common.ErrorNoChildren {
+			return nil, ErrorNoChildren
+		}
 		return nil, err
 	}
 	ret := make([]*Process, 0, len(pids))

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -19,7 +19,7 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
-var ErrorNoChildren = errors.New("Process does not have children")
+var ErrorNoChildren = errors.New("process does not have children")
 
 const (
 	PrioProcess = 0 // linux/resource.h
@@ -208,7 +208,7 @@ func (p *Process) MemoryPercent() (float32, error) {
 func (p *Process) Children() ([]*Process, error) {
 	pids, err := common.CallPgrep(invoke, p.Pid)
 	if err != nil {
-		if err == common.ErrorNoChildren {
+		if pids == nil || len(pids) == 0 {
 			return nil, ErrorNoChildren
 		}
 		return nil, err

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -19,7 +19,7 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
-var ErrorNoChildren = errors.New("Process does not have children or does not exist")
+var ErrorNoChildren = errors.New("Process does not have children")
 
 const (
 	PrioProcess = 0 // linux/resource.h


### PR DESCRIPTION
One indicates a broken system (no pgrep command) and one is a normal error state of pgrep
meaning no processes found for the criteria given (in this case the parent pid does not exist or the process simply has no children).  The later case is quite useful to know about so I added a static error for this case.