### PR TITLE
Make IOCounters a variadic function

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -62,7 +62,3 @@ func (d IOCountersStat) String() string {
 	s, _ := json.Marshal(d)
 	return string(s)
 }
-
-func IOCounters() (map[string]IOCountersStat, error) {
-	return IOCountersForNames([]string{})
-}

--- a/disk/disk_darwin_cgo.go
+++ b/disk/disk_darwin_cgo.go
@@ -34,7 +34,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	if C.StartIOCounterFetch() == 0 {
 		return nil, errors.New("Unable to fetch disk list")
 	}

--- a/disk/disk_darwin_nocgo.go
+++ b/disk/disk_darwin_nocgo.go
@@ -5,6 +5,6 @@ package disk
 
 import "github.com/shirou/gopsutil/internal/common"
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }

--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -4,7 +4,7 @@ package disk
 
 import "github.com/shirou/gopsutil/internal/common"
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -94,7 +94,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	// statinfo->devinfo->devstat
 	// /usr/include/devinfo.h
 	ret := make(map[string]IOCountersStat)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -272,7 +272,7 @@ func getFileSystems() ([]string, error) {
 	return ret, nil
 }
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	filename := common.HostProc("diskstats")
 	lines, err := common.ReadLines(filename)
 	if err != nil {

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -63,7 +63,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat)
 
 	r, err := syscall.Sysctl("hw.diskstats")

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -129,7 +129,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return ret, nil
 }
 
-func IOCountersForNames(names []string) (map[string]IOCountersStat, error) {
+func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat, 0)
 	var dst []Win32_PerfFormattedData
 


### PR DESCRIPTION
Remove IOCountersForNames that was recently added in favor of variadic
function with same capabilities.