### PR TITLE
Read disk partitions on linux from /proc/mounts instead of /etc/mtab

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -214,8 +214,6 @@ var fsTypeMap = map[int64]string{
 // Partitions returns disk partitions. If all is false, returns
 // physical devices only (e.g. hard disks, cd-rom drives, USB keys)
 // and ignore all others (e.g. memory partitions such as /dev/shm)
-//
-// should use setmntent(3) but this implement use /etc/mtab file
 func Partitions(all bool) ([]PartitionStat, error) {
 	filename := common.HostProc("mounts")
 	lines, err := common.ReadLines(filename)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -215,7 +215,7 @@ var fsTypeMap = map[int64]string{
 // physical devices only (e.g. hard disks, cd-rom drives, USB keys)
 // and ignore all others (e.g. memory partitions such as /dev/shm)
 func Partitions(all bool) ([]PartitionStat, error) {
-	filename := common.HostProc("mounts")
+	filename := common.HostProc("self/mounts")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
 		return nil, err

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -217,7 +217,7 @@ var fsTypeMap = map[int64]string{
 //
 // should use setmntent(3) but this implement use /etc/mtab file
 func Partitions(all bool) ([]PartitionStat, error) {
-	filename := common.HostEtc("mtab")
+	filename := common.HostProc("mounts")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #371