### PR TITLE
add disk IoTime on freebsd and fix read & write time calculation

### DIFF
--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -124,8 +124,9 @@ func IOCounters() (map[string]IOCountersStat, error) {
 			WriteCount: d.Operations[DEVSTAT_WRITE],
 			ReadBytes:  d.Bytes[DEVSTAT_READ],
 			WriteBytes: d.Bytes[DEVSTAT_WRITE],
-			ReadTime:   d.Duration[DEVSTAT_READ].Compute(),
-			WriteTime:  d.Duration[DEVSTAT_WRITE].Compute(),
+			ReadTime:   uint64(d.Duration[DEVSTAT_READ].Compute() * 1000),
+			WriteTime:  uint64(d.Duration[DEVSTAT_WRITE].Compute() * 1000),
+			IoTime:     uint64(d.Busy_time.Compute() * 1000),
 			Name:       name,
 		}
 		ret[name] = ds
@@ -134,9 +135,9 @@ func IOCounters() (map[string]IOCountersStat, error) {
 	return ret, nil
 }
 
-func (b Bintime) Compute() uint64 {
+func (b Bintime) Compute() float64 {
 	BINTIME_SCALE := 5.42101086242752217003726400434970855712890625e-20
-	return uint64(b.Sec) + b.Frac*uint64(BINTIME_SCALE)
+	return float64(b.Sec) + float64(b.Frac)*BINTIME_SCALE
 }
 
 // BT2LD(time)     ((long double)(time).sec + (time).frac * BINTIME_SCALE)


### PR DESCRIPTION
This PR does 2 things.

1. It adds the `IoTime` metric to FreeBSD
2. It fixes the the disk time calculations.

In regards to number 2, the `Compute()` function was effectively doing nothing. It was converting `BINTIME_SCALE` to a `uint64`. But because the value is a float < 0, when converted to `int64`, it becomes `0`. So the function effectively just returned the field `b.Sec`. This fixes the calculation by preserving the value as a float.
Also relatedly, the times were being returned in seconds, when the raw values offer much higher precision than that. Since the linux values are returned in milliseconds, I opted to keep the type (a `uint64`), but am now returning the values measured in milliseconds instead of seconds. *(It would probably be a good idea to use a `time.Duration` instead of `uint64`)*