### PR TITLE
Fix process.Exe() on macOS 10.12

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -99,8 +99,8 @@ func (p *Process) Exe() (string, error) {
 		return "", err
 	}
 
-	lsof := exec.Command(lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fn")
-	awk := exec.Command(awk_bin, "NR==3{print}")
+	lsof := exec.Command(lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
+	awk := exec.Command(awk_bin, "NR==5{print}")
 	sed := exec.Command(sed_bin, "s/n\\//\\//")
 
 	output, _, err := common.Pipeline(lsof, awk, sed)


### PR DESCRIPTION
The `lsof` command on macOS < 10.12 always selects the `p` field
when using the `-F` option. On macOS 10.12 the `f` field is also
always selected causing an incorrect result. This modification adds
both options which are always selected to maintain consistency.