### PR TITLE
CPU: Fix linter warning on OSX

### DIFF
--- a/cpu/cpu_darwin_cgo.go
+++ b/cpu/cpu_darwin_cgo.go
@@ -84,8 +84,10 @@ func perCPUTimes() ([]TimesStat, error) {
 }
 
 func allCPUTimes() ([]TimesStat, error) {
-	var count C.mach_msg_type_number_t = C.HOST_CPU_LOAD_INFO_COUNT
+	var count C.mach_msg_type_number_t
 	var cpuload C.host_cpu_load_info_data_t
+
+	count = C.HOST_CPU_LOAD_INFO_COUNT
 
 	status := C.host_statistics(C.host_t(C.mach_host_self()),
 		C.HOST_CPU_LOAD_INFO,


### PR DESCRIPTION
On current master the linter returns this warning on OSX:

```
gajah:gopsutil lfittl$ make check
errcheck -ignore="Close|Run|Write" ./...
golint ./... | egrep -v 'underscores|HttpOnly|should have comment|comment on exported|CamelCase|VM|UID' && exit 1 || exit 0
cpu/cpu_darwin_cgo.go:87:12: should omit type C.mach_msg_type_number_t from declaration of var count; it will be inferred from the right-hand side
make: *** [check] Error 1
```

We can workaround the problem here by introducing a cast and direct assignment - not that I agree with the linter's idea here, but its an easy fix and gets us green.