### PR TITLE
Add disk.IOCountersForNames function

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -62,3 +62,7 @@ func (d IOCountersStat) String() string {
 	s, _ := json.Marshal(d)
 	return string(s)
 }
+
+func IOCounters() (map[string]IOCountersStat, error) {
+	return IOCountersForNames([]string{})
+}

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -87,6 +87,10 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
 func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
 	var _p0 unsafe.Pointer
 	var bufsize uintptr

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -87,10 +87,6 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
 func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
 	var _p0 unsafe.Pointer
 	var bufsize uintptr

--- a/disk/disk_darwin_cgo.go
+++ b/disk/disk_darwin_cgo.go
@@ -30,9 +30,11 @@ import (
 	"errors"
 	"strings"
 	"unsafe"
+
+	"github.com/shirou/gopsutil/internal/common"
 )
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	if C.StartIOCounterFetch() == 0 {
 		return nil, errors.New("Unable to fetch disk list")
 	}
@@ -76,6 +78,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 			WriteTime:  uint64(di.WriteTime),
 			IoTime:     uint64(di.ReadTime + di.WriteTime),
 			Name:       strings.TrimFunc(C.GoStringN(&di.DiskName[0], C.MAX_DISK_NAME), isRuneNull),
+		}
+
+		if len(names) > 0 && !common.StringsHas(names, d.Name) {
+			continue
 		}
 
 		ret[d.Name] = d

--- a/disk/disk_darwin_nocgo.go
+++ b/disk/disk_darwin_nocgo.go
@@ -5,6 +5,6 @@ package disk
 
 import "github.com/shirou/gopsutil/internal/common"
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }

--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -4,7 +4,7 @@ package disk
 
 import "github.com/shirou/gopsutil/internal/common"
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -94,7 +94,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	// statinfo->devinfo->devstat
 	// /usr/include/devinfo.h
 	ret := make(map[string]IOCountersStat)
@@ -118,6 +118,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		}
 		un := strconv.Itoa(int(d.Unit_number))
 		name := common.IntToString(d.Device_name[:]) + un
+
+		if len(names) > 0 && !common.StringsHas(names, name) {
+			continue
+		}
 
 		ds := IOCountersStat{
 			ReadCount:  d.Operations[DEVSTAT_READ],

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -272,7 +272,7 @@ func getFileSystems() ([]string, error) {
 	return ret, nil
 }
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	filename := common.HostProc("diskstats")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
@@ -288,6 +288,11 @@ func IOCounters() (map[string]IOCountersStat, error) {
 			continue
 		}
 		name := fields[2]
+
+		if len(names) > 0 && !common.StringsHas(names, name) {
+			continue
+		}
+
 		reads, err := strconv.ParseUint((fields[3]), 10, 64)
 		if err != nil {
 			return ret, err

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -63,7 +63,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat)
 
 	r, err := syscall.Sysctl("hw.diskstats")
@@ -83,6 +83,10 @@ func IOCounters() (map[string]IOCountersStat, error) {
 			continue
 		}
 		name := common.IntToString(d.Name[:])
+
+		if len(names) > 0 && !common.StringsHas(names, name) {
+			continue
+		}
 
 		ds := IOCountersStat{
 			ReadCount:  d.Rxfer,

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -129,7 +129,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCounters() (map[string]IOCountersStat, error) {
+func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat, 0)
 	var dst []Win32_PerfFormattedData
 
@@ -141,6 +141,11 @@ func IOCounters() (map[string]IOCountersStat, error) {
 		if len(d.Name) > 3 { // not get _Total or Harddrive
 			continue
 		}
+
+		if len(names) > 0 && !common.StringsHas(names, name) {
+			continue
+		}
+
 		ret[d.Name] = IOCountersStat{
 			Name:       d.Name,
 			ReadCount:  uint64(d.AvgDiskReadQueueLength),


### PR DESCRIPTION
Operates like disk.IOCounters, but accepts an array of names to limit the results.

I only tested this on linux.

Should address #341