### PR TITLE
Reduce unnecessary syscalls on common.NumProcs() in Linux

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -35,7 +35,7 @@ func NumProcs() (uint64, error) {
 	}
 	defer f.Close()
 
-	list, err := f.Readdir(-1)
+	list, err := f.Readdirnames(-1)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
(in *nix, ) `os.File.Readdir()` calls `lstat` on files under the directory, but `os.File.Readdirnames()` does not call and simply returns its names.
In `common.NumProcs()`, only `len(list)` will be used as return value, so this `Readdir()` can be replaced by `Readdirnames()`, maybe.