### PR TITLE
Ensure "make check" can succeeed if it doesn't find any golint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:  ## Show help
 
 check:  ## Check
 	errcheck -ignore="Close|Run|Write" ./...
-	golint ./... | egrep -v 'underscores|HttpOnly|should have comment|comment on exported|CamelCase|VM|UID'
+	golint ./... | egrep -v 'underscores|HttpOnly|should have comment|comment on exported|CamelCase|VM|UID' && exit 1 || exit 0
 
 build_test:  ## test only buildable
 	GOOS=linux go test ./... | grep -v "exec format error"


### PR DESCRIPTION
In the Makefile, when running `golint` in `check` we're using `egrep -v` to check for any errors except for those that match the whitelist.

Unfortunately `egrep` will return an errorcode if it doesn't find anything and the `make check` task will return an error.

This commit flips the logic, so `make check` is successful if there are no linting errors.