### PR TITLE
process: make `ClockTicks` arch-independent

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -26,7 +26,8 @@ var (
 )
 
 const (
-	PrioProcess = 0 // linux/resource.h
+	PrioProcess = 0   // linux/resource.h
+	ClockTicks  = 100 // C.sysconf(C._SC_CLK_TCK)
 )
 
 // MemoryInfoExStat is different between OSes

--- a/process/process_linux_386.go
+++ b/process/process_linux_386.go
@@ -1,8 +1,0 @@
-// +build linux
-// +build 386
-
-package process
-
-const (
-	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
-)

--- a/process/process_linux_amd64.go
+++ b/process/process_linux_amd64.go
@@ -1,8 +1,0 @@
-// +build linux
-// +build amd64
-
-package process
-
-const (
-	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
-)

--- a/process/process_linux_arm.go
+++ b/process/process_linux_arm.go
@@ -1,8 +1,0 @@
-// +build linux
-// +build arm
-
-package process
-
-const (
-	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
-)

--- a/process/process_linux_arm64.go
+++ b/process/process_linux_arm64.go
@@ -1,8 +1,0 @@
-// +build linux
-// +build arm64
-
-package process
-
-const (
-	ClockTicks = 100 // C.sysconf(C._SC_CLK_TCK)
-)


### PR DESCRIPTION
The value for `ClockTicks` is defined as `100` by the Linux kernel for
all currently supported architectures in Go. Therefore, there is no need
to define this constant for each architecture separately.

This fixes #260.

Signed-off-by: Thomas Hipp <thomashipp@gmail.com>