### PR TITLE
Fix data race in host.BootTime

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -6,10 +6,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var (
-	invoke         common.Invoker
-	cachedBootTime = uint64(0)
-)
+var invoke common.Invoker
 
 func init() {
 	invoke = common.Invoke{}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -72,9 +73,13 @@ func Info() (*InfoStat, error) {
 	return ret, nil
 }
 
+// cachedBootTime must be accessed via atomic.Load/StoreUint64
+var cachedBootTime uint64
+
 func BootTime() (uint64, error) {
-	if cachedBootTime != 0 {
-		return cachedBootTime, nil
+	t := atomic.LoadUint64(&cachedBootTime)
+	if t != 0 {
+		return t, nil
 	}
 	values, err := common.DoSysctrl("kern.boottime")
 	if err != nil {
@@ -86,9 +91,10 @@ func BootTime() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	cachedBootTime = uint64(boottime)
+	t = uint64(boottime)
+	atomic.StoreUint64(&cachedBootTime, t)
 
-	return cachedBootTime, nil
+	return t, nil
 }
 
 func uptime(boot uint64) uint64 {

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -68,9 +69,13 @@ func Info() (*InfoStat, error) {
 	return ret, nil
 }
 
+// cachedBootTime must be accessed via atomic.Load/StoreUint64
+var cachedBootTime uint64
+
 func BootTime() (uint64, error) {
-	if cachedBootTime != 0 {
-		return cachedBootTime, nil
+	t := atomic.LoadUint64(&cachedBootTime)
+	if t != 0 {
+		return t, nil
 	}
 	values, err := common.DoSysctrl("kern.boottime")
 	if err != nil {
@@ -83,9 +88,10 @@ func BootTime() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	cachedBootTime = boottime
+	t = uint64(boottime)
+	atomic.StoreUint64(&cachedBootTime, t)
 
-	return boottime, nil
+	return t, nil
 }
 
 func uptime(boot uint64) uint64 {


### PR DESCRIPTION
When `host.BootTime` is accessed concurrently there is a data race on `cachedBootTime`. Since `host.BootTime` is the only method accessing this variable I've moved it in front of the function using it to make it less likely to just use it by accident.