### PR TITLE
[load]all: add Misc in load to get miscellaneous host info from /proc…

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -2,7 +2,15 @@ package load
 
 import (
 	"encoding/json"
+
+	"github.com/shirou/gopsutil/internal/common"
 )
+
+var invoke common.Invoker
+
+func init() {
+	invoke = common.Invoke{}
+}
 
 type LoadAvgStat struct {
 	Load1  float64 `json:"load1"`
@@ -12,5 +20,16 @@ type LoadAvgStat struct {
 
 func (l LoadAvgStat) String() string {
 	s, _ := json.Marshal(l)
+	return string(s)
+}
+
+type MiscStat struct {
+	ProcsRunning int `json:"procsRunning"`
+	ProcsBlocked int `json:"procsBlocked"`
+	Ctxt         int `json:"ctxt"`
+}
+
+func (m MiscStat) String() string {
+	s, _ := json.Marshal(m)
 	return string(s)
 }

--- a/load/load_darwin.go
+++ b/load/load_darwin.go
@@ -38,6 +38,11 @@ func LoadAvg() (*LoadAvgStat, error) {
 	return ret, nil
 }
 
+
+// Misc returnes miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as FreeBSD implementation, but state is different.
+// U means 'Uninterruptible Sleep'.
 func Misc() (*MiscStat, error) {
 	bin, err := exec.LookPath("ps")
 	if err != nil {

--- a/load/load_darwin.go
+++ b/load/load_darwin.go
@@ -3,7 +3,9 @@
 package load
 
 import (
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -34,4 +36,28 @@ func LoadAvg() (*LoadAvgStat, error) {
 	}
 
 	return ret, nil
+}
+
+func Misc() (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.Command(bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning += 1
+		} else if strings.Contains(l, "U") {
+			// uninterruptible sleep == blocked
+			ret.ProcsBlocked += 1
+		}
+	}
+
+	return &ret, nil
 }

--- a/load/load_freebsd.go
+++ b/load/load_freebsd.go
@@ -38,6 +38,9 @@ func LoadAvg() (*LoadAvgStat, error) {
 	return ret, nil
 }
 
+// Misc returnes miscellaneous host-wide statistics.
+// darwin use ps command to get process running/blocked count.
+// Almost same as Darwin implementation, but state is different.
 func Misc() (*MiscStat, error) {
 	bin, err := exec.LookPath("ps")
 	if err != nil {

--- a/load/load_freebsd.go
+++ b/load/load_freebsd.go
@@ -3,7 +3,9 @@
 package load
 
 import (
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -34,4 +36,27 @@ func LoadAvg() (*LoadAvgStat, error) {
 	}
 
 	return ret, nil
+}
+
+func Misc() (*MiscStat, error) {
+	bin, err := exec.LookPath("ps")
+	if err != nil {
+		return nil, err
+	}
+	out, err := invoke.Command(bin, "axo", "state")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(out), "\n")
+
+	ret := MiscStat{}
+	for _, l := range lines {
+		if strings.Contains(l, "R") {
+			ret.ProcsRunning += 1
+		} else if strings.Contains(l, "D") {
+			ret.ProcsBlocked += 1
+		}
+	}
+
+	return &ret, nil
 }

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -40,3 +40,41 @@ func LoadAvg() (*LoadAvgStat, error) {
 
 	return ret, nil
 }
+
+func Misc() (*MiscStat, error) {
+	filename := common.HostProc("stat")
+	lines, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &Misc{
+		ProcsRunning: pr,
+		ProcsBlocked: pb,
+		Ctxt:         ctxt,
+	}
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		v, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "procs_running":
+			ret.ProcessRunning = v
+		case "procs_blocked":
+			ret.ProcessBlocked = v
+		case "ctxt":
+			ret.Ctxt = v
+		default:
+			continue
+		}
+
+	}
+
+	return ret, nil
+}

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -43,17 +43,13 @@ func LoadAvg() (*LoadAvgStat, error) {
 
 func Misc() (*MiscStat, error) {
 	filename := common.HostProc("stat")
-	lines, err := ioutil.ReadFile(filename)
+	out, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	ret := &Misc{
-		ProcsRunning: pr,
-		ProcsBlocked: pb,
-		Ctxt:         ctxt,
-	}
-
+	ret := &MiscStat{}
+	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
@@ -65,11 +61,11 @@ func Misc() (*MiscStat, error) {
 		}
 		switch fields[0] {
 		case "procs_running":
-			ret.ProcessRunning = v
+			ret.ProcsRunning = int(v)
 		case "procs_blocked":
-			ret.ProcessBlocked = v
+			ret.ProcsBlocked = int(v)
 		case "ctxt":
-			ret.Ctxt = v
+			ret.Ctxt = int(v)
 		default:
 			continue
 		}

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -41,6 +41,9 @@ func LoadAvg() (*LoadAvgStat, error) {
 	return ret, nil
 }
 
+
+// Misc returnes miscellaneous host-wide statistics.
+// Note: the name should be changed near future.
 func Misc() (*MiscStat, error) {
 	filename := common.HostProc("stat")
 	out, err := ioutil.ReadFile(filename)

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -28,3 +28,27 @@ func TestLoadAvgStat_String(t *testing.T) {
 		t.Errorf("LoadAvgStat string is invalid: %v", v)
 	}
 }
+
+func TestMisc(t *testing.T) {
+	v, err := Misc()
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	empty := &MiscStat{}
+	if v == empty {
+		t.Errorf("error load: %v", v)
+	}
+}
+
+func TestMiscStatString(t *testing.T) {
+	v := MiscStat{
+		ProcsRunning: 1,
+		ProcsBlocked: 2,
+		Ctxt:         3,
+	}
+	e := `{"procsRunning":1,"procsBlocked":2,"ctxt":3}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("TestMiscString string is invalid: %v", v)
+	}
+}

--- a/load/load_windows.go
+++ b/load/load_windows.go
@@ -11,3 +11,9 @@ func LoadAvg() (*LoadAvgStat, error) {
 
 	return &ret, common.NotImplementedError
 }
+
+func Misc() (*MiscStat, error) {
+	ret := MiscStat{}
+
+	return &ret, common.NotImplementedError
+}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -673,7 +674,11 @@ func callLsof(arg string, pid int32) ([]string, error) {
 	} else {
 		cmd = []string{"-a", "-F" + arg, "-p", strconv.Itoa(int(pid))}
 	}
-	out, err := invoke.Command("/usr/bin/lsof", cmd...)
+	lsof, err := exec.LookPath("lsof")
+	if err != nil {
+		return []string{}, err
+	}
+	out, err := invoke.Command(lsof, cmd...)
 	if err != nil {
 		return []string{}, err
 	}


### PR DESCRIPTION
See #157

Add process running, process blocked and context switched. These are related to host-wide load metrics, I place in the `load`. But I can not decide the right name because it includes process and context. So, at first, I choose `Misc` (toooo bad, I know). 

Linux:
   from `/proc/stat`
FreeBSD/Darwin
  run `ps axo state` and count state. ctxt is not implemented (How to get?)
Wndows
  not implemented.
