### PR TITLE
Added support to alias interfaces (e.g., ifname0:1)

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -37,7 +37,7 @@ func IOCountersByFile(pernic bool, filename string) ([]IOCountersStat, error) {
 	ret := make([]IOCountersStat, 0, statlen)
 
 	for _, line := range lines[2:] {
-		parts := strings.SplitN(line, ":", 2)
+		parts := strings.SplitN(line, ": ", 2)
 		if len(parts) != 2 {
 			continue
 		}


### PR DESCRIPTION
In linux, alias interfaces can end up in `/proc/net/dev` as shown below:
```
[root@host ~]# cat /proc/net/dev
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
    lo: 1638928809 4771634    0    0    0     0          0         0 1638928809 4771634    0    0    0     0       0          0
  eth0: 1000866899965 764654426    0    0    0     0          0         0 1267144066 5373060    0    0    0     0       0          0
tun999999:       0       0    0    0    0     0          0         0        0       0    0   15    0     0       0          0
tun10001:1:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
tun10001:2:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          
```

Current parsing will delimit field on a `:` only which results in `:1` as the first element of a line with an alias interface. This will result in an error as `:1` will not be parseable to an int later on.

This PR changes the delimiter to `: ` (space added), correctly parsing alias interfaces as well.