### PR TITLE
Allow clock field in /proc/cpuinfo as cpu MHz fallback value

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -152,9 +152,9 @@ func Info() ([]InfoStat, error) {
 				return ret, err
 			}
 			c.Stepping = int32(t)
-		case "cpu MHz":
+		case "cpu MHz", "clock":
 			// treat this as the fallback value, thus we ignore error
-			if t, err := strconv.ParseFloat(value, 64); err == nil {
+			if t, err := strconv.ParseFloat(strings.Replace(value, "MHz", "", 1), 64); err == nil {
 				c.Mhz = t
 			}
 		case "cache size":


### PR DESCRIPTION
Needed on ppc64le debian porter boxes atleast.

See #230 

This avoids getting MHz from both sysfs cpufreq and /proc/cpuinfo failing. Previously an error was thrown. With this patch we have MHz value in fallback.