### PR TITLE
try to fix diskio stats on FreeBSD-10.x

### DIFF
--- a/internal/common/common_freebsd.go
+++ b/internal/common/common_freebsd.go
@@ -22,13 +22,14 @@ func DoSysctrl(mib string) ([]string, error) {
 }
 
 func CallSyscall(mib []int32) ([]byte, uint64, error) {
+	mibptr := unsafe.Pointer(&mib[0])
 	miblen := uint64(len(mib))
 
 	// get required buffer size
 	length := uint64(0)
 	_, _, err := syscall.Syscall6(
 		syscall.SYS___SYSCTL,
-		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(mibptr),
 		uintptr(miblen),
 		0,
 		uintptr(unsafe.Pointer(&length)),
@@ -46,7 +47,7 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	buf := make([]byte, length)
 	_, _, err = syscall.Syscall6(
 		syscall.SYS___SYSCTL,
-		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(mibptr),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(unsafe.Pointer(&length)),


### PR DESCRIPTION
FreeBSD apparently changed the magic sysctl mib values for devstats.

    --- FAIL: TestDisk_io_counters (0.00s)
    disk_test.go:39: error no such file or directory
    disk_test.go:42: ret is empty, map[]

This code uses an undocumented, but exported, go stdlib method to fetch
the sysctl by string instead of mib.