### PR TITLE
fix incorrect names for fields in proc/pid/io

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -527,9 +527,9 @@ func (p *Process) fillFromIO() (*IOCountersStat, error) {
 			ret.ReadCount = t
 		case "syscw":
 			ret.WriteCount = t
-		case "readBytes":
+		case "read_bytes":
 			ret.ReadBytes = t
-		case "writeBytes":
+		case "write_bytes":
 			ret.WriteBytes = t
 		}
 	}


### PR DESCRIPTION
Fix issue #235 