### PR TITLE
Fix NaN percentage if process was created too soon

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -214,6 +214,9 @@ func (p *Process) CPUPercent() (float64, error) {
 
         created := time.Unix(0, crt_time * int64(time.Millisecond))
         totalTime := time.Since(created).Seconds()
+        if totalTime <= 0 {
+                return 0, nil
+        }
 
         return 100 * cput.Total() / totalTime, nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -215,5 +215,5 @@ func (p *Process) CPUPercent() (float64, error) {
         created := time.Unix(0, crt_time * int64(time.Millisecond))
         totalTime := time.Since(created).Seconds()
 
-        return (100 * (cput.Total() / totalTime)), nil
+        return 100 * cput.Total() / totalTime, nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -207,12 +207,13 @@ func (p *Process) CPUPercent() (float64, error) {
         }
 
 
-        cpu, err := p.Times()
+        cput, err := p.Times()
         if err != nil {
                 return 0, err
         }
 
+        created := time.Unix(0, crt_time * int64(time.Millisecond))
+        totalTime := time.Since(created).Seconds()
 
-        return (100 * (cpu.Total()) / float64(time.Now().Unix()-(crt_time/1000))), nil
+        return (100 * (cput.Total() / totalTime)), nil
 }
-


### PR DESCRIPTION
If the process was created within the second or so of a `process.CPUPercent()` call, it would return `NaN`: the crt_time calculation is made with second-precision so it causes a division-by-zero, but since we are in the float64 space, the result is `NaN`.