### PR TITLE
[windows] add implementation for process.Username()

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -197,8 +197,8 @@ func (p *Process) Username() (string, error) {
 	defer token.Close()
 	tokenUser, err := token.GetTokenUser()
 
-	user, _, _, err := tokenUser.User.Sid.LookupAccount("")
-	return user, err
+	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
+	return domain + "\\" + user, err
 }
 
 func (p *Process) Uids() ([]int32, error) {


### PR DESCRIPTION
(Windows) Added implementation of Username()
Changed the calls to OpenProcess() to use  PROCESS_QUERY_LIMITED_INFORMATION rather than  PROCESS_QUERY_INFORMATION, as it's more likely to be authorized.