### PR TITLE
Implement CreateTime for darwin.

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/cpu"
@@ -105,7 +106,34 @@ func (p *Process) CmdlineSlice() ([]string, error) {
 	return r[0], err
 }
 func (p *Process) CreateTime() (int64, error) {
-	return 0, common.ErrNotImplementedError
+	r, err := callPs("etime", p.Pid, false)
+	if err != nil {
+		return 0, err
+	}
+
+	elapsedSegments := strings.Split(r[0][0], ":")
+	var elapsedDurations []time.Duration
+	for i := len(elapsedSegments) - 1; i >= 0; i-- {
+		p, err := strconv.ParseInt(elapsedSegments[i], 10, 0)
+		if err != nil {
+			return 0, err
+		}
+		elapsedDurations = append(elapsedDurations, time.Duration(p))
+	}
+
+	var elapsed time.Duration = time.Duration(elapsedDurations[0]) * time.Second
+	if len(elapsedDurations) > 1 {
+		elapsed += time.Duration(elapsedDurations[1]) * time.Minute
+	}
+	if len(elapsedDurations) > 2 {
+		elapsed += time.Duration(elapsedDurations[2]) * time.Hour
+	}
+	if len(elapsedDurations) > 3 {
+		elapsed += time.Duration(elapsedDurations[3]) * time.Hour * 24
+	}
+
+	start := time.Now().Add(-elapsed)
+	return start.Unix() * 1000, nil
 }
 func (p *Process) Cwd() (string, error) {
 	return "", common.ErrNotImplementedError


### PR DESCRIPTION
Parses elapsed time and converts this to epoch time.
Passes CreateTime unit test on OSX and verified using a separate app.