### PR TITLE
Update host type linux

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -124,9 +124,9 @@ func Users() ([]UserStat, error) {
 			continue
 		}
 		user := UserStat{
-			User:     common.UintToString(u.User[:]),
-			Terminal: common.UintToString(u.Line[:]),
-			Host:     common.UintToString(u.Host[:]),
+			User:     common.IntToString(u.User[:]),
+			Terminal: common.IntToString(u.Line[:]),
+			Host:     common.IntToString(u.Host[:]),
 			Started:  int(u.Tv.Sec),
 		}
 		ret = append(ret, user)

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -108,14 +107,12 @@ func Users() ([]UserStat, error) {
 		return nil, err
 	}
 
-	u := utmp{}
-	entrySize := int(unsafe.Sizeof(u))
-	count := len(buf) / entrySize
+	count := len(buf) / sizeOfUtmp
 
 	ret := make([]UserStat, 0, count)
 
 	for i := 0; i < count; i++ {
-		b := buf[i*entrySize : i*entrySize+entrySize]
+		b := buf[i*sizeOfUtmp : (i+1)*sizeOfUtmp]
 
 		var u utmp
 		br := bytes.NewReader(b)
@@ -127,10 +124,10 @@ func Users() ([]UserStat, error) {
 			continue
 		}
 		user := UserStat{
-			User:     common.IntToString(u.User[:]),
-			Terminal: common.IntToString(u.Line[:]),
-			Host:     common.IntToString(u.Host[:]),
-			Started:  int(u.Tv.TvSec),
+			User:     common.UintToString(u.User[:]),
+			Terminal: common.UintToString(u.Line[:]),
+			Host:     common.UintToString(u.Host[:]),
+			Started:  int(u.Tv.Sec),
 		}
 		ret = append(ret, user)
 	}

--- a/host/host_linux_386.go
+++ b/host/host_linux_386.go
@@ -39,6 +39,6 @@ type exit_status struct {
 	Exit        int16
 }
 type UtTv struct {
-	TvSec  int32
-	TvUsec int32
+	Sec  int32
+	Usec int32
 }

--- a/host/host_linux_386.go
+++ b/host/host_linux_386.go
@@ -11,6 +11,7 @@ const (
 	sizeofInt      = 0x4
 	sizeofLong     = 0x4
 	sizeofLongLong = 0x8
+	sizeOfUtmp     = 0x180
 )
 
 type (

--- a/host/host_linux_amd64.go
+++ b/host/host_linux_amd64.go
@@ -4,45 +4,45 @@
 package host
 
 const (
-	sizeofPtr	= 0x8
-	sizeofShort	= 0x2
-	sizeofInt	= 0x4
-	sizeofLong	= 0x8
-	sizeofLongLong	= 0x8
-	sizeOfUtmp	= 0x180
+	sizeofPtr      = 0x8
+	sizeofShort    = 0x2
+	sizeofInt      = 0x4
+	sizeofLong     = 0x8
+	sizeofLongLong = 0x8
+	sizeOfUtmp     = 0x180
 )
 
 type (
-	_C_short	int16
-	_C_int		int32
-	_C_long		int64
-	_C_long_long	int64
+	_C_short     int16
+	_C_int       int32
+	_C_long      int64
+	_C_long_long int64
 )
 
 type utmp struct {
-	Type			int16
-	Pad_cgo_0		[2]byte
-	Pid			int32
-	Line			[32]int8
-	Id			[4]int8
-	User			[32]int8
-	Host			[256]int8
-	Exit			exit_status
-	Session			int32
-	Tv			_Ctype_struct___0
-	Addr_v6			[4]int32
-	X__glibc_reserved	[20]int8
+	Type              int16
+	Pad_cgo_0         [2]byte
+	Pid               int32
+	Line              [32]int8
+	Id                [4]int8
+	User              [32]int8
+	Host              [256]int8
+	Exit              exit_status
+	Session           int32
+	Tv                _Ctype_struct___0
+	Addr_v6           [4]int32
+	X__glibc_reserved [20]int8
 }
 type exit_status struct {
-	Termination	int16
-	Exit		int16
+	Termination int16
+	Exit        int16
 }
 type timeval struct {
-	Sec	int64
-	Usec	int64
+	Sec  int64
+	Usec int64
 }
 
 type _Ctype_struct___0 struct {
-        Sec  int32
-        Usec int32
+	Sec  int32
+	Usec int32
 }

--- a/host/host_linux_amd64.go
+++ b/host/host_linux_amd64.go
@@ -4,39 +4,45 @@
 package host
 
 const (
-	sizeofPtr      = 0x8
-	sizeofShort    = 0x2
-	sizeofInt      = 0x4
-	sizeofLong     = 0x8
-	sizeofLongLong = 0x8
+	sizeofPtr	= 0x8
+	sizeofShort	= 0x2
+	sizeofInt	= 0x4
+	sizeofLong	= 0x8
+	sizeofLongLong	= 0x8
+	sizeOfUtmp	= 0x180
 )
 
 type (
-	_C_short     int16
-	_C_int       int32
-	_C_long      int64
-	_C_long_long int64
+	_C_short	int16
+	_C_int		int32
+	_C_long		int64
+	_C_long_long	int64
 )
 
 type utmp struct {
-	Type              int16
-	Pad_cgo_0         [2]byte
-	Pid               int32
-	Line              [32]int8
-	ID                [4]int8
-	User              [32]int8
-	Host              [256]int8
-	Exit              exit_status
-	Session           int32
-	Tv                UtTv
-	Addr_v6           [4]int32
-	X__glibc_reserved [20]int8
+	Type			int16
+	Pad_cgo_0		[2]byte
+	Pid			int32
+	Line			[32]int8
+	Id			[4]int8
+	User			[32]int8
+	Host			[256]int8
+	Exit			exit_status
+	Session			int32
+	Tv			_Ctype_struct___0
+	Addr_v6			[4]int32
+	X__glibc_reserved	[20]int8
 }
 type exit_status struct {
-	Termination int16
-	Exit        int16
+	Termination	int16
+	Exit		int16
 }
-type UtTv struct {
-	TvSec  int32
-	TvUsec int32
+type timeval struct {
+	Sec	int64
+	Usec	int64
+}
+
+type _Ctype_struct___0 struct {
+        Sec  int32
+        Usec int32
 }

--- a/host/host_linux_arm.go
+++ b/host/host_linux_arm.go
@@ -1,5 +1,5 @@
 // Created by cgo -godefs - DO NOT EDIT
-// cgo -godefs types_linux.go
+// cgo -godefs types_linux.go | sed "s/uint8/int8/g"
 
 package host
 
@@ -23,15 +23,15 @@ type utmp struct {
 	Type			int16
 	Pad_cgo_0		[2]byte
 	Pid			int32
-	Line			[32]uint8
-	Id			[4]uint8
-	User			[32]uint8
-	Host			[256]uint8
+	Line			[32]int8
+	Id			[4]int8
+	User			[32]int8
+	Host			[256]int8
 	Exit			exit_status
 	Session			int32
 	Tv			timeval
 	Addr_v6			[4]int32
-	X__glibc_reserved	[20]uint8
+	X__glibc_reserved	[20]int8
 }
 type exit_status struct {
 	Termination	int16

--- a/host/host_linux_arm.go
+++ b/host/host_linux_arm.go
@@ -4,40 +4,40 @@
 package host
 
 const (
-	sizeofPtr	= 0x4
-	sizeofShort	= 0x2
-	sizeofInt	= 0x4
-	sizeofLong	= 0x4
-	sizeofLongLong	= 0x8
-	sizeOfUtmp	= 0x180
+	sizeofPtr      = 0x4
+	sizeofShort    = 0x2
+	sizeofInt      = 0x4
+	sizeofLong     = 0x4
+	sizeofLongLong = 0x8
+	sizeOfUtmp     = 0x180
 )
 
 type (
-	_C_short	int16
-	_C_int		int32
-	_C_long		int32
-	_C_long_long	int64
+	_C_short     int16
+	_C_int       int32
+	_C_long      int32
+	_C_long_long int64
 )
 
 type utmp struct {
-	Type			int16
-	Pad_cgo_0		[2]byte
-	Pid			int32
-	Line			[32]int8
-	Id			[4]int8
-	User			[32]int8
-	Host			[256]int8
-	Exit			exit_status
-	Session			int32
-	Tv			timeval
-	Addr_v6			[4]int32
-	X__glibc_reserved	[20]int8
+	Type              int16
+	Pad_cgo_0         [2]byte
+	Pid               int32
+	Line              [32]int8
+	Id                [4]int8
+	User              [32]int8
+	Host              [256]int8
+	Exit              exit_status
+	Session           int32
+	Tv                timeval
+	Addr_v6           [4]int32
+	X__glibc_reserved [20]int8
 }
 type exit_status struct {
-	Termination	int16
-	Exit		int16
+	Termination int16
+	Exit        int16
 }
 type timeval struct {
-	Sec	int32
-	Usec	int32
+	Sec  int32
+	Usec int32
 }

--- a/host/host_linux_arm.go
+++ b/host/host_linux_arm.go
@@ -1,42 +1,43 @@
-// +build linux
-// +build arm
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_linux.go
 
 package host
 
 const (
-	sizeofPtr      = 0x8
-	sizeofShort    = 0x2
-	sizeofInt      = 0x4
-	sizeofLong     = 0x8
-	sizeofLongLong = 0x8
+	sizeofPtr	= 0x4
+	sizeofShort	= 0x2
+	sizeofInt	= 0x4
+	sizeofLong	= 0x4
+	sizeofLongLong	= 0x8
+	sizeOfUtmp	= 0x180
 )
 
 type (
-	_C_short     int16
-	_C_int       int32
-	_C_long      int64
-	_C_long_long int64
+	_C_short	int16
+	_C_int		int32
+	_C_long		int32
+	_C_long_long	int64
 )
 
 type utmp struct {
-	Type              int16
-	Pad_cgo_0         [2]byte
-	Pid               int32
-	Line              [32]int8
-	ID                [4]int8
-	User              [32]int8
-	Host              [256]int8
-	Exit              exit_status
-	Session           int32
-	Tv                UtTv
-	Addr_v6           [4]int32
-	X__glibc_reserved [20]int8
+	Type			int16
+	Pad_cgo_0		[2]byte
+	Pid			int32
+	Line			[32]uint8
+	Id			[4]uint8
+	User			[32]uint8
+	Host			[256]uint8
+	Exit			exit_status
+	Session			int32
+	Tv			timeval
+	Addr_v6			[4]int32
+	X__glibc_reserved	[20]uint8
 }
 type exit_status struct {
-	Termination int16
-	Exit        int16
+	Termination	int16
+	Exit		int16
 }
-type UtTv struct {
-	TvSec  int32
-	TvUsec int32
+type timeval struct {
+	Sec	int32
+	Usec	int32
 }

--- a/host/types_linux.go
+++ b/host/types_linux.go
@@ -7,12 +7,11 @@ Input to cgo -godefs.
 package host
 
 /*
-#define KERNEL
 #include <sys/types.h>
 #include <utmp.h>
 
 enum {
-	sizeofPtr = sizeof(void*),
+       sizeofPtr = sizeof(void*),
 };
 
 */
@@ -26,6 +25,7 @@ const (
 	sizeofInt      = C.sizeof_int
 	sizeofLong     = C.sizeof_long
 	sizeofLongLong = C.sizeof_longlong
+	sizeOfUtmp     = C.sizeof_struct_utmp
 )
 
 // Basic types
@@ -39,7 +39,4 @@ type (
 
 type utmp C.struct_utmp
 type exit_status C.struct_exit_status
-type UtTv struct {
-	TvSec  int32
-	TvUsec int32
-}
+type timeval C.struct_timeval

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -117,6 +117,23 @@ func IntToString(orig []int8) string {
 	return string(ret[0:size])
 }
 
+func UintToString(orig []uint8) string {
+        ret := make([]byte, len(orig))
+        size := -1
+        for i, o := range orig {
+                if o == 0 {
+                        size = i
+                        break
+                }
+                ret[i] = byte(o)
+        }
+        if size == -1 {
+                size = len(orig)
+        }
+
+        return string(ret[0:size])
+}
+
 func ByteToString(orig []byte) string {
 	n := -1
 	l := -1


### PR DESCRIPTION
`host` under linux_386, linux_amd64 and linux_arm has been fixed. `type_linunx.go` is replaced, but we still hand-writing because of `ifdef`. 