### PR TITLE
Read /proc/net files with a single read syscall.

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -613,14 +614,18 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 		// IPv6 not supported, return empty.
 		return []connTmp{}, nil
 	}
-	lines, err := common.ReadLines(file)
+
+	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
+
+	lines := bytes.Split(contents, []byte("\n"))
+
 	var ret []connTmp
 	// skip first line
 	for _, line := range lines[1:] {
-		l := strings.Fields(line)
+		l := strings.Fields(string(line))
 		if len(l) < 10 {
 			continue
 		}
@@ -667,15 +672,17 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 }
 
 func processUnix(file string, kind netConnectionKindType, inodes map[string][]inodeMap, filterPid int32) ([]connTmp, error) {
-	lines, err := common.ReadLines(file)
+	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
 
+	lines := bytes.Split(contents, []byte("\n"))
+
 	var ret []connTmp
 	// skip first line
 	for _, line := range lines[1:] {
-		tokens := strings.Fields(line)
+		tokens := strings.Fields(string(line))
 		if len(tokens) < 6 {
 			continue
 		}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -615,6 +615,10 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 		return []connTmp{}, nil
 	}
 
+	// Read the contents of the /proc file with a single read sys call.
+	// This minimizes duplicates in the returned connections
+	// For more info:
+	// https://github.com/shirou/gopsutil/pull/361
 	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -672,6 +676,10 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 }
 
 func processUnix(file string, kind netConnectionKindType, inodes map[string][]inodeMap, filterPid int32) ([]connTmp, error) {
+	// Read the contents of the /proc file with a single read sys call.
+	// This minimizes duplicates in the returned connections
+	// For more info:
+	// https://github.com/shirou/gopsutil/pull/361
 	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The /proc/net files are not guaranteed to be consistent, they are only
consitent on the row level. This is probably one of the reasons why
consequent read calls might return duplicate entries - the kernel is
changing the file as it is being read. In certain situations this might
lead to loop like situations - the same net entry is being returned by consequent read calls as new connections are added to the kernel tcp table.

This PR is trying to reduce the duplications, by fetching the contents
of the net files with a single read syscall.

[This](http://stackoverflow.com/questions/5713451/is-it-safe-to-parse-a-proc-file) discussion on Stackoverflow goes into more detail on how the /proc files work in terms of consistency.

In our use case, there were certain situations where the netstat telegraf input plugin spiked eating up a lot of memory. On further inspection it appeared that this was due to a lot of entries in the /proc/net/tcp file. These entries, however, did not correspond to higher tcp connections - they remained within the expected range. This is what leads me to believe, that in certain situations loop like conditions are created and a lot of duplicate rows appear in /proc/net/tcp.

Consider the following graphs:

![graphs](https://cloud.githubusercontent.com/assets/1012269/25661089/c42621c8-3017-11e7-95b7-fa1b5fbf184b.png)

The memory in the graph is the memory taken from the netstat telegraf plugin. You can see how spikes in the /proc/net/tcp length correspond to spikes in netstat's memory usage. Additionally, in those spikes, there are no real spikes in tcp connection counts. The length of /proc/net/tcp was gathered separately using `cat /proc/net/tcp`. `cat` itself issues many read calls to the file, so it has the same behavior as the netstat plugin.

After the patch the graphs look like this:

![graphafter](https://cloud.githubusercontent.com/assets/1012269/25661312/c4944f76-3018-11e7-9e8f-7f8e6010c225.png)

There are no more spikes in memory.

Slightly more CPU is consumed, but this is compensated with the reduction of duplicates and stabilization of the memory used. For smaller use cases I don't think CPU usage will be an issue, in higher ones overall single reads yields much better performance.
In our use case we are observing a 56% improvement in the time required to gather the netstat data:

![netstatcomparison](https://cloud.githubusercontent.com/assets/1012269/25661408/2fc579dc-3019-11e7-9066-fb0e7f645ee6.png)