### PR TITLE
Casting the values of working set and page file to uint64

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -257,8 +257,8 @@ func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
 	}
 
 	ret := &MemoryInfoStat{
-		RSS: mem.WorkingSetSize,
-		VMS: mem.PagefileUsage,
+		RSS: uint64(mem.WorkingSetSize),
+		VMS: uint64(mem.PagefileUsage),
 	}
 
 	return ret, nil


### PR DESCRIPTION
This fixes the build on `windows/386` platforms.