### PR TITLE
Add ConnectionsMax function that limits connections per pid.

### DIFF
--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -19,3 +19,7 @@ func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
 func Connections(kind string) ([]ConnectionStat, error) {
 	return []ConnectionStat{}, common.ErrNotImplementedError
 }
+
+func ConnectionsMax(kind string, max int) ([]ConnectionStat, error) {
+	return []ConnectionStat{}, common.ErrNotImplementedError
+}

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -15,9 +15,30 @@ func TestGetProcInodesAll(t *testing.T) {
 	}
 
 	root := common.HostProc("")
-	v, err := getProcInodesAll(root)
+	v, err := getProcInodesAll(root, 0)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, v)
+}
+
+func TestConnectionsMax(t *testing.T) {
+	if os.Getenv("CIRCLECI") == "true" {
+		t.Skip("Skip CI")
+	}
+
+	max := 10
+	v, err := ConnectionsMax("tcp", max)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, v)
+
+	cxByPid := map[int32]int{}
+	for _, cx := range v {
+		if cx.Pid > 0 {
+			cxByPid[cx.Pid]++
+		}
+	}
+	for _, c := range cxByPid {
+		assert.True(t, c <= max)
+	}
 }
 
 type AddrTest struct {

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -13,6 +13,12 @@ func Connections(kind string) ([]ConnectionStat, error) {
 	return ConnectionsPid(kind, 0)
 }
 
+// Return a list of network connections opened returning at most `max`
+// connections for each running process.
+func ConnectionsMax(kind string, max int) ([]ConnectionStat, error) {
+	return []ConnectionStat{}, common.ErrNotImplementedError
+}
+
 // Return a list of network connections opened by a process.
 func ConnectionsPid(kind string, pid int32) ([]ConnectionStat, error) {
 	var ret []ConnectionStat
@@ -65,4 +71,9 @@ func ConnectionsPid(kind string, pid int32) ([]ConnectionStat, error) {
 	}
 
 	return ret, nil
+}
+
+// Return up to `max` network connections opened by a process.
+func ConnectionsPidMax(kind string, pid int32, max int) ([]ConnectionStat, error) {
+	return []ConnectionStat{}, common.ErrNotImplementedError
 }

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -76,6 +76,12 @@ func Connections(kind string) ([]ConnectionStat, error) {
 	return ret, common.ErrNotImplementedError
 }
 
+// Return a list of network connections opened returning at most `max`
+// connections for each running process.
+func ConnectionsMax(kind string, max int) ([]ConnectionStat, error) {
+	return []ConnectionStat{}, common.ErrNotImplementedError
+}
+
 func FilterCounters() ([]FilterStat, error) {
 	return nil, errors.New("NetFilterCounters not implemented for windows")
 }


### PR DESCRIPTION
The motivation is to improve performance of fetching connections across
all processes when some processes can have several hundred or thousands of file
descriptors. Right now when you have many thousands of fds the process spends
lots of time inside the syscalls from Readdir and Readlink.

The public API works as before with two new functions:
- `ConnectionsMax`
- `ConnectionsPidMax`

Each function takes an additional int argument that sets the max number of fds
read per process.

This does add some duplication between `ConnectionsMax` and `Connections`
so I'm open to suggestions on a better approach.
