### PR TITLE
Add HOST_VAR envvar and use to locate utmp on Linux.

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -132,7 +132,7 @@ func Uptime() (uint64, error) {
 }
 
 func Users() ([]UserStat, error) {
-	utmpfile := "/var/run/utmp"
+	utmpfile := common.HostVar("run/utmp")
 
 	file, err := os.Open(utmpfile)
 	if err != nil {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -316,6 +316,10 @@ func HostEtc(combineWith ...string) string {
 	return GetEnv("HOST_ETC", "/etc", combineWith...)
 }
 
+func HostVar(combineWith ...string) string {
+	return GetEnv("HOST_VAR", "/var", combineWith...)
+}
+
 // https://gist.github.com/kylelemons/1525278
 func Pipeline(cmds ...*exec.Cmd) ([]byte, []byte, error) {
 	// Require at least one command


### PR DESCRIPTION
Add `HOST_VAR` envvar and use to locate utmp on Linux.  

As discussed in https://github.com/influxdata/telegraf/issues/3339