### PR TITLE
Added Terminate() for Windows

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -308,9 +308,20 @@ func (p *Process) Suspend() error {
 func (p *Process) Resume() error {
 	return common.ErrNotImplementedError
 }
+
 func (p *Process) Terminate() error {
-	return common.ErrNotImplementedError
+	// PROCESS_TERMINATE = 0x0001
+	proc := w32.OpenProcess(0x0001, false, uint32(p.Pid))
+	ret := w32.TerminateProcess(proc, 0)
+	w32.CloseHandle(proc)
+
+	if ret == false {
+		return syscall.GetLastError()
+	} else {
+		return nil
+	}
 }
+
 func (p *Process) Kill() error {
 	return common.ErrNotImplementedError
 }


### PR DESCRIPTION
Since it appears to not have been implemented yet, I added support for `Terminate()` in *process_windows.go*.

As a side note, perhaps it would be worth adding PROCESS related constants (like `PROCESS_TERMINATE = 0x0001` to [shirou/w32](https://github.com/shirou/w32).