### PR TITLE
Fix compile errors for iOS/arm64

### DIFF
--- a/cpu/cpu_darwin_cgo.go
+++ b/cpu/cpu_darwin_cgo.go
@@ -10,7 +10,9 @@ package cpu
 #include <mach/mach_init.h>
 #include <mach/mach_host.h>
 #include <mach/host_info.h>
+#if TARGET_OS_MAC
 #include <libproc.h>
+#endif
 #include <mach/processor_info.h>
 #include <mach/vm_map.h>
 */

--- a/disk/disk_darwin_arm64.go
+++ b/disk/disk_darwin_arm64.go
@@ -1,0 +1,58 @@
+// +build darwin
+// +build arm64
+
+package disk
+
+const (
+	MntWait    = 1
+	MfsNameLen = 15 /* length of fs type name, not inc. nul */
+	MNameLen   = 90 /* length of buffer for returned name */
+
+	MFSTYPENAMELEN = 16 /* length of fs type name including null */
+	MAXPATHLEN     = 1024
+	MNAMELEN       = MAXPATHLEN
+
+	SYS_GETFSSTAT64 = 347
+)
+
+type Fsid struct{ val [2]int32 } /* file system id type */
+type uid_t int32
+
+// sys/mount.h
+const (
+	MntReadOnly     = 0x00000001 /* read only filesystem */
+	MntSynchronous  = 0x00000002 /* filesystem written synchronously */
+	MntNoExec       = 0x00000004 /* can't exec from filesystem */
+	MntNoSuid       = 0x00000008 /* don't honor setuid bits on fs */
+	MntUnion        = 0x00000020 /* union with underlying filesystem */
+	MntAsync        = 0x00000040 /* filesystem written asynchronously */
+	MntSuidDir      = 0x00100000 /* special handling of SUID on dirs */
+	MntSoftDep      = 0x00200000 /* soft updates being done */
+	MntNoSymFollow  = 0x00400000 /* do not follow symlinks */
+	MntGEOMJournal  = 0x02000000 /* GEOM journal support enabled */
+	MntMultilabel   = 0x04000000 /* MAC support for individual objects */
+	MntACLs         = 0x08000000 /* ACL support enabled */
+	MntNoATime      = 0x10000000 /* disable update of file access time */
+	MntClusterRead  = 0x40000000 /* disable cluster read */
+	MntClusterWrite = 0x80000000 /* disable cluster write */
+	MntNFS4ACLs     = 0x00000010
+)
+
+type Statfs_t struct {
+	Bsize       uint32
+	Iosize      int32
+	Blocks      uint64
+	Bfree       uint64
+	Bavail      uint64
+	Files       uint64
+	Ffree       uint64
+	Fsid        Fsid
+	Owner       uint32
+	Type        uint32
+	Flags       uint32
+	Fssubtype   uint32
+	Fstypename  [16]int8
+	Mntonname   [1024]int8
+	Mntfromname [1024]int8
+	Reserved    [8]uint32
+}


### PR DESCRIPTION
- Added conditional preprocessor guard on cpu_darwin_cgo.go

- Duplicated disk_darwin_amd64 for arm64 (after confirming
that sys/mount.h are the same between the two platforms, hence the
constants should be valid).