### PR TITLE
Include "DRIVE_REMOTE" volumes on windows

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -84,9 +84,9 @@ func Partitions(all bool) ([]PartitionStat, error) {
 			if typeret == 0 {
 				return ret, syscall.GetLastError()
 			}
-			// 2: DRIVE_REMOVABLE 3: DRIVE_FIXED 5: DRIVE_CDROM
+			// 2: DRIVE_REMOVABLE 3: DRIVE_FIXED 4: DRIVE_REMOTE 5: DRIVE_CDROM
 
-			if typeret == 2 || typeret == 3 || typeret == 5 {
+			if typeret == 2 || typeret == 3 || typeret == 4 || typeret == 5 {
 				lpVolumeNameBuffer := make([]byte, 256)
 				lpVolumeSerialNumber := int64(0)
 				lpMaximumComponentLength := int64(0)


### PR DESCRIPTION
Unix systems show remote mounts as there is no distinction on those platforms, so it makes sense to include on windows as well.