### PR TITLE
Breaking change: use state code rather than "description"

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -556,10 +556,7 @@ func (p *Process) fillFromStatus() error {
 		case "Name":
 			p.name = strings.Trim(value, " \t")
 		case "State":
-			// get between "(" and ")"
-			s := strings.Index(value, "(") + 1
-			e := strings.Index(value, ")")
-			p.status = value[s:e]
+			p.status = value[0:1]
 		case "Uid":
 			p.uids = make([]int32, 0, 4)
 			for _, i := range strings.Split(value, "\t") {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -152,7 +152,7 @@ func Test_Process_Status(t *testing.T) {
 	if err != nil {
 		t.Errorf("geting status error %v", err)
 	}
-	if !strings.HasPrefix(v, "S") && v != "running" && v != "sleeping" {
+	if v != "R" && v != "S" {
 		t.Errorf("could not get state %v", v)
 	}
 }


### PR DESCRIPTION
For process.Status(), linux is the only platform where it's possible to
get state descriptions. This is specific to the linux /proc/pid/status
file.

I think it would be better to get the more platform-neutral state codes,
which are also present on FreeBSD, OpenBSD, darwin, etc.

The state codes are also better documented on "man proc" and "man ps"