### PR TITLE
fix panic when /proc/stat is empty

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -36,6 +36,9 @@ func Times(percpu bool) ([]TimesStat, error) {
 		var startIdx uint = 1
 		for {
 			linen, _ := common.ReadLinesOffsetN(filename, startIdx, 1)
+			if len(linen) == 0 {
+				break
+			}
 			line := linen[0]
 			if !strings.HasPrefix(line, "cpu") {
 				break


### PR DESCRIPTION
I don't really know why this would be the case, but I suppose there are
always edge-cases.

see https://github.com/influxdata/telegraf/issues/2356