### PR TITLE
Return a valid JSON `String()` output for network lists

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -54,18 +54,25 @@ type ProtoCountersStat struct {
 	Stats    map[string]int64 `json:"stats"`
 }
 
-// NetInterfaceAddr is designed for represent interface addresses
+// InterfaceAddr is designed for represent interface addresses
 type InterfaceAddr struct {
 	Addr string `json:"addr"`
 }
 
+// InterfaceAddrList is a list of InterfaceAddr
+type InterfaceAddrList []InterfaceAddr
+
+// InterfaceStat represents the basic information of an interface
 type InterfaceStat struct {
-	MTU          int             `json:"mtu"`          // maximum transmission unit
-	Name         string          `json:"name"`         // e.g., "en0", "lo0", "eth0.100"
-	HardwareAddr string          `json:"hardwareaddr"` // IEEE MAC-48, EUI-48 and EUI-64 form
-	Flags        []string        `json:"flags"`        // e.g., FlagUp, FlagLoopback, FlagMulticast
-	Addrs        []InterfaceAddr `json:"addrs"`
+	MTU          int               `json:"mtu"`          // maximum transmission unit
+	Name         string            `json:"name"`         // e.g., "en0", "lo0", "eth0.100"
+	HardwareAddr string            `json:"hardwareaddr"` // IEEE MAC-48, EUI-48 and EUI-64 form
+	Flags        []string          `json:"flags"`        // e.g., FlagUp, FlagLoopback, FlagMulticast
+	Addrs        InterfaceAddrList `json:"addrs"`
 }
+
+// InterfaceStatList is a list of InterfaceStat
+type InterfaceStatList []InterfaceStat
 
 type FilterStat struct {
 	ConnTrackCount int64 `json:"conntrackCount"`
@@ -104,17 +111,22 @@ func (n InterfaceStat) String() string {
 	return string(s)
 }
 
+func (l InterfaceStatList) String() string {
+	s, _ := json.Marshal(l)
+	return string(s)
+}
+
 func (n InterfaceAddr) String() string {
 	s, _ := json.Marshal(n)
 	return string(s)
 }
 
-func Interfaces() ([]InterfaceStat, error) {
+func Interfaces() (InterfaceStatList, error) {
 	is, err := net.Interfaces()
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]InterfaceStat, 0, len(is))
+	ret := make(InterfaceStatList, 0, len(is))
 	for _, ifi := range is {
 
 		var flags []string
@@ -142,7 +154,7 @@ func Interfaces() ([]InterfaceStat, error) {
 		}
 		addrs, err := ifi.Addrs()
 		if err == nil {
-			r.Addrs = make([]InterfaceAddr, 0, len(addrs))
+			r.Addrs = make(InterfaceAddrList, 0, len(addrs))
 			for _, addr := range addrs {
 				r.Addrs = append(r.Addrs, InterfaceAddr{
 					Addr: addr.String(),

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -18,6 +18,21 @@ func TestAddrString(t *testing.T) {
 	}
 }
 
+func TestInterfaceStatString(t *testing.T) {
+	v := InterfaceStat{MTU: 1500, Name: "eth0", HardwareAddr: "01:23:45:67:89:ab", Flags: []string{"up", "down"}, Addrs: []InterfaceAddr{{Addr: "1.2.3.4"}, {Addr: "5.6.7.8"}}}
+
+	s := fmt.Sprintf("%v", v)
+	if s != "{\"mtu\":1500,\"name\":\"eth0\",\"hardwareaddr\":\"01:23:45:67:89:ab\",\"flags\":[\"up\",\"down\"],\"addrs\":[{\"addr\":\"1.2.3.4\"},{\"addr\":\"5.6.7.8\"}]}" {
+		t.Errorf("InterfaceStat string is invalid: %v", v)
+	}
+
+	list := InterfaceStatList{v, v}
+	s = fmt.Sprintf("%v", list)
+	if s != "[{\"mtu\":1500,\"name\":\"eth0\",\"hardwareaddr\":\"01:23:45:67:89:ab\",\"flags\":[\"up\",\"down\"],\"addrs\":[{\"addr\":\"1.2.3.4\"},{\"addr\":\"5.6.7.8\"}]},{\"mtu\":1500,\"name\":\"eth0\",\"hardwareaddr\":\"01:23:45:67:89:ab\",\"flags\":[\"up\",\"down\"],\"addrs\":[{\"addr\":\"1.2.3.4\"},{\"addr\":\"5.6.7.8\"}]}]" {
+		t.Errorf("InterfaceStatList string is invalid: %v", v)
+	}
+}
+
 func TestNetIOCountersStatString(t *testing.T) {
 	v := IOCountersStat{
 		Name:      "test",


### PR DESCRIPTION
Hi, what do you think about JSON marshalling lists as you are already doing with standalone items ?

If you like the idea, I can continue on the other resource types

---

Before

``` go
fmt.Println(myList)
// output: [{"a": "hello", "c": 42} {"a": "world", "c": 1337}] -> invalid json
```

After

``` go
fmt.Println(myList)
// output: [{"a": "hello", "c": 42},{"a": "world", "c": 1337}] -> valid json
```
