### PR TITLE
Optimize memory usage for net.Connections on Linux

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -370,7 +370,7 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 			// Build TCP key to id the connection uniquely
 			// socket type, src ip, src port, dst ip, dst port and state should be enough
 			// to prevent duplications.
-			connKey = strconv.Itoa(int(c.sockType)) + "-" + c.laddr.IP + ":" + strconv.Itoa(int(c.laddr.Port)) + "-" + c.raddr.IP + ":" + strconv.Itoa(int(c.raddr.Port)) + "-" + c.status
+			connKey = fmt.Sprintf("%s-%s:%d-%s:%d-%s", c.sockType, c.laddr.IP, c.laddr.Port, c.raddr.IP, c.raddr.Port, c.status)
 			if _, ok := dupCheckMap[connKey]; ok {
 				continue
 			}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -368,9 +368,9 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 		}
 		for _, c := range ls {
 			// Build TCP key to id the connection uniquely
-			// socket type, src ip, src port, dst ip dst port should be enough
+			// socket type, src ip, src port, dst ip, dst port and state should be enough
 			// to prevent duplications.
-			connKey = strconv.Itoa(int(c.sockType)) + "-" + c.laddr.IP + ":" + strconv.Itoa(int(c.laddr.Port)) + "-" + c.raddr.IP + ":" + strconv.Itoa(int(c.raddr.Port))
+			connKey = strconv.Itoa(int(c.sockType)) + "-" + c.laddr.IP + ":" + strconv.Itoa(int(c.laddr.Port)) + "-" + c.raddr.IP + ":" + strconv.Itoa(int(c.raddr.Port)) + "-" + c.status
 			if _, ok := dupCheckMap[connKey]; ok {
 				continue
 			}


### PR DESCRIPTION
Hey,

In servers with higher tcp connection counts the /proc/net/tcp file and the likes get big. For example, one one of our servers /proc/net/tcp is 9 MBs. Parsing it becomes expensive.

As such the impact of keeping another copy of the connTemp structure just for indexing and filtering out duplicates is considerable. My PR proposes indexing on the socket type, src ip, src port, dst ip and dst port. The combination of these should be enough to ID the connection uniquely. This saves some memory because the other connTemp struct members are not used.

Regarding CPU utilization, on my local tests the modified version results in a little below 1% more CPU time.

I've run both mine and the original version through some test files from our production machines and both return the same results.

On average in our setup this change saves 30% of memory. We are using the telegraf input plugin, which runs netstat in 1 minute intervals.