### PR TITLE
Return correct user name from process.Username()

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -125,18 +125,10 @@ func (p *Process) Uids() ([]int32, error) {
 		return nil, err
 	}
 
-	uids := make([]int32, 0, 3)
-
 	// See: http://unix.superglobalmegacorp.com/Net2/newsrc/sys/ucred.h.html
 	userEffectiveUID := int32(k.Eproc.Ucred.Uid)
 
-	// See: http://unix.superglobalmegacorp.com/Net2/newsrc/sys/proc.h.html
-	procRealUID := int32(k.Eproc.Pcred.P_ruid)
-	procSavedEffectiveUID := int32(k.Eproc.Pcred.P_svuid)
-
-	uids = append(uids, userEffectiveUID, procRealUID, procSavedEffectiveUID)
-
-	return uids, nil
+	return []int32{userEffectiveUID}, nil
 }
 func (p *Process) Gids() ([]int32, error) {
 	k, err := p.getKProc()

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -127,7 +127,14 @@ func (p *Process) Uids() ([]int32, error) {
 
 	uids := make([]int32, 0, 3)
 
-	uids = append(uids, int32(k.Eproc.Pcred.P_ruid), int32(k.Eproc.Ucred.Uid), int32(k.Eproc.Pcred.P_svuid))
+	// See: http://unix.superglobalmegacorp.com/Net2/newsrc/sys/ucred.h.html
+	userEffectiveUID := int32(k.Eproc.Ucred.Uid)
+
+	// See: http://unix.superglobalmegacorp.com/Net2/newsrc/sys/proc.h.html
+	procRealUID := int32(k.Eproc.Pcred.P_ruid)
+	procSavedEffectiveUID := int32(k.Eproc.Pcred.P_svuid)
+
+	uids = append(uids, userEffectiveUID, procRealUID, procSavedEffectiveUID)
 
 	return uids, nil
 }
@@ -371,6 +378,8 @@ func parseKinfoProc(buf []byte) (KinfoProc, error) {
 	return k, nil
 }
 
+// Returns a proc as defined here:
+// http://unix.superglobalmegacorp.com/Net2/newsrc/sys/kinfo_proc.h.html
 func (p *Process) getKProc() (*KinfoProc, error) {
 	mib := []int32{CTLKern, KernProc, KernProcPID, p.Pid}
 	procK := KinfoProc{}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"os"
+	"os/user"
 	"runtime"
 	"strings"
 	"sync"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"github.com/stretchr/testify/assert"
 )
 
 var mu sync.Mutex
@@ -326,5 +328,14 @@ func Test_Children(t *testing.T) {
 	if len(c) == 0 {
 		t.Fatalf("children is empty")
 	}
+}
 
+func Test_Username(t *testing.T) {
+	myPid := os.Getpid()
+	currentUser, _ := user.Current()
+	myUsername := currentUser.Username
+
+	process, _ := NewProcess(int32(myPid))
+	pidUsername, _ := process.Username()
+	assert.Equal(t, myUsername, pidUsername)
 }


### PR DESCRIPTION
Before this change, `process.Username()` always returned `root` on Darwin.

With this change in place, it returns the user the process is running as.

This change also adds a regression test for the new behavior and some documentation links.