### PR TITLE
Unconditionally lowercase the `HostID` from all supported platforms.

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -59,7 +59,7 @@ func Info() (*InfoStat, error) {
 
 	values, err := common.DoSysctrl("kern.uuid")
 	if err == nil && len(values) == 1 && values[0] != "" {
-		ret.HostID = values[0]
+		ret.HostID = strings.ToLower(values[0])
 	}
 
 	return ret, nil

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -62,7 +62,7 @@ func Info() (*InfoStat, error) {
 
 	values, err := common.DoSysctrl("kern.hostuuid")
 	if err == nil && len(values) == 1 && values[0] != "" {
-		ret.HostID = values[0]
+		ret.HostID = strings.ToLower(values[0])
 	}
 
 	return ret, nil

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -70,14 +70,14 @@ func Info() (*InfoStat, error) {
 	case common.PathExists(sysProductUUID):
 		lines, err := common.ReadLines(sysProductUUID)
 		if err == nil && len(lines) > 0 && lines[0] != "" {
-			ret.HostID = lines[0]
+			ret.HostID = strings.ToLower(lines[0])
 			break
 		}
 		fallthrough
 	default:
 		values, err := common.DoSysctrl("kernel.random.boot_id")
 		if err == nil && len(values) == 1 && values[0] != "" {
-			ret.HostID = values[0]
+			ret.HostID = strings.ToLower(values[0])
 		}
 	}
 

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -64,7 +64,7 @@ func Info() (*InfoStat, error) {
 	{
 		hostID, err := getMachineGuid()
 		if err == nil {
-			ret.HostID = hostID
+			ret.HostID = strings.ToLower(hostID)
 		}
 	}
 


### PR DESCRIPTION
This was an oversight from earlier.  All of the platforms I use toss out lowercase UUIDs, but Linux does not.