### PR TITLE
fix panic in starvation situations

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -201,6 +201,10 @@ func Info() ([]InfoStat, error) {
 func parseStatLine(line string) (*TimesStat, error) {
 	fields := strings.Fields(line)
 
+	if len(fields) == 0 {
+		return nil, errors.New("stat does not contain cpu info")
+	}
+
 	if strings.HasPrefix(fields[0], "cpu") == false {
 		//		return CPUTimesStat{}, e
 		return nil, errors.New("not contain cpu")


### PR DESCRIPTION
line 208 was panic'ing because fields could be 0 len, if we had trouble reading from proc, this just makes this safe. 