### PR TITLE
cpu[linux]: ignore cpufreq/cpuinfo_max_freq error

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -83,22 +83,14 @@ func finishCPUInfo(c *InfoStat) error {
 	// of the value from /proc/cpuinfo because we want to report the maximum
 	// clock-speed of the CPU for c.Mhz, matching the behaviour of Windows
 	lines, err = common.ReadLines(sysCPUPath(c.CPU, "cpufreq/cpuinfo_max_freq"))
-	// if we encounter errors below but has a value from parsing /proc/cpuinfo
-	// then we ignore the error
+	// if we encounter errors below such as there are no cpuinfo_max_freq file,
+	// we just ignore. so let Mhz is 0.
 	if err != nil {
-		if c.Mhz == 0 {
-			return err
-		} else {
-			return nil
-		}
+		return nil
 	}
 	value, err = strconv.ParseFloat(lines[0], 64)
 	if err != nil {
-		if c.Mhz == 0 {
-			return err
-		} else {
-			return nil
-		}
+		return nil
 	}
 	c.Mhz = value / 1000.0 // value is in kHz
 	return nil


### PR DESCRIPTION
This fixes #282, just a ignore error and leave MHz 0.

