### PR TITLE
Fix: wrong swap values on i686 / 4GB ram.

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -70,8 +70,8 @@ func SwapMemory() (*SwapMemoryStat, error) {
 		return nil, err
 	}
 	ret := &SwapMemoryStat{
-		Total: uint64(sysinfo.Totalswap),
-		Free:  uint64(sysinfo.Freeswap),
+		Total: uint64(sysinfo.Totalswap) * uint64(sysinfo.Unit),
+		Free:  uint64(sysinfo.Freeswap) * uint64(sysinfo.Unit),
 	}
 	ret.Used = ret.Total - ret.Free
 	//check Infinity


### PR DESCRIPTION
According to sysinfo manpages: swap fields need to be interpreted along
with the mem_unit (Unit) field.

See also http://stackoverflow.com/a/4229727