### PR TITLE
Fix potential panic in linux disk IO counters

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -283,6 +283,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 
 	for _, line := range lines {
 		fields := strings.Fields(line)
+		if len(fields) < 14 {
+			// malformed line in /proc/diskstats, avoid panic by ignoring.
+			continue
+		}
 		name := fields[2]
 		reads, err := strconv.ParseUint((fields[3]), 10, 64)
 		if err != nil {


### PR DESCRIPTION
Old kernels have a bug in diskstats where lines can have less than 14
fields. This applies to the kernel present in RHEL 5.2 and earlier.

It's a bit of a niche but probably best to patch to be safe from future
bugs too.

RHEL bug case:
https://bugzilla.redhat.com/show_bug.cgi?id=583285

Encountered in Telegraf:
https://github.com/influxdata/telegraf/issues/1322