### PR TITLE
process: determine page sizes via function

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -20,7 +20,10 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
-var ErrorNoChildren = errors.New("process does not have children")
+var (
+	ErrorNoChildren = errors.New("process does not have children")
+	PageSize        = uint64(os.Getpagesize())
+)
 
 const (
 	PrioProcess = 0 // linux/resource.h

--- a/process/process_linux_386.go
+++ b/process/process_linux_386.go
@@ -4,6 +4,5 @@
 package process
 
 const (
-	ClockTicks = 100  // C.sysconf(C._SC_CLK_TCK)
-	PageSize   = 4096 // C.sysconf(C._SC_PAGE_SIZE)
+	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
 )

--- a/process/process_linux_amd64.go
+++ b/process/process_linux_amd64.go
@@ -4,6 +4,5 @@
 package process
 
 const (
-	ClockTicks = 100  // C.sysconf(C._SC_CLK_TCK)
-	PageSize   = 4096 // C.sysconf(C._SC_PAGE_SIZE)
+	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
 )

--- a/process/process_linux_arm.go
+++ b/process/process_linux_arm.go
@@ -4,6 +4,5 @@
 package process
 
 const (
-	ClockTicks = 100  // C.sysconf(C._SC_CLK_TCK)
-	PageSize   = 4096 // C.sysconf(C._SC_PAGE_SIZE)
+	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
 )

--- a/process/process_linux_arm64.go
+++ b/process/process_linux_arm64.go
@@ -4,6 +4,5 @@
 package process
 
 const (
-	ClockTicks = 100  // C.sysconf(C._SC_CLK_TCK)
-	PageSize   = 4096 // C.sysconf(C._SC_PAGE_SIZE)
+	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
 )


### PR DESCRIPTION
Instead of hard-coding the page size for linux systems, use Go's
`Getpagesize` function.

This resolves #258.

Signed-off-by: Thomas Hipp <thipp@suse.de>