### PR TITLE
Fromat socketType properly in tcp duplication check key

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -370,7 +370,7 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 			// Build TCP key to id the connection uniquely
 			// socket type, src ip, src port, dst ip, dst port and state should be enough
 			// to prevent duplications.
-			connKey = fmt.Sprintf("%s-%s:%d-%s:%d-%s", c.sockType, c.laddr.IP, c.laddr.Port, c.raddr.IP, c.raddr.Port, c.status)
+			connKey = fmt.Sprintf("%d-%s:%d-%s:%d-%s", c.sockType, c.laddr.IP, c.laddr.Port, c.raddr.IP, c.raddr.Port, c.status)
 			if _, ok := dupCheckMap[connKey]; ok {
 				continue
 			}


### PR DESCRIPTION
Hey,

I am sorry for the spam and the second PR. Upon further testing I noticed that I wasn't formatting the c.sockType properly, it is a uint32 and I formatted it as a string.