### PR TITLE
Add fallback code for all unsupported operating systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,17 @@ check:  ## Check
 	errcheck -ignore="Close|Run|Write" ./...
 	golint ./... | egrep -v 'underscores|HttpOnly|should have comment|comment on exported|CamelCase|VM|UID' && exit 1 || exit 0
 
+BUILD_FAIL_PATTERN=grep -v "exec format error" | grep "build failed" && exit 1 || exit 0
 build_test:  ## test only buildable
-	GOOS=linux go test ./... | grep -v "exec format error"
-	GOOS=freebsd go test ./... | grep -v "exec format error"
-	CGO_ENABLED=0 GOOS=darwin go test ./... | grep -v "exec format error"
-	CGO_ENABLED=1 GOOS=darwin go test ./... | grep -v "exec format error"
-	GOOS=windows go test ./...| grep -v "exec format error"
+	# Supported operating systems
+	GOOS=linux go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=freebsd go test ./... | $(BUILD_FAIL_PATTERN)
+	CGO_ENABLED=0 GOOS=darwin go test ./... | $(BUILD_FAIL_PATTERN)
+	CGO_ENABLED=1 GOOS=darwin go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=windows go test ./... | $(BUILD_FAIL_PATTERN)
+	# Operating systems supported for building only (not implemented error if used)
+	GOOS=dragonfly go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=netbsd go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=openbsd go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=solaris go test ./... | $(BUILD_FAIL_PATTERN)
+	@echo 'Successfully built on all known operating systems'

--- a/cpu/cpu_fallback.go
+++ b/cpu/cpu_fallback.go
@@ -1,0 +1,21 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package cpu
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/internal/common"
+)
+
+func Times(percpu bool) ([]TimesStat, error) {
+	return []TimesStat{}, common.ErrNotImplementedError
+}
+
+func Info() ([]InfoStat, error) {
+	return []InfoStat{}, common.ErrNotImplementedError
+}
+
+func Percent(interval time.Duration, percpu bool) ([]float64, error) {
+	return []float64{}, common.ErrNotImplementedError
+}

--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -1,0 +1,17 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package disk
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func IOCounters() (map[string]IOCountersStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func Partitions(all bool) ([]PartitionStat, error) {
+	return []PartitionStat{}, common.ErrNotImplementedError
+}
+
+func Usage(path string) (*UsageStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/host/host_fallback.go
+++ b/host/host_fallback.go
@@ -1,0 +1,21 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package host
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func Info() (*InfoStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func BootTime() (uint64, error) {
+	return 0, common.ErrNotImplementedError
+}
+
+func Uptime() (uint64, error) {
+	return 0, common.ErrNotImplementedError
+}
+
+func Users() ([]UserStat, error) {
+	return []UserStat{}, common.ErrNotImplementedError
+}

--- a/load/load_fallback.go
+++ b/load/load_fallback.go
@@ -1,0 +1,13 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package load
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func Avg() (*AvgStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func Misc() (*MiscStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/mem/mem_fallback.go
+++ b/mem/mem_fallback.go
@@ -1,0 +1,13 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package mem
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func SwapMemory() (*SwapMemoryStat, error) {
+	return nil, common.ErrNotImplementedError
+}

--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -1,0 +1,21 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package net
+
+import "github.com/shirou/gopsutil/internal/common"
+
+func IOCounters(pernic bool) ([]IOCountersStat, error) {
+	return []IOCountersStat{}, common.ErrNotImplementedError
+}
+
+func FilterCounters() ([]FilterStat, error) {
+	return []FilterStat{}, common.ErrNotImplementedError
+}
+
+func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
+	return []ProtoCountersStat{}, common.ErrNotImplementedError
+}
+
+func Connections(kind string) ([]ConnectionStat, error) {
+	return []ConnectionStat{}, common.ErrNotImplementedError
+}

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -1,0 +1,145 @@
+// +build !darwin,!linux,!freebsd,!windows
+
+package process
+
+import (
+	"syscall"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/internal/common"
+	"github.com/shirou/gopsutil/net"
+)
+
+type MemoryMapsStat struct {
+	Path         string `json:"path"`
+	Rss          uint64 `json:"rss"`
+	Size         uint64 `json:"size"`
+	Pss          uint64 `json:"pss"`
+	SharedClean  uint64 `json:"sharedClean"`
+	SharedDirty  uint64 `json:"sharedDirty"`
+	PrivateClean uint64 `json:"privateClean"`
+	PrivateDirty uint64 `json:"privateDirty"`
+	Referenced   uint64 `json:"referenced"`
+	Anonymous    uint64 `json:"anonymous"`
+	Swap         uint64 `json:"swap"`
+}
+
+type MemoryInfoExStat struct {
+}
+
+func Pids() ([]int32, error) {
+	return []int32{}, common.ErrNotImplementedError
+}
+
+func NewProcess(pid int32) (*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) Ppid() (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) Name() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) Exe() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) Cmdline() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) CmdlineSlice() ([]string, error) {
+	return []string{}, common.ErrNotImplementedError
+}
+func (p *Process) CreateTime() (int64, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) Cwd() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) Parent() (*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) Status() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) Uids() ([]int32, error) {
+	return []int32{}, common.ErrNotImplementedError
+}
+func (p *Process) Gids() ([]int32, error) {
+	return []int32{}, common.ErrNotImplementedError
+}
+func (p *Process) Terminal() (string, error) {
+	return "", common.ErrNotImplementedError
+}
+func (p *Process) Nice() (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) IOnice() (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) Rlimit() ([]RlimitStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) IOCounters() (*IOCountersStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) NumFDs() (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) NumThreads() (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+func (p *Process) Threads() (map[string]string, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) Times() (*cpu.TimesStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) CPUAffinity() ([]int32, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) Children() ([]*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
+	return []OpenFilesStat{}, common.ErrNotImplementedError
+}
+func (p *Process) Connections() ([]net.ConnectionStat, error) {
+	return []net.ConnectionStat{}, common.ErrNotImplementedError
+}
+func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
+	return []net.IOCountersStat{}, common.ErrNotImplementedError
+}
+func (p *Process) IsRunning() (bool, error) {
+	return true, common.ErrNotImplementedError
+}
+func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+func (p *Process) SendSignal(sig syscall.Signal) error {
+	return common.ErrNotImplementedError
+}
+func (p *Process) Suspend() error {
+	return common.ErrNotImplementedError
+}
+func (p *Process) Resume() error {
+	return common.ErrNotImplementedError
+}
+func (p *Process) Terminate() error {
+	return common.ErrNotImplementedError
+}
+func (p *Process) Kill() error {
+	return common.ErrNotImplementedError
+}
+func (p *Process) Username() (string, error) {
+	return "", common.ErrNotImplementedError
+}


### PR DESCRIPTION
This enables using gopsutil in a codebase that gets built on other OSes
than the ones supported. Instead of a build failure as before, due to
the build tags, gopsutil will now throw an "not implemented" runtime
error.

Fixes #234.