### PR TITLE
Just look at filenames for linux NumFDs call

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -219,7 +219,7 @@ func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
 
 // NumFDs returns the number of File Descriptors used by the process.
 func (p *Process) NumFDs() (int32, error) {
-	numFds, _, err := p.fillFromfd()
+	numFds, _, err := p.fillFromfdList()
 	return numFds, err
 }
 
@@ -514,16 +514,25 @@ func (p *Process) fillFromLimits() ([]RlimitStat, error) {
 	return limitStats, nil
 }
 
-// Get num_fds from /proc/(pid)/fd
-func (p *Process) fillFromfd() (int32, []*OpenFilesStat, error) {
+// Get list of /proc/(pid)/fd files
+func (p *Process) fillFromfdList() (string, []string, error) {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "fd")
 	d, err := os.Open(statPath)
 	if err != nil {
-		return 0, nil, err
+		return statPath, []string{}, err
 	}
 	defer d.Close()
 	fnames, err := d.Readdirnames(-1)
+	return statPath, fnames, err
+}
+
+// Get num_fds from /proc/(pid)/fd
+func (p *Process) fillFromfd() (int32, []*OpenFilesStat, error) {
+	statPath, fnames, err := p.fillFromfdList()
+	if err != nil {
+		return 0, nil, err
+	}
 	numFDs := int32(len(fnames))
 
 	var openfiles []*OpenFilesStat


### PR DESCRIPTION
Speed up `NumFDs` on Linux by just using a list of fd filenames and finding the length vs reading every file contents when we don't need it.