### PR TITLE
[host]darwin: change to use sw_vers to get platform version

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -32,11 +32,11 @@ func Info() (*InfoStat, error) {
 		ret.Hostname = hostname
 	}
 
-	platform, family, version, err := PlatformInformation()
+	platform, family, pver, version, err := PlatformInformation()
 	if err == nil {
 		ret.Platform = platform
 		ret.PlatformFamily = family
-		ret.PlatformVersion = version
+		ret.PlatformVersion = pver
 		ret.KernelVersion = version
 	}
 
@@ -135,18 +135,29 @@ func Users() ([]UserStat, error) {
 
 }
 
-func PlatformInformation() (string, string, string, error) {
+func PlatformInformation() (string, string, string, string, error) {
 	platform := ""
 	family := ""
 	version := ""
+	pver := ""
 
+	sw_vers, err := exec.LookPath("sw_vers")
+	if err != nil {
+		return "", "", "", "", err
+	}
 	uname, err := exec.LookPath("uname")
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
+
 	out, err := invoke.Command(uname, "-s")
 	if err == nil {
 		platform = strings.ToLower(strings.TrimSpace(string(out)))
+	}
+
+	out, err = invoke.Command(sw_vers, "-productVersion")
+	if err == nil {
+		pver = strings.ToLower(strings.TrimSpace(string(out)))
 	}
 
 	out, err = invoke.Command(uname, "-r")
@@ -154,7 +165,7 @@ func PlatformInformation() (string, string, string, error) {
 		version = strings.ToLower(strings.TrimSpace(string(out)))
 	}
 
-	return platform, family, version, nil
+	return platform, family, pver, version, nil
 }
 
 func Virtualization() (string, string, error) {


### PR DESCRIPTION
use `sw_vers` instead of `uname` to get platform version. previous platform version is same as kernel version. This PR fixes and return Product version.

- prev: 14.5.0
- now PR: 10.10.5