### PR TITLE
Add CGO implementation of Process.Exe on OS X

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -79,7 +79,7 @@ func (p *Process) Name() (string, error) {
 	return common.IntToString(k.Proc.P_comm[:]), nil
 }
 func (p *Process) Exe() (string, error) {
-	return "", common.ErrNotImplementedError
+	return internal_GetProcessExe(int(p.Pid))
 }
 
 // Cmdline returns the command line arguments of the process as a string with

--- a/process/process_exe_darwin.go
+++ b/process/process_exe_darwin.go
@@ -1,0 +1,29 @@
+// +build darwin
+
+package process
+
+// #include <stdlib.h>
+// #include <libproc.h>
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// internal_GetProcessExe is a OS X specific way to get the full path to exe of a running process.
+func internal_GetProcessExe(pid int) (string, error) {
+	var c C.char // need a var for unsafe.Sizeof need a var
+	const bufsize = C.PROC_PIDPATHINFO_MAXSIZE * unsafe.Sizeof(c)
+	buffer := (*C.char)(C.malloc(C.size_t(bufsize)))
+	defer C.free(unsafe.Pointer(buffer))
+
+	ret, err := C.proc_pidpath(C.int(pid), unsafe.Pointer(buffer), C.uint32_t(bufsize))
+	if err != nil {
+		return "", err
+	} else if ret <= 0 {
+		return "", fmt.Errorf("Unknown error: proc_pidpath returned %d", ret)
+	}
+
+	gostr := C.GoString(buffer)
+	return gostr, nil
+}


### PR DESCRIPTION
A the moment we have `Process.Exe` "not implemented" for OS X.

If CGO is an option for darwin, it can be done like this.
