### PR TITLE
Ignore errors with single inode when getting all proc inodes

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -541,7 +541,7 @@ func getProcInodesAll(root string, max int) (map[string][]inodeMap, error) {
 	for _, pid := range pids {
 		t, err := getProcInodes(root, pid, max)
 		if err != nil {
-			return ret, err
+			continue
 		}
 		if len(t) == 0 {
 			continue


### PR DESCRIPTION
To fix this issue I think we should just ignore any error reading the fd.  I considered ignoring only permission errors but I think due to race conditions with processes we should ignore all errors.

fixes #433