### PR TITLE
Fixes memory leak

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -407,6 +407,7 @@ func getProcInodes(root string, pid int32, max int) (map[string][]inodeMap, erro
 	if err != nil {
 		return ret, nil
 	}
+	defer f.Close()
 	files, err := f.Readdir(max)
 	if err != nil {
 		return ret, nil


### PR DESCRIPTION
In net_linux.go we open all files in /proc but we never close them. This causes a psutil golang app to crash on a busy system after 3 or 4 calls to `net.Connections()`.