### PR TITLE
Add missing disk IO statistics for merged reads/writes, IOPS in progress

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -33,15 +33,18 @@ type PartitionStat struct {
 }
 
 type IOCountersStat struct {
-	ReadCount    uint64 `json:"readCount"`
-	WriteCount   uint64 `json:"writeCount"`
-	ReadBytes    uint64 `json:"readBytes"`
-	WriteBytes   uint64 `json:"writeBytes"`
-	ReadTime     uint64 `json:"readTime"`
-	WriteTime    uint64 `json:"writeTime"`
-	Name         string `json:"name"`
-	IoTime       uint64 `json:"ioTime"`
-	SerialNumber string `json:"serialNumber"`
+	ReadCount        uint64 `json:"readCount"`
+	MergedReadCount  uint64 `json:"mergedReadCount"`
+	WriteCount       uint64 `json:"writeCount"`
+	MergedWriteCount uint64 `json:"mergedWriteCount"`
+	ReadBytes        uint64 `json:"readBytes"`
+	WriteBytes       uint64 `json:"writeBytes"`
+	ReadTime         uint64 `json:"readTime"`
+	WriteTime        uint64 `json:"writeTime"`
+	IopsInProgress   uint64 `json:"iopsInProgress"`
+	IoTime           uint64 `json:"ioTime"`
+	Name             string `json:"name"`
+	SerialNumber     string `json:"serialNumber"`
 }
 
 func (d UsageStat) String() string {

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -292,6 +292,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		mergedReads, err := strconv.ParseUint((fields[4]), 10, 64)
+		if err != nil {
+			return ret, err
+		}
 		rbytes, err := strconv.ParseUint((fields[5]), 10, 64)
 		if err != nil {
 			return ret, err
@@ -304,6 +308,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		mergedWrites, err := strconv.ParseUint((fields[8]), 10, 64)
+		if err != nil {
+			return ret, err
+		}
 		wbytes, err := strconv.ParseUint((fields[9]), 10, 64)
 		if err != nil {
 			return ret, err
@@ -312,18 +320,25 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		iopsInProgress, err := strconv.ParseUint((fields[11]), 10, 64)
+		if err != nil {
+			return ret, err
+		}
 		iotime, err := strconv.ParseUint((fields[12]), 10, 64)
 		if err != nil {
 			return ret, err
 		}
 		d := IOCountersStat{
-			ReadBytes:  rbytes * SectorSize,
-			WriteBytes: wbytes * SectorSize,
-			ReadCount:  reads,
-			WriteCount: writes,
-			ReadTime:   rtime,
-			WriteTime:  wtime,
-			IoTime:     iotime,
+			ReadBytes:        rbytes * SectorSize,
+			WriteBytes:       wbytes * SectorSize,
+			ReadCount:        reads,
+			WriteCount:       writes,
+			MergedReadCount:  mergedReads,
+			MergedWriteCount: mergedWrites,
+			ReadTime:         rtime,
+			WriteTime:        wtime,
+			IopsInProgress:   iopsInProgress,
+			IoTime:           iotime,
 		}
 		if d == empty {
 			continue

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -93,7 +93,7 @@ func TestDiskIOCountersStat_String(t *testing.T) {
 		WriteBytes:   400,
 		SerialNumber: "SERIAL",
 	}
-	e := `{"readCount":100,"writeCount":200,"readBytes":300,"writeBytes":400,"readTime":0,"writeTime":0,"name":"sd01","ioTime":0,"serialNumber":"SERIAL"}`
+	e := `{"readCount":100,"mergedReadCount":0,"writeCount":200,"mergedWriteCount":0,"readBytes":300,"writeBytes":400,"readTime":0,"writeTime":0,"iopsInProgress":0,"ioTime":0,"name":"sd01","serialNumber":"SERIAL"}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("DiskUsageStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
This is the missing piece so I can replace my previous platform-specific logic with `gopsutil`. It adds:

* Number of merged write operations
* Number of merged read operations
* Number of I/O operations in progress

It seems reasonable to add those, even though its just Linux for now, since other platforms likely provide similar data, and the alternative (having to read `/proc/diskstats` yourself in addition to using `gopsutil`) seems worse.