### PR TITLE
Improve CPU identification for POWER processors

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -144,10 +144,22 @@ func Info() ([]InfoStat, error) {
 			c.Family = value
 		case "model":
 			c.Model = value
-		case "model name":
+		case "model name", "cpu":
 			c.ModelName = value
-		case "stepping":
-			t, err := strconv.ParseInt(value, 10, 64)
+			if strings.Contains(value, "POWER8") ||
+			   strings.Contains(value, "POWER7") {
+				c.Model = strings.Split(value, " ")[0]
+				c.Family = "POWER"
+				c.VendorID = "IBM"
+			}
+		case "stepping", "revision":
+			val := value
+
+			if key == "revision" {
+				val = strings.Split(value, ".")[0]
+			}
+
+			t, err := strconv.ParseInt(val, 10, 64)
 			if err != nil {
 				return ret, err
 			}


### PR DESCRIPTION
Currently gopsutils fails to indentify the POWER processors family,
returning an almost empty Info() structure.

This patch improves the POWER identification without changing what is
available for x86.