### PR TITLE
Fix for getMachineGuid() return value

### DIFF
--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -80,7 +80,7 @@ func Info() (*InfoStat, error) {
 
 func getMachineGuid() (string, error) {
 	var h syscall.Handle
-	err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, syscall.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, syscall.KEY_READ, &h)
+	err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, syscall.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, syscall.KEY_READ|syscall.KEY_WOW64_64KEY, &h)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
getMachineGuid() function return a empty value in x86 windows builds.
Issue: https://github.com/shirou/gopsutil/issues/322