### PR TITLE
added weightedIO field to disk IOCountersStat (last field of /etc/mtab)

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -43,6 +43,7 @@ type IOCountersStat struct {
 	WriteTime        uint64 `json:"writeTime"`
 	IopsInProgress   uint64 `json:"iopsInProgress"`
 	IoTime           uint64 `json:"ioTime"`
+	WeightedIO       uint64 `json:"weightedIO"`
 	Name             string `json:"name"`
 	SerialNumber     string `json:"serialNumber"`
 }

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -328,6 +328,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		weightedIO, err := strconv.ParseUint((fields[13]), 10, 64)
+		if err != nil {
+			return ret, err
+		}
 		d := IOCountersStat{
 			ReadBytes:        rbytes * SectorSize,
 			WriteBytes:       wbytes * SectorSize,
@@ -339,6 +343,7 @@ func IOCounters() (map[string]IOCountersStat, error) {
 			WriteTime:        wtime,
 			IopsInProgress:   iopsInProgress,
 			IoTime:           iotime,
+			WeightedIO:       weightedIO,
 		}
 		if d == empty {
 			continue

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -93,7 +93,7 @@ func TestDiskIOCountersStat_String(t *testing.T) {
 		WriteBytes:   400,
 		SerialNumber: "SERIAL",
 	}
-	e := `{"readCount":100,"mergedReadCount":0,"writeCount":200,"mergedWriteCount":0,"readBytes":300,"writeBytes":400,"readTime":0,"writeTime":0,"iopsInProgress":0,"ioTime":0,"name":"sd01","serialNumber":"SERIAL"}`
+	e := `{"readCount":100,"mergedReadCount":0,"writeCount":200,"mergedWriteCount":0,"readBytes":300,"writeBytes":400,"readTime":0,"writeTime":0,"iopsInProgress":0,"ioTime":0,"weightedIO":0,"name":"sd01","serialNumber":"SERIAL"}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("DiskUsageStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
The field is described as "weighted time spent doing I/Os (ms)"
It enables mimic iostat avgqu-sz