### PR TITLE
set win cpu total name to "cpu-total"

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -69,6 +69,7 @@ func Times(percpu bool) ([]TimesStat, error) {
 	system := (kernel - idle)
 
 	ret = append(ret, TimesStat{
+		CPU:    "cpu-total",
 		Idle:   float64(idle),
 		User:   float64(user),
 		System: float64(system),


### PR DESCRIPTION
set the name of windows cpu total percent to "cpu-total"
keep the same with Linux, Freebsd system