### PR TITLE
Add separate kernelVersion field to host information

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -18,11 +18,12 @@ type InfoStat struct {
 	Hostname             string `json:"hostname"`
 	Uptime               uint64 `json:"uptime"`
 	BootTime             uint64 `json:"bootTime"`
-	Procs                uint64 `json:"procs"`          // number of processes
-	OS                   string `json:"os"`             // ex: freebsd, linux
-	Platform             string `json:"platform"`       // ex: ubuntu, linuxmint
-	PlatformFamily       string `json:"platformFamily"` // ex: debian, rhel
-	PlatformVersion      string `json:"platformVersion"`
+	Procs                uint64 `json:"procs"`           // number of processes
+	OS                   string `json:"os"`              // ex: freebsd, linux
+	Platform             string `json:"platform"`        // ex: ubuntu, linuxmint
+	PlatformFamily       string `json:"platformFamily"`  // ex: debian, rhel
+	PlatformVersion      string `json:"platformVersion"` // version of the complete OS
+	KernelVersion        string `json:"kernelVersion"`   // version of the OS kernel (if available)
 	VirtualizationSystem string `json:"virtualizationSystem"`
 	VirtualizationRole   string `json:"virtualizationRole"` // guest or host
 	HostID               string `json:"hostid"`             // ex: uuid

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -37,6 +37,7 @@ func Info() (*InfoStat, error) {
 		ret.Platform = platform
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
+		ret.KernelVersion = version
 	}
 
 	system, role, err := Virtualization()

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -40,6 +40,7 @@ func Info() (*InfoStat, error) {
 		ret.Platform = platform
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
+		ret.KernelVersion = version
 	}
 
 	system, role, err := Virtualization()

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -44,6 +44,10 @@ func Info() (*InfoStat, error) {
 		ret.PlatformFamily = family
 		ret.PlatformVersion = version
 	}
+	kernelVersion, err := KernelVersion()
+	if err == nil {
+		ret.KernelVersion = kernelVersion
+	}
 
 	system, role, err := Virtualization()
 	if err == nil {
@@ -352,6 +356,22 @@ func PlatformInformation() (platform string, family string, version string, err 
 
 	return platform, family, version, nil
 
+}
+
+func KernelVersion() (version string, err error) {
+	filename := common.HostProc("sys/kernel/osrelease")
+	if common.PathExists(filename) {
+		contents, err := common.ReadLines(filename)
+		if err != nil {
+			return "", err
+		}
+
+		if len(contents) > 0 {
+			version = contents[0]
+		}
+	}
+
+	return version, nil
 }
 
 func getRedhatishVersion(contents []string) string {

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -68,7 +68,7 @@ func TestHostInfoStat_String(t *testing.T) {
 		BootTime: 1447040000,
 		HostID:   "edfd25ff-3c9c-b1a4-e660-bd826495ad35",
 	}
-	e := `{"hostname":"test","uptime":3000,"bootTime":1447040000,"procs":100,"os":"linux","platform":"ubuntu","platformFamily":"","platformVersion":"","virtualizationSystem":"","virtualizationRole":"","hostid":"edfd25ff-3c9c-b1a4-e660-bd826495ad35"}`
+	e := `{"hostname":"test","uptime":3000,"bootTime":1447040000,"procs":100,"os":"linux","platform":"ubuntu","platformFamily":"","platformVersion":"","kernelVersion":"","virtualizationSystem":"","virtualizationRole":"","hostid":"edfd25ff-3c9c-b1a4-e660-bd826495ad35"}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("HostInfoStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
This is mostly intended for Linux, where we are returning the OS version
in the PlatformVersion field, which seems reasonable. Often it is still
useful to know which Linux kernel is running (uname -r).

For FreeBSD and Darwin the kernel version matches the platform version,
since they previously used the kernel version for the platform version.

For Windows the kernel version is empty, since there is no clear way
to determine it.