### PR TITLE
Fix NetIOCounter windows interface behavior

### DIFF
--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"syscall"
-	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -35,37 +34,28 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ai, err := getAdapterList()
-	if err != nil {
-		return nil, err
-	}
 	var ret []IOCountersStat
 
 	for _, ifi := range ifs {
-		name := ifi.Name
-		for ; ai != nil; ai = ai.Next {
-			name = common.BytePtrToString(&ai.Description[0])
-			c := IOCountersStat{
-				Name: name,
-			}
-
-			row := syscall.MibIfRow{Index: ai.Index}
-			e := syscall.GetIfEntry(&row)
-			if e != nil {
-				return nil, os.NewSyscallError("GetIfEntry", e)
-			}
-			c.BytesSent = uint64(row.OutOctets)
-			c.BytesRecv = uint64(row.InOctets)
-			c.PacketsSent = uint64(row.OutUcastPkts)
-			c.PacketsRecv = uint64(row.InUcastPkts)
-			c.Errin = uint64(row.InErrors)
-			c.Errout = uint64(row.OutErrors)
-			c.Dropin = uint64(row.InDiscards)
-			c.Dropout = uint64(row.OutDiscards)
-
-			ret = append(ret, c)
+		c := IOCountersStat{
+			Name: ifi.Name,
 		}
+
+		row := syscall.MibIfRow{Index: uint32(ifi.Index)}
+		e := syscall.GetIfEntry(&row)
+		if e != nil {
+			return nil, os.NewSyscallError("GetIfEntry", e)
+		}
+		c.BytesSent = uint64(row.OutOctets)
+		c.BytesRecv = uint64(row.InOctets)
+		c.PacketsSent = uint64(row.OutUcastPkts)
+		c.PacketsRecv = uint64(row.InUcastPkts)
+		c.Errin = uint64(row.InErrors)
+		c.Errout = uint64(row.OutErrors)
+		c.Dropin = uint64(row.InDiscards)
+		c.Dropout = uint64(row.OutDiscards)
+
+		ret = append(ret, c)
 	}
 
 	if pernic == false {
@@ -84,23 +74,6 @@ func Connections(kind string) ([]ConnectionStat, error) {
 	var ret []ConnectionStat
 
 	return ret, common.ErrNotImplementedError
-}
-
-// borrowed from src/pkg/net/interface_windows.go
-func getAdapterList() (*syscall.IpAdapterInfo, error) {
-	b := make([]byte, 1000)
-	l := uint32(len(b))
-	a := (*syscall.IpAdapterInfo)(unsafe.Pointer(&b[0]))
-	err := syscall.GetAdaptersInfo(a, &l)
-	if err == syscall.ERROR_BUFFER_OVERFLOW {
-		b = make([]byte, l)
-		a = (*syscall.IpAdapterInfo)(unsafe.Pointer(&b[0]))
-		err = syscall.GetAdaptersInfo(a, &l)
-	}
-	if err != nil {
-		return nil, os.NewSyscallError("GetAdaptersInfo", err)
-	}
-	return a, nil
 }
 
 func FilterCounters() ([]FilterStat, error) {


### PR DESCRIPTION
addresses a few things:

- Windows has a concept of both a network "interface" and an "adapter"
- These are almost always a one-to-one relationship, though there can be
esoteric instances where they are not.
- I believe the gopsutil NetIOCounters function should only return on a
per-interface level, since this is the behavior on linux/darwin.

Previously, the plugin was basically ignoring the actual interfaces
returned from net.Interfaces(). Instead, it was looping over the net
adapters for each interface, somewhat uselessly.

FWIW, the code for getAdapterList() doesn't exist in the Go standard lib
anymore.

closes #245