### PR TITLE
disk: Remove -mmacosx-version-min from darwin+cgo

### DIFF
--- a/disk/disk_darwin_cgo.go
+++ b/disk/disk_darwin_cgo.go
@@ -4,8 +4,7 @@
 package disk
 
 /*
-#cgo CFLAGS: -mmacosx-version-min=10.10 -DMACOSX_DEPLOYMENT_TARGET=10.10
-#cgo LDFLAGS: -mmacosx-version-min=10.10 -lobjc -framework Foundation -framework IOKit
+#cgo LDFLAGS: -lobjc -framework Foundation -framework IOKit
 #include <stdint.h>
 
 // ### enough?


### PR DESCRIPTION
The presence of the -mmacosx-version-min flag in `disk_darwin_cgo.go` makes it impossible to build the other cgo components - specifically the CPU statistics - on modern Mac OS X (10.12), since the object files with which they must link are not 10.10 compatible.

Errors present from Go Tip (1.9, effectively) in the form:

`ld: warning: object file (whatever.o) was built for newer OSX version (10.12) than being linked (10.10)`

This commit removes the minimum version flag, instead targeting the version of OS X on which a binary is compiled as the minimum. Without this, I believe (though have not verified it actually works) that the only way to build without without warnings/undefined behaviour if the OS X 10.10 headers and objects are installed and configured correctly.

I am not entirely sure of the change between Go 1.8.3 and the nascent 1.9 builds which exposed this - I assume some of the settings passed to `ld` have changed.