### PR TITLE
Obtain executable path from macOS process (fix #270)

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -343,7 +343,7 @@ func WaitTimeout(c *exec.Cmd, timeout time.Duration) error {
 }
 
 // https://gist.github.com/kylelemons/1525278
-func Pipeline(cmds ...*exec.Cmd) (pipeLineOutput, collectedStandardError []byte, pipeLineError os.Error) {
+func Pipeline(cmds ...*exec.Cmd) ([]byte, []byte, error) {
         // Require at least one command
         if len(cmds) < 1 { 
                 return nil, nil, nil
@@ -355,7 +355,7 @@ func Pipeline(cmds ...*exec.Cmd) (pipeLineOutput, collectedStandardError []byte,
 
         last := len(cmds) - 1
         for i, cmd := range cmds[:last] {
-                var err os.Error
+                var err error
                 // Connect each command's stdin to the previous command's stdout
                 if cmds[i+1].Stdin, err = cmd.StdoutPipe(); err != nil {
                         return nil, nil, err

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -341,3 +341,46 @@ func WaitTimeout(c *exec.Cmd, timeout time.Duration) error {
 		return ErrTimeout
 	}
 }
+
+// https://gist.github.com/kylelemons/1525278
+func Pipeline(cmds ...*exec.Cmd) (pipeLineOutput, collectedStandardError []byte, pipeLineError os.Error) {
+        // Require at least one command
+        if len(cmds) < 1 { 
+                return nil, nil, nil
+        }
+
+        // Collect the output from the command(s)
+        var output bytes.Buffer
+        var stderr bytes.Buffer
+
+        last := len(cmds) - 1
+        for i, cmd := range cmds[:last] {
+                var err os.Error
+                // Connect each command's stdin to the previous command's stdout
+                if cmds[i+1].Stdin, err = cmd.StdoutPipe(); err != nil {
+                        return nil, nil, err
+                }
+                // Connect each command's stderr to a buffer
+                cmd.Stderr = &stderr
+        }
+
+        // Connect the output and error for the last command
+        cmds[last].Stdout, cmds[last].Stderr = &output, &stderr
+
+        // Start each command
+        for _, cmd := range cmds {
+                if err := cmd.Start(); err != nil {
+                        return output.Bytes(), stderr.Bytes(), err
+                }
+        }
+
+        // Wait for each command to complete
+        for _, cmd := range cmds {
+                if err := cmd.Wait(); err != nil {
+                        return output.Bytes(), stderr.Bytes(), err
+                }
+        }
+
+        // Return the pipeline output and the collected standard error
+        return output.Bytes(), stderr.Bytes(), nil
+}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -85,8 +85,15 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	awk_bin, _ := exec.Lookpath("awk")
-	sed_bin, _ := exec.LookPath("sed")
+	awk_bin, err := exec.LookPath("awk")
+	if err != nil {
+		return "", err
+	}
+
+	sed_bin, err := exec.LookPath("sed")
+	if err != nil {
+		return "", err
+	}
 
 	lsof := exec.Command(lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fn")
 	awk := exec.Command(awk_bin, "NR==3{print}")

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -86,7 +86,9 @@ func (p *Process) Exe() (string, error) {
 	}
 
 	cmd := []string{"-p", string(p.Pid), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
-	
+
+	fmt.Println(strings.Join(cmd, " "))
+
 	out, err := invoke.Command(bin, cmd...)
 	if err != nil {
 		return "", err

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -85,7 +85,7 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	cmd := []string{"-p", strconv.Itoa(int(pid)), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
+	cmd := []string{"-p", strconv.Itoa(int(p.Pid)), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
 
 	fmt.Println(strings.Join(cmd, " "))
 

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -85,15 +85,14 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	var cmd []string
-	cmd := []string{"-p", p.Pid, "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
+	cmd := []string{"-p", string(p.Pid), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
 	
 	out, err := invoke.Command(bin, cmd...)
 	if err != nil {
 		return "", err
 	}
 
-	ret := strings.TrimSpace(out)
+	ret := strings.TrimSpace(string(out))
 
 	return ret, nil
 }

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -97,9 +97,9 @@ func (p *Process) Exe() (string, error) {
 
 	lsof := exec.Command(lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fn")
 	awk := exec.Command(awk_bin, "NR==3{print}")
-	sed := exec.Command("s/n\\//\\//")
+	sed := exec.Command(sed_bin, "s/n\\//\\//")
 
-	output, stderr, err := common.Pipeline(lsof, awk, sed)
+	output, _, err := common.Pipeline(lsof, awk, sed)
 
 	if err != nil {
 		return "", err

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -85,7 +85,7 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	cmd := []string{"-p", strconv.Itoa(int(p.Pid)), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
+	cmd := []string{"-p", strconv.Itoa(int(p.Pid)), "-Fn", "|", "awk", "NR==3{print}", "|", "sed",  "s/n\\//\\//"}
 
 	fmt.Println(strings.Join(cmd, " "))
 

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -80,7 +80,22 @@ func (p *Process) Name() (string, error) {
 	return common.IntToString(k.Proc.P_comm[:]), nil
 }
 func (p *Process) Exe() (string, error) {
-	return "", common.ErrNotImplementedError
+	bin, err := exec.LookPath("lsof")
+	if err != nil {
+		return "", err
+	}
+
+	var cmd []string
+	cmd := []string{"-p", p.Pid, "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
+	
+	out, err = invoke.Command(bin, cmd...)
+	if err != nil {
+		return "", err
+	}
+
+	ret = strings.TrimSpace(out)
+
+	return ret, nil
 }
 
 // Cmdline returns the command line arguments of the process as a string with

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -88,12 +88,12 @@ func (p *Process) Exe() (string, error) {
 	var cmd []string
 	cmd := []string{"-p", p.Pid, "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
 	
-	out, err = invoke.Command(bin, cmd...)
+	out, err := invoke.Command(bin, cmd...)
 	if err != nil {
 		return "", err
 	}
 
-	ret = strings.TrimSpace(out)
+	ret := strings.TrimSpace(out)
 
 	return ret, nil
 }

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -85,7 +85,7 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	cmd := []string{"-p", string(p.Pid), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
+	cmd := []string{"-p", strconv.Itoa(int(pid)), "-Fn", "|", "awk", "'NR==3{print}'", "|", "sed",  "'s/n\\//\\//'"}
 
 	fmt.Println(strings.Join(cmd, " "))
 


### PR DESCRIPTION
This is in relation to the ticket #270.
It might appear a bit hacky, but it is the most reliable way I have found to obtain the executable path for macOS processes. It finds the appropriate line from open handles.

Additionally, I had to add a function in common to introduce piping of shell commands.