### PR TITLE
Move from the `syscall` package to the `golang.org/x/sys/{unix,windows}`

### DIFF
--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 // sys/sched.h
@@ -100,7 +100,7 @@ func Info() ([]InfoStat, error) {
 
 	c := InfoStat{}
 
-	v, err := syscall.Sysctl("hw.model")
+	v, err := unix.Sysctl("hw.model")
 	if err != nil {
 		return nil, err
 	}

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -4,12 +4,11 @@ package cpu
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/windows"
 )
 
 type Win32_Processor struct {
@@ -35,7 +34,7 @@ func Times(percpu bool) ([]TimesStat, error) {
 		uintptr(unsafe.Pointer(&lpKernelTime)),
 		uintptr(unsafe.Pointer(&lpUserTime)))
 	if r == 0 {
-		return ret, syscall.GetLastError()
+		return ret, windows.GetLastError()
 	}
 
 	LOT := float64(0.0000001)

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -4,10 +4,10 @@ package disk
 
 import (
 	"path"
-	"syscall"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 func Partitions(all bool) ([]PartitionStat, error) {
@@ -94,7 +94,7 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
 		_p0 = unsafe.Pointer(&buf[0])
 		bufsize = unsafe.Sizeof(Statfs_t{}) * uintptr(len(buf))
 	}
-	r0, _, e1 := syscall.Syscall(SYS_GETFSSTAT64, uintptr(_p0), bufsize, uintptr(flags))
+	r0, _, e1 := unix.Syscall(SYS_GETFSSTAT64, uintptr(_p0), bufsize, uintptr(flags))
 	n = int(r0)
 	if e1 != 0 {
 		err = e1
@@ -102,6 +102,6 @@ func Getfsstat(buf []Statfs_t, flags int) (n int, err error) {
 	return
 }
 
-func getFsType(stat syscall.Statfs_t) string {
+func getFsType(stat unix.Statfs_t) string {
 	return common.IntToString(stat.Fstypename[:])
 }

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -7,8 +7,9 @@ import (
 	"encoding/binary"
 	"path"
 	"strconv"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -17,7 +18,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
 	// get length
-	count, err := syscall.Getfsstat(nil, MNT_WAIT)
+	count, err := unix.Getfsstat(nil, MNT_WAIT)
 	if err != nil {
 		return ret, err
 	}
@@ -99,7 +100,7 @@ func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	// /usr/include/devinfo.h
 	ret := make(map[string]IOCountersStat)
 
-	r, err := syscall.Sysctl("kern.devstat.all")
+	r, err := unix.Sysctl("kern.devstat.all")
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func Getfsstat(buf []Statfs, flags int) (n int, err error) {
 		_p0 = unsafe.Pointer(&buf[0])
 		bufsize = unsafe.Sizeof(Statfs{}) * uintptr(len(buf))
 	}
-	r0, _, e1 := syscall.Syscall(syscall.SYS_GETFSSTAT, uintptr(_p0), bufsize, uintptr(flags))
+	r0, _, e1 := unix.Syscall(unix.SYS_GETFSSTAT, uintptr(_p0), bufsize, uintptr(flags))
 	n = int(r0)
 	if e1 != 0 {
 		err = e1
@@ -175,6 +176,6 @@ func parseDevstat(buf []byte) (Devstat, error) {
 	return ds, nil
 }
 
-func getFsType(stat syscall.Statfs_t) string {
+func getFsType(stat unix.Statfs_t) string {
 	return common.IntToString(stat.Fstypename[:])
 }

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -7,7 +7,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -386,7 +387,7 @@ func GetDiskSerialNumber(name string) string {
 	return ""
 }
 
-func getFsType(stat syscall.Statfs_t) string {
+func getFsType(stat unix.Statfs_t) string {
 	t := int64(stat.Type)
 	ret, ok := fsTypeMap[t]
 	if !ok {

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -6,17 +6,17 @@ import (
 	"bytes"
 	"encoding/binary"
 	"path"
-	"syscall"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 func Partitions(all bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
 	// get length
-	count, err := syscall.Getfsstat(nil, MNT_WAIT)
+	count, err := unix.Getfsstat(nil, MNT_WAIT)
 	if err != nil {
 		return ret, err
 	}
@@ -66,7 +66,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat)
 
-	r, err := syscall.Sysctl("hw.diskstats")
+	r, err := unix.Sysctl("hw.diskstats")
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func Getfsstat(buf []Statfs, flags int) (n int, err error) {
 		_p0 = unsafe.Pointer(&buf[0])
 		bufsize = unsafe.Sizeof(Statfs{}) * uintptr(len(buf))
 	}
-	r0, _, e1 := syscall.Syscall(syscall.SYS_GETFSSTAT, uintptr(_p0), bufsize, uintptr(flags))
+	r0, _, e1 := unix.Syscall(unix.SYS_GETFSSTAT, uintptr(_p0), bufsize, uintptr(flags))
 	n = int(r0)
 	if e1 != 0 {
 		err = e1
@@ -133,8 +133,8 @@ func parseDiskstats(buf []byte) (Diskstats, error) {
 }
 
 func Usage(path string) (*UsageStat, error) {
-	stat := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &stat)
+	stat := unix.Statfs_t{}
+	err := unix.Statfs(path, &stat)
 	if err != nil {
 		return nil, err
 	}
@@ -157,6 +157,6 @@ func Usage(path string) (*UsageStat, error) {
 	return ret, nil
 }
 
-func getFsType(stat syscall.Statfs_t) string {
+func getFsType(stat unix.Statfs_t) string {
 	return common.IntToString(stat.F_fstypename[:])
 }

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -2,11 +2,11 @@
 
 package disk
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 func Usage(path string) (*UsageStat, error) {
-	stat := syscall.Statfs_t{}
-	err := syscall.Statfs(path, &stat)
+	stat := unix.Statfs_t{}
+	err := unix.Statfs(path, &stat)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 func DoSysctrl(mib string) ([]string, error) {
@@ -36,8 +37,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 
 	// get required buffer size
 	length := uint64(0)
-	_, _, err := syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err := unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		0,
@@ -54,8 +55,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	}
 	// get proc info itself
 	buf := make([]byte, length)
-	_, _, err = syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err = unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/internal/common/common_freebsd.go
+++ b/internal/common/common_freebsd.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 func DoSysctrl(mib string) ([]string, error) {
@@ -36,8 +37,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 
 	// get required buffer size
 	length := uint64(0)
-	_, _, err := syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err := unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		0,
@@ -54,8 +55,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	}
 	// get proc info itself
 	buf := make([]byte, length)
-	_, _, err = syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err = unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/internal/common/common_openbsd.go
+++ b/internal/common/common_openbsd.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 func DoSysctrl(mib string) ([]string, error) {
@@ -36,8 +37,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 
 	// get required buffer size
 	length := uint64(0)
-	_, _, err := syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err := unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		0,
@@ -54,8 +55,8 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	}
 	// get proc info itself
 	buf := make([]byte, length)
-	_, _, err = syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err = unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -3,8 +3,9 @@
 package common
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // for double values
@@ -44,9 +45,9 @@ const (
 )
 
 var (
-	Modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-	ModNt       = syscall.NewLazyDLL("ntdll.dll")
-	ModPdh      = syscall.NewLazyDLL("pdh.dll")
+	Modkernel32 = windows.NewLazyDLL("kernel32.dll")
+	ModNt       = windows.NewLazyDLL("ntdll.dll")
+	ModPdh      = windows.NewLazyDLL("pdh.dll")
 
 	ProcGetSystemTimes           = Modkernel32.NewProc("GetSystemTimes")
 	ProcNtQuerySystemInformation = ModNt.NewProc("NtQuerySystemInformation")
@@ -77,13 +78,13 @@ func BytePtrToString(p *uint8) string {
 type CounterInfo struct {
 	PostName    string
 	CounterName string
-	Counter     syscall.Handle
+	Counter     windows.Handle
 }
 
 // CreateQuery XXX
 // copied from https://github.com/mackerelio/mackerel-agent/
-func CreateQuery() (syscall.Handle, error) {
-	var query syscall.Handle
+func CreateQuery() (windows.Handle, error) {
+	var query windows.Handle
 	r, _, err := PdhOpenQuery.Call(0, 0, uintptr(unsafe.Pointer(&query)))
 	if r != 0 {
 		return 0, err
@@ -92,11 +93,11 @@ func CreateQuery() (syscall.Handle, error) {
 }
 
 // CreateCounter XXX
-func CreateCounter(query syscall.Handle, pname, cname string) (*CounterInfo, error) {
-	var counter syscall.Handle
+func CreateCounter(query windows.Handle, pname, cname string) (*CounterInfo, error) {
+	var counter windows.Handle
 	r, _, err := PdhAddCounter.Call(
 		uintptr(query),
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(cname))),
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(cname))),
 		0,
 		uintptr(unsafe.Pointer(&counter)))
 	if r != 0 {

--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -6,18 +6,18 @@ import (
 	"encoding/binary"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 func getHwMemsize() (uint64, error) {
-	totalString, err := syscall.Sysctl("hw.memsize")
+	totalString, err := unix.Sysctl("hw.memsize")
 	if err != nil {
 		return 0, err
 	}
 
-	// syscall.sysctl() helpfully assumes the result is a null-terminated string and
+	// unix.sysctl() helpfully assumes the result is a null-terminated string and
 	// removes the last byte of the result if it's 0 :/
 	totalString += "\x00"
 

--- a/mem/mem_darwin_cgo.go
+++ b/mem/mem_darwin_cgo.go
@@ -10,8 +10,9 @@ import "C"
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // VirtualMemory returns VirtualmemoryStat.
@@ -28,7 +29,7 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 		return nil, fmt.Errorf("host_statistics error=%d", status)
 	}
 
-	pageSize := uint64(syscall.Getpagesize())
+	pageSize := uint64(unix.Getpagesize())
 	total, err := getHwMemsize()
 	if err != nil {
 		return nil, err

--- a/mem/mem_darwin_nocgo.go
+++ b/mem/mem_darwin_nocgo.go
@@ -7,7 +7,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Runs vm_stat and returns Free and inactive pages
@@ -27,7 +28,7 @@ func parseVMStat(out string, vms *VirtualMemoryStat) error {
 	var err error
 
 	lines := strings.Split(out, "\n")
-	pagesize := uint64(syscall.Getpagesize())
+	pagesize := uint64(unix.Getpagesize())
 	for _, line := range lines {
 		fields := strings.Split(line, ":")
 		if len(fields) < 2 {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -5,9 +5,9 @@ package mem
 import (
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 func VirtualMemory() (*VirtualMemoryStat, error) {
@@ -72,9 +72,9 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 }
 
 func SwapMemory() (*SwapMemoryStat, error) {
-	sysinfo := &syscall.Sysinfo_t{}
+	sysinfo := &unix.Sysinfo_t{}
 
-	if err := syscall.Sysinfo(sysinfo); err != nil {
+	if err := unix.Sysinfo(sysinfo); err != nil {
 		return nil, err
 	}
 	ret := &SwapMemoryStat{

--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -3,10 +3,10 @@
 package mem
 
 import (
-	"syscall"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -30,7 +30,7 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 	memInfo.cbSize = uint32(unsafe.Sizeof(memInfo))
 	mem, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&memInfo)))
 	if mem == 0 {
-		return nil, syscall.GetLastError()
+		return nil, windows.GetLastError()
 	}
 
 	ret := &VirtualMemoryStat{

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"net"
 	"os"
-	"syscall"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/windows"
 )
 
 var (
-	modiphlpapi             = syscall.NewLazyDLL("iphlpapi.dll")
+	modiphlpapi             = windows.NewLazyDLL("iphlpapi.dll")
 	procGetExtendedTCPTable = modiphlpapi.NewProc("GetExtendedTcpTable")
 	procGetExtendedUDPTable = modiphlpapi.NewProc("GetExtendedUdpTable")
 )
@@ -41,8 +41,8 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 			Name: ifi.Name,
 		}
 
-		row := syscall.MibIfRow{Index: uint32(ifi.Index)}
-		e := syscall.GetIfEntry(&row)
+		row := windows.MibIfRow{Index: uint32(ifi.Index)}
+		e := windows.GetIfEntry(&row)
 		if e != nil {
 			return nil, os.NewSyscallError("GetIfEntry", e)
 		}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -9,13 +9,13 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/net"
+	"golang.org/x/sys/unix"
 )
 
 // copied from sys/sysctl.h
@@ -443,8 +443,8 @@ func (p *Process) getKProc() (*KinfoProc, error) {
 	procK := KinfoProc{}
 	length := uint64(unsafe.Sizeof(procK))
 	buf := make([]byte, length)
-	_, _, syserr := syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, syserr := unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(len(mib)),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -6,11 +6,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"strings"
-	"syscall"
 
 	cpu "github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	net "github.com/shirou/gopsutil/net"
+	"golang.org/x/sys/unix"
 )
 
 // MemoryInfoExStat is different between OSes
@@ -223,7 +223,7 @@ func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
 	if err != nil {
 		return nil, err
 	}
-	v, err := syscall.Sysctl("vm.stats.vm.v_page_size")
+	v, err := unix.Sysctl("vm.stats.vm.v_page_size")
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -14,12 +14,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/net"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -857,7 +857,7 @@ func (p *Process) fillFromStat() (string, int32, *cpu.TimesStat, int64, int32, e
 
 	//	p.Nice = mustParseInt32(fields[18])
 	// use syscall instead of parse Stat file
-	snice, _ := syscall.Getpriority(PrioProcess, int(pid))
+	snice, _ := unix.Getpriority(PrioProcess, int(pid))
 	nice := int32(snice) // FIXME: is this true?
 
 	return terminal, int32(ppid), cpuTimes, createTime, nice, nil

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -7,13 +7,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	cpu "github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	mem "github.com/shirou/gopsutil/mem"
 	net "github.com/shirou/gopsutil/net"
+	"golang.org/x/sys/unix"
 )
 
 // MemoryInfoExStat is different between OSes
@@ -328,8 +328,8 @@ func CallKernProcSyscall(op int32, arg int32) ([]byte, uint64, error) {
 	mibptr := unsafe.Pointer(&mib[0])
 	miblen := uint64(len(mib))
 	length := uint64(0)
-	_, _, err := syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err := unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		0,
@@ -346,8 +346,8 @@ func CallKernProcSyscall(op int32, arg int32) ([]byte, uint64, error) {
 	miblen = uint64(len(mib))
 	// get proc info itself
 	buf := make([]byte, length)
-	_, _, err = syscall.Syscall6(
-		syscall.SYS___SYSCTL,
+	_, _, err = unix.Syscall6(
+		unix.SYS___SYSCTL,
 		uintptr(mibptr),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // POSIX
@@ -50,8 +52,8 @@ func getTerminalMap() (map[uint64]string, error) {
 	}
 
 	for _, name := range termfiles {
-		stat := syscall.Stat_t{}
-		if err = syscall.Stat(name, &stat); err != nil {
+		stat := unix.Stat_t{}
+		if err = unix.Stat(name, &stat); err != nil {
 			return nil, err
 		}
 		rdev := uint64(stat.Rdev)
@@ -60,7 +62,7 @@ func getTerminalMap() (map[uint64]string, error) {
 	return ret, nil
 }
 
-// SendSignal sends a syscall.Signal to the process.
+// SendSignal sends a unix.Signal to the process.
 // Currently, SIGSTOP, SIGCONT, SIGTERM and SIGKILL are supported.
 func (p *Process) SendSignal(sig syscall.Signal) error {
 	process, err := os.FindProcess(int(p.Pid))
@@ -78,22 +80,22 @@ func (p *Process) SendSignal(sig syscall.Signal) error {
 
 // Suspend sends SIGSTOP to the process.
 func (p *Process) Suspend() error {
-	return p.SendSignal(syscall.SIGSTOP)
+	return p.SendSignal(unix.SIGSTOP)
 }
 
 // Resume sends SIGCONT to the process.
 func (p *Process) Resume() error {
-	return p.SendSignal(syscall.SIGCONT)
+	return p.SendSignal(unix.SIGCONT)
 }
 
 // Terminate sends SIGTERM to the process.
 func (p *Process) Terminate() error {
-	return p.SendSignal(syscall.SIGTERM)
+	return p.SendSignal(unix.SIGTERM)
 }
 
 // Kill sends SIGKILL to the process.
 func (p *Process) Kill() error {
-	return p.SendSignal(syscall.SIGKILL)
+	return p.SendSignal(unix.SIGKILL)
 }
 
 // Username returns a username of the process.

--- a/process/process_posix_test.go
+++ b/process/process_posix_test.go
@@ -4,15 +4,16 @@ package process
 
 import (
 	"os"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func Test_SendSignal(t *testing.T) {
 	checkPid := os.Getpid()
 
 	p, _ := NewProcess(int32(checkPid))
-	err := p.SendSignal(syscall.SIGCONT)
+	err := p.SendSignal(unix.SIGCONT)
 	if err != nil {
 		t.Errorf("send signal %v", err)
 	}

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -425,7 +425,7 @@ func getMemoryInfo(pid int32) (PROCESS_MEMORY_COUNTERS, error) {
 }
 
 func getProcessMemoryInfo(h windows.Handle, mem *PROCESS_MEMORY_COUNTERS) (err error) {
-	r1, _, e1 := windows.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(h), uintptr(unsafe.Pointer(mem)), uintptr(unsafe.Sizeof(*mem)))
+	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(h), uintptr(unsafe.Pointer(mem)), uintptr(unsafe.Sizeof(*mem)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -16,6 +15,7 @@ import (
 	cpu "github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	net "github.com/shirou/gopsutil/net"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	modpsapi                 = syscall.NewLazyDLL("psapi.dll")
+	modpsapi                 = windows.NewLazyDLL("psapi.dll")
 	procGetProcessMemoryInfo = modpsapi.NewProc("GetProcessMemoryInfo")
 )
 
@@ -298,7 +298,7 @@ func NewProcess(pid int32) (*Process, error) {
 	return p, nil
 }
 
-func (p *Process) SendSignal(sig syscall.Signal) error {
+func (p *Process) SendSignal(sig windows.Signal) error {
 	return common.ErrNotImplementedError
 }
 
@@ -316,7 +316,7 @@ func (p *Process) Terminate() error {
 	w32.CloseHandle(proc)
 
 	if ret == false {
-		return syscall.GetLastError()
+		return windows.GetLastError()
 	} else {
 		return nil
 	}
@@ -329,23 +329,23 @@ func (p *Process) Kill() error {
 func (p *Process) getFromSnapProcess(pid int32) (int32, int32, string, error) {
 	snap := w32.CreateToolhelp32Snapshot(w32.TH32CS_SNAPPROCESS, uint32(pid))
 	if snap == 0 {
-		return 0, 0, "", syscall.GetLastError()
+		return 0, 0, "", windows.GetLastError()
 	}
 	defer w32.CloseHandle(snap)
 	var pe32 w32.PROCESSENTRY32
 	pe32.DwSize = uint32(unsafe.Sizeof(pe32))
 	if w32.Process32First(snap, &pe32) == false {
-		return 0, 0, "", syscall.GetLastError()
+		return 0, 0, "", windows.GetLastError()
 	}
 
 	if pe32.Th32ProcessID == uint32(pid) {
-		szexe := syscall.UTF16ToString(pe32.SzExeFile[:])
+		szexe := windows.UTF16ToString(pe32.SzExeFile[:])
 		return int32(pe32.Th32ParentProcessID), int32(pe32.CntThreads), szexe, nil
 	}
 
 	for w32.Process32Next(snap, &pe32) {
 		if pe32.Th32ProcessID == uint32(pid) {
-			szexe := syscall.UTF16ToString(pe32.SzExeFile[:])
+			szexe := windows.UTF16ToString(pe32.SzExeFile[:])
 			return int32(pe32.Th32ParentProcessID), int32(pe32.CntThreads), szexe, nil
 		}
 	}
@@ -388,22 +388,22 @@ func getProcInfo(pid int32) (*SystemProcessInformation, error) {
 		uintptr(unsafe.Pointer(&bufferSize)),
 		uintptr(unsafe.Pointer(&bufferSize)))
 	if ret != 0 {
-		return nil, syscall.GetLastError()
+		return nil, windows.GetLastError()
 	}
 
 	return &sysProcInfo, nil
 }
 
-func getRusage(pid int32) (*syscall.Rusage, error) {
-	var CPU syscall.Rusage
+func getRusage(pid int32) (*windows.Rusage, error) {
+	var CPU windows.Rusage
 
-	c, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(pid))
+	c, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return nil, err
 	}
-	defer syscall.CloseHandle(c)
+	defer windows.CloseHandle(c)
 
-	if err := syscall.GetProcessTimes(c, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime); err != nil {
+	if err := windows.GetProcessTimes(c, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime); err != nil {
 		return nil, err
 	}
 
@@ -412,11 +412,11 @@ func getRusage(pid int32) (*syscall.Rusage, error) {
 
 func getMemoryInfo(pid int32) (PROCESS_MEMORY_COUNTERS, error) {
 	var mem PROCESS_MEMORY_COUNTERS
-	c, err := syscall.OpenProcess(syscall.PROCESS_QUERY_INFORMATION, false, uint32(pid))
+	c, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return mem, err
 	}
-	defer syscall.CloseHandle(c)
+	defer windows.CloseHandle(c)
 	if err := getProcessMemoryInfo(c, &mem); err != nil {
 		return mem, err
 	}
@@ -424,13 +424,13 @@ func getMemoryInfo(pid int32) (PROCESS_MEMORY_COUNTERS, error) {
 	return mem, err
 }
 
-func getProcessMemoryInfo(h syscall.Handle, mem *PROCESS_MEMORY_COUNTERS) (err error) {
-	r1, _, e1 := syscall.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(h), uintptr(unsafe.Pointer(mem)), uintptr(unsafe.Sizeof(*mem)))
+func getProcessMemoryInfo(h windows.Handle, mem *PROCESS_MEMORY_COUNTERS) (err error) {
+	r1, _, e1 := windows.Syscall(procGetProcessMemoryInfo.Addr(), 3, uintptr(h), uintptr(unsafe.Pointer(mem)), uintptr(unsafe.Sizeof(*mem)))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)
 		} else {
-			err = syscall.EINVAL
+			err = windows.EINVAL
 		}
 	}
 	return

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -6,15 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"syscall"
 	"time"
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-	"github.com/shirou/w32"
-
 	cpu "github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	net "github.com/shirou/gopsutil/net"
+	"github.com/shirou/w32"
 	"golang.org/x/sys/windows"
 )
 
@@ -430,7 +430,7 @@ func getProcessMemoryInfo(h windows.Handle, mem *PROCESS_MEMORY_COUNTERS) (err e
 		if e1 != 0 {
 			err = error(e1)
 		} else {
-			err = windows.EINVAL
+			err = syscall.EINVAL
 		}
 	}
 	return


### PR DESCRIPTION
This is a very mechanical change: `syscall.` -> `unix.` or `windows.`

Assuming this passes compile time checks, this should be g2g.