### PR TITLE
Added fields to VirtualMemoryStat

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -48,8 +48,12 @@ type VirtualMemoryStat struct {
 
 	// Linux specific numbers
 	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
-	Buffers uint64 `json:"buffers"`
-	Cached  uint64 `json:"cached"`
+	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+	Buffers      uint64 `json:"buffers"`
+	Cached       uint64 `json:"cached"`
+	Writeback    uint64 `json:"writeback"`
+	Dirty        uint64 `json:"dirty"`
+	WritebackTmp uint64 `json:"writebacktmp"`
 }
 
 type SwapMemoryStat struct {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -46,6 +46,12 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 			ret.Active = t * 1024
 		case "Inactive":
 			ret.Inactive = t * 1024
+		case "Writeback":
+			ret.Writeback = t * 1024
+		case "WritebackTmp":
+			ret.WritebackTmp = t * 1024
+		case "Dirty":
+			ret.Dirty = t * 1024
 		}
 	}
 	if !memavail {

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -52,7 +52,7 @@ func TestVirtualMemoryStat_String(t *testing.T) {
 		UsedPercent: 30.1,
 		Free:        40,
 	}
-	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"buffers":0,"cached":0}`
+	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("VirtualMemoryStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
Added the writeback, dirty and writebacktmp fields from /proc/meminfo… on Linux

Tests done:
- unit test using mem_test.go
- used in Telegraf system plugin (with appropriate changes in Telegraf) and confirmed that new fields were being properly inserted into InfluxDB measurement
