### PR TITLE
Correctly detect host Procs on all platforms.

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"github.com/shirou/gopsutil/process"
 )
 
 // from utmpx.h
@@ -37,6 +38,7 @@ func Info() (*InfoStat, error) {
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
 	}
+
 	system, role, err := Virtualization()
 	if err == nil {
 		ret.VirtualizationSystem = system
@@ -47,6 +49,11 @@ func Info() (*InfoStat, error) {
 	if err == nil {
 		ret.BootTime = boot
 		ret.Uptime = uptime(boot)
+	}
+
+	procs, err := process.Pids()
+	if err == nil {
+		ret.Procs = uint64(len(procs))
 	}
 
 	return ret, nil

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"github.com/shirou/gopsutil/process"
 )
 
 const (
@@ -40,6 +41,7 @@ func Info() (*InfoStat, error) {
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
 	}
+
 	system, role, err := Virtualization()
 	if err == nil {
 		ret.VirtualizationSystem = system
@@ -50,6 +52,11 @@ func Info() (*InfoStat, error) {
 	if err == nil {
 		ret.BootTime = boot
 		ret.Uptime = uptime(boot)
+	}
+
+	procs, err := process.Pids()
+	if err == nil {
+		ret.Procs = uint64(len(procs))
 	}
 
 	return ret, nil

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"github.com/shirou/gopsutil/process"
 )
 
 type LSB struct {
@@ -44,15 +45,22 @@ func Info() (*InfoStat, error) {
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
 	}
+
 	system, role, err := Virtualization()
 	if err == nil {
 		ret.VirtualizationSystem = system
 		ret.VirtualizationRole = role
 	}
+
 	boot, err := BootTime()
 	if err == nil {
 		ret.BootTime = boot
 		ret.Uptime = uptime(boot)
+	}
+
+	procs, err := process.Pids()
+	if err == nil {
+		ret.Procs = uint64(len(procs))
 	}
 
 	return ret, nil

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
-	common "github.com/shirou/gopsutil/internal/common"
 )
 
 type LSB struct {

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/shirou/gopsutil/internal/common"
 	common "github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/process"
 )
 
 type LSB struct {
@@ -59,9 +58,8 @@ func Info() (*InfoStat, error) {
 		ret.Uptime = uptime(boot)
 	}
 
-	procs, err := process.Pids()
-	if err == nil {
-		ret.Procs = uint64(len(procs))
+	if numProcs, err := common.NumProcs(); err == nil {
+		ret.Procs = numProcs
 	}
 
 	return ret, nil

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -14,6 +14,9 @@ func TestHostInfo(t *testing.T) {
 	if v == empty {
 		t.Errorf("Could not get hostinfo %v", v)
 	}
+	if v.Procs == 0 {
+		t.Errorf("Could not determine the number of host processes")
+	}
 }
 
 func TestBoot_time(t *testing.T) {

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -54,11 +54,9 @@ func Info() (*InfoStat, error) {
 	}
 
 	procs, err := process.Pids()
-	if err != nil {
-		return ret, err
+	if err == nil {
+		ret.Procs = uint64(len(procs))
 	}
-
-	ret.Procs = uint64(len(procs))
 
 	return ret, nil
 }

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -1,3 +1,19 @@
 // +build linux
 
 package common
+
+import "os"
+
+func NumProcs() (uint64, error) {
+	f, err := os.Open(HostProc())
+	if err != nil {
+		return 0, err
+	}
+
+	list, err := f.Readdir(-1)
+	defer f.Close()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(list)), error
+}

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -15,5 +15,5 @@ func NumProcs() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint64(len(list)), error
+	return uint64(len(list)), err
 }


### PR DESCRIPTION
Previously this only worked on Windows.  Expand to all supported platforms.

Fixes: #227 