### PR TITLE
[disk]linux: add documentation for GetDiskSerialNumber()

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -336,6 +336,8 @@ func IOCounters() (map[string]IOCountersStat, error) {
 	return ret, nil
 }
 
+// GetDiskSerialNumber returns Serial Number of given device or empty string
+// on error. Name of device is expected, eg. /dev/sda
 func GetDiskSerialNumber(name string) string {
 	n := fmt.Sprintf("--name=%s", name)
 	udevadm, err := exec.LookPath("/sbin/udevadm")


### PR DESCRIPTION
Commit adds documentation for GetDiskSerialNumber(), because it wasn't clear
what was expected as a parameter.

Fixes #212