### PR TITLE
NewProcess does not close file descriptor

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -70,7 +70,8 @@ func NewProcess(pid int32) (*Process, error) {
 	p := &Process{
 		Pid: int32(pid),
 	}
-	_, err := os.Open(common.HostProc(strconv.Itoa(int(p.Pid))))
+	file, err := os.Open(common.HostProc(strconv.Itoa(int(p.Pid))))
+	defer file.Close()
 	return p, err
 }
 


### PR DESCRIPTION
If you loop through `gopsutilProcess.Pids()` and create `Process` for each pid `NewProcess` call will a file descriptor to check if it exists. It was introduced in https://github.com/shirou/gopsutil/commit/a3bbd9e3cdb1e1c7e757b395e6e806fc4353e442.

Dummy code example:
```go
func foo() {
	pids, _ := gopsutilProcess.Pids()
	for _, pid := range pids {
		_, _ = gopsutilProcess.NewProcess(pid)
	}
}
```
Will produce something like this:
```
# lsof -p 11256
COMMAND   PID USER   FD   TYPE     DEVICE SIZE/OFF       NODE NAME
dummy 11256 root   18r   DIR        0,3        0      12388 /proc/1
dummy 11256 root   19r   DIR        0,3        0        188 /proc/2
dummy 11256 root   20r   DIR        0,3        0        189 /proc/3
dummy 11256 root   21r   DIR        0,3        0        192 /proc/6
dummy 11256 root   22r   DIR        0,3        0        193 /proc/7
dummy 11256 root   23r   DIR        0,3        0        194 /proc/8
dummy 11256 root   24r   DIR        0,3        0        195 /proc/9
dummy 11256 root   25r   DIR        0,3        0        196 /proc/10
dummy 11256 root   26r   DIR        0,3        0        198 /proc/12
dummy 11256 root   27r   DIR        0,3        0        199 /proc/13
dummy 11256 root   28r   DIR        0,3        0        200 /proc/14
dummy 11256 root   29r   DIR        0,3        0        201 /proc/15
dummy 11256 root   30r   DIR        0,3        0        202 /proc/16
dummy 11256 root   31r   DIR        0,3        0        203 /proc/17
dummy 11256 root   32r   DIR        0,3        0        205 /proc/19
dummy 11256 root   33r   DIR        0,3        0        206 /proc/20
dummy 11256 root   34r   DIR        0,3        0        207 /proc/21
dummy 11256 root   35r   DIR        0,3        0        208 /proc/22
dummy 11256 root   36r   DIR        0,3        0        209 /proc/23
dummy 11256 root   37r   DIR        0,3        0        210 /proc/24
dummy 11256 root   38r   DIR        0,3        0        211 /proc/25
dummy 11256 root   39r   DIR        0,3        0        212 /proc/26
dummy 11256 root   40r   DIR        0,3        0        213 /proc/27
dummy 11256 root   41r   DIR        0,3        0        214 /proc/28
dummy 11256 root   42r   DIR        0,3        0        215 /proc/29
dummy 11256 root   43r   DIR        0,3        0        217 /proc/31
... # fd for each running process
dummy 11256 root  153r   DIR        0,3        0 1964597790 /proc/13865
```

Chart (before fix/after fix):
<img width="607" alt="screenshot 2016-03-02 18 15 57" src="https://cloud.githubusercontent.com/assets/189443/13464800/d2e69162-e0a3-11e5-8d62-81ea798e9bde.png">

