### PR TITLE
Update README / required go version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ see http://godoc.org/github.com/shirou/gopsutil
 Requirements
 -----------------
 
-- go1.5 or above is required.
+- go1.7 or above is required.
 
 
 More Info


### PR DESCRIPTION
Adding the `context` package import in 3834908232bba96806f9c9e9a07403c55c813ba4 bumps the required go version to 1.7.