### PR TITLE
Addressing frequency unit discrepancies

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -96,11 +96,11 @@ func Info() ([]InfoStat, error) {
 	}
 
 	values := strings.Fields(string(out))
-	mhz, err := strconv.ParseFloat(values[1], 64)
+	hz, err := strconv.ParseFloat(values[1], 64)
 	if err != nil {
 		return ret, err
 	}
-	c.Mhz = mhz / 1000000.0
+	c.Mhz = hz / 1000000.0
 
 	return append(ret, c), nil
 }

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -72,7 +72,7 @@ func finishCPUInfo(c *InfoStat) error {
 			if err != nil {
 				return err
 			}
-			c.Mhz = value
+			c.Mhz = value/1000.0  // value is in kHz
 		}
 	}
 	if len(c.CoreID) == 0 {


### PR DESCRIPTION
* for Darwin, it is a minor tweak for readability: the value
  returned is in Hz, so using a variable named 'hz' makes more
  sense than 'mhz'
* for Linux, the unit is in kHz so we need to divide the value
  from `cpuinfo_max_freq` by 10^3 to get MHz (see
  cpu-freq/user-guide.txt of the kernel documentation)