### PR TITLE
Windows: Read processor performance metrics overall, per cpu and per core

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -23,6 +23,26 @@ type Win32_Processor struct {
 	MaxClockSpeed             uint32
 }
 
+// Win32_PerfFormattedData_Counters_ProcessorInformation stores instance value of the perf counters
+type Win32_PerfFormattedData_Counters_ProcessorInformation struct {
+	Name                  string
+	PercentDPCTime        uint64
+	PercentIdleTime       uint64
+	PercentUserTime       uint64
+	PercentProcessorTime  uint64
+	PercentInterruptTime  uint64
+	PercentPriorityTime   uint64
+	PercentPrivilegedTime uint64
+	InterruptsPerSec      uint32
+	ProcessorFrequency    uint32
+	DPCRate               uint32
+}
+
+type Win32_PerfFormattedData_PerfOS_System struct {
+	Processes            uint32
+	ProcessorQueueLength uint32
+}
+
 // TODO: Get percpu
 func Times(percpu bool) ([]TimesStat, error) {
 	var ret []TimesStat
@@ -83,4 +103,22 @@ func Info() ([]InfoStat, error) {
 	}
 
 	return ret, nil
+}
+
+// PerfInfo returns the performance counter's instance value for ProcessorInformation.
+// Name property is the key by which overall, per cpu and per core metric is known.
+func PerfInfo() ([]Win32_PerfFormattedData_Counters_ProcessorInformation, error) {
+	var ret []Win32_PerfFormattedData_Counters_ProcessorInformation
+	q := wmi.CreateQuery(&ret, "")
+	err := wmi.Query(q, &ret)
+	return ret, err
+}
+
+// ProcInfo returns processes count and processor queue length in the system.
+// There is a single queue for processor even on multiprocessors systems.
+func ProcInfo() ([]Win32_PerfFormattedData_PerfOS_System, error) {
+	var ret []Win32_PerfFormattedData_PerfOS_System
+	q := wmi.CreateQuery(&ret, "")
+	err := wmi.Query(q, &ret)
+	return ret, err
 }

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -8,7 +8,6 @@ import (
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-
 	"github.com/shirou/gopsutil/internal/common"
 )
 
@@ -38,12 +37,13 @@ type Win32_PerfFormattedData_Counters_ProcessorInformation struct {
 	DPCRate               uint32
 }
 
+// Win32_PerfFormattedData_PerfOS_System struct to have count of processes and processor queue length
 type Win32_PerfFormattedData_PerfOS_System struct {
 	Processes            uint32
 	ProcessorQueueLength uint32
 }
 
-// TODO: Get percpu
+// Times returns times stat per cpu and combined for all CPUs
 func Times(percpu bool) ([]TimesStat, error) {
 	if percpu {
 		return perCPUTimes()
@@ -126,6 +126,7 @@ func ProcInfo() ([]Win32_PerfFormattedData_PerfOS_System, error) {
 	return ret, err
 }
 
+// perCPUTimes returns times stat per cpu, per core and overall for all CPUs
 func perCPUTimes() ([]TimesStat, error) {
 	var ret []TimesStat
 	stats, err := PerfInfo()


### PR DESCRIPTION
Pull request for the enhancement ([#373](https://github.com/shirou/gopsutil/issues/373)) to get the processor performance metric cpu and core wise specific to windows platform.

In addition to this added a function which provide number of processes and processor queue length.
