### PR TITLE
Standardize `Mhz` to mean maximum CPU frequency on Linux platform

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -65,22 +65,29 @@ func sysCPUPath(cpu int32, relPath string) string {
 }
 
 func finishCPUInfo(c *InfoStat) error {
-	if c.Mhz == 0 {
-		lines, err := common.ReadLines(sysCPUPath(c.CPU, "cpufreq/cpuinfo_max_freq"))
-		if err == nil {
-			value, err := strconv.ParseFloat(lines[0], 64)
-			if err != nil {
-				return err
-			}
-			c.Mhz = value/1000.0  // value is in kHz
-		}
-	}
+	var lines []string
+	var err error
+	var value float64
+
 	if len(c.CoreID) == 0 {
-		lines, err := common.ReadLines(sysCPUPath(c.CPU, "topology/coreId"))
+		lines, err = common.ReadLines(sysCPUPath(c.CPU, "topology/core_id"))
 		if err == nil {
 			c.CoreID = lines[0]
 		}
 	}
+
+	// override the value of c.Mhz with cpufreq/cpuinfo_max_freq regardless
+	// of the value from /proc/cpuinfo because we want to report the maximum
+	// clock-speed of the CPU for c.Mhz, matching the behaviour of Windows
+	lines, err = common.ReadLines(sysCPUPath(c.CPU, "cpufreq/cpuinfo_max_freq"))
+	if err != nil {
+		return err
+	}
+	value, err = strconv.ParseFloat(lines[0], 64)
+	if err != nil {
+		return err
+	}
+	c.Mhz = value/1000.0  // value is in kHz
 	return nil
 }
 
@@ -136,11 +143,10 @@ func Info() ([]InfoStat, error) {
 			}
 			c.Stepping = int32(t)
 		case "cpu MHz":
-			t, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return ret, err
+			// treat this as the fallback value, thus we ignore error
+			if t, err := strconv.ParseFloat(value, 64); err == nil {
+				c.Mhz = t
 			}
-			c.Mhz = t
 		case "cache size":
 			t, err := strconv.ParseInt(strings.Replace(value, " KB", "", 1), 10, 64)
 			if err != nil {

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -80,12 +80,22 @@ func finishCPUInfo(c *InfoStat) error {
 	// of the value from /proc/cpuinfo because we want to report the maximum
 	// clock-speed of the CPU for c.Mhz, matching the behaviour of Windows
 	lines, err = common.ReadLines(sysCPUPath(c.CPU, "cpufreq/cpuinfo_max_freq"))
+	// if we encounter errors below but has a value from parsing /proc/cpuinfo
+	// then we ignore the error
 	if err != nil {
-		return err
+		if c.Mhz == 0 {
+			return err
+		} else {
+			return nil
+		}
 	}
 	value, err = strconv.ParseFloat(lines[0], 64)
 	if err != nil {
-		return err
+		if c.Mhz == 0 {
+			return err
+		} else {
+			return nil
+		}
 	}
 	c.Mhz = value/1000.0  // value is in kHz
 	return nil


### PR DESCRIPTION
* resolve #249
* in `cpu_windows.go`, `Mhz` is the value of `MaxClockSpeed`
* on Linux platform, the `Mhz` value is extracted from `/proc/cpuinfo`
  which reflects the current clock speed; treat this as the fallback
  value instead
* read from `cpufreq/cpuinfo_max_freq` under sysfs to get the
  maximum clock speed for `Mhz`, just like for Windows platform
* also fix the path to `cpu.CoreID` value; the filename is `core_id`