### PR TITLE
make process.processes function public

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -390,8 +390,8 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 	return &ret, common.ErrNotImplementedError
 }
 
-func processes() ([]Process, error) {
-	results := make([]Process, 0, 50)
+func Processes() ([]*Process, error) {
+	results := make([]*Process)
 
 	mib := []int32{CTLKern, KernProc, KernProcAll, 0}
 	buf, length, err := common.CallSyscall(mib)
@@ -403,13 +403,6 @@ func processes() ([]Process, error) {
 	k := KinfoProc{}
 	procinfoLen := int(unsafe.Sizeof(k))
 	count := int(length / uint64(procinfoLen))
-	/*
-		fmt.Println(length, procinfoLen, count)
-		b := buf[0*procinfoLen : 0*procinfoLen+procinfoLen]
-		fmt.Println(b)
-		kk, err := parseKinfoProc(b)
-		fmt.Printf("%#v", kk)
-	*/
 
 	// parse buf to procs
 	for i := 0; i < count; i++ {
@@ -422,7 +415,7 @@ func processes() ([]Process, error) {
 		if err != nil {
 			continue
 		}
-		results = append(results, *p)
+		results = append(results, p)
 	}
 
 	return results, nil

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -391,7 +391,7 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 }
 
 func Processes() ([]*Process, error) {
-	results := make([]*Process)
+	results := []*Process{}
 
 	mib := []int32{CTLKern, KernProc, KernProcAll, 0}
 	buf, length, err := common.CallSyscall(mib)

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -279,7 +279,7 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 }
 
 func Processes() ([]*Process, error) {
-	results := make([]*Process)
+	results := []*Process{}
 
 	mib := []int32{CTLKern, KernProc, KernProcProc, 0}
 	buf, length, err := common.CallSyscall(mib)

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -22,7 +22,7 @@ type MemoryMapsStat struct {
 
 func Pids() ([]int32, error) {
 	var ret []int32
-	procs, err := processes()
+	procs, err := Processes()
 	if err != nil {
 		return ret, nil
 	}
@@ -278,8 +278,8 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 	return &ret, common.ErrNotImplementedError
 }
 
-func processes() ([]Process, error) {
-	results := make([]Process, 0, 50)
+func Processes() ([]*Process, error) {
+	results := make([]*Process)
 
 	mib := []int32{CTLKern, KernProc, KernProcProc, 0}
 	buf, length, err := common.CallSyscall(mib)
@@ -302,7 +302,7 @@ func processes() ([]Process, error) {
 			continue
 		}
 
-		results = append(results, *p)
+		results = append(results, p)
 	}
 
 	return results, nil

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1017,6 +1017,27 @@ func Pids() ([]int32, error) {
 	return readPidsFromDir(common.HostProc())
 }
 
+// Process returns a slice of pointers to Process structs for all
+// currently running processes.
+func Processes() ([]*Process, error) {
+	out := []*Process{}
+
+	pids, err := Pids()
+	if err != nil {
+		return out, err
+	}
+
+	for _, pid := range pids {
+		p, err := NewProcess(pid)
+		if err != nil {
+			continue
+		}
+		out = append(out, p)
+	}
+
+	return out, nil
+}
+
 func readPidsFromDir(path string) ([]int32, error) {
 	var ret []int32
 

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -25,7 +25,7 @@ type MemoryMapsStat struct {
 
 func Pids() ([]int32, error) {
 	var ret []int32
-	procs, err := processes()
+	procs, err := Processes()
 	if err != nil {
 		return ret, nil
 	}
@@ -268,8 +268,8 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 	return &ret, common.ErrNotImplementedError
 }
 
-func processes() ([]Process, error) {
-	results := make([]Process, 0, 50)
+func Processes() ([]*Process, error) {
+	results := make([]*Process)
 
 	buf, length, err := CallKernProcSyscall(KernProcAll, 0)
 
@@ -292,7 +292,7 @@ func processes() ([]Process, error) {
 			continue
 		}
 
-		results = append(results, *p)
+		results = append(results, p)
 	}
 
 	return results, nil

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -269,7 +269,7 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 }
 
 func Processes() ([]*Process, error) {
-	results := make([]*Process)
+	results := []*Process{}
 
 	buf, length, err := CallKernProcSyscall(KernProcAll, 0)
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -95,7 +95,7 @@ func init() {
 func Pids() ([]int32, error) {
 	var ret []int32
 
-	procs, err := processes()
+	procs, err := Processes()
 	if err != nil {
 		return ret, nil
 	}
@@ -292,11 +292,11 @@ func (p *Process) Times() (*cpu.TimesStat, error) {
 	// below from psutil's _psutil_windows.c, and in turn from Python's
 	// Modules/posixmodule.c
 
-	user := float64(sysTimes.UserTime.HighDateTime) * 429.4967296 + float64(sysTimes.UserTime.LowDateTime) * 1e-7
-	kernel := float64(sysTimes.KernelTime.HighDateTime) * 429.4967296 + float64(sysTimes.KernelTime.LowDateTime) * 1e-7
+	user := float64(sysTimes.UserTime.HighDateTime)*429.4967296 + float64(sysTimes.UserTime.LowDateTime)*1e-7
+	kernel := float64(sysTimes.KernelTime.HighDateTime)*429.4967296 + float64(sysTimes.KernelTime.LowDateTime)*1e-7
 
 	return &cpu.TimesStat{
-		User: user,
+		User:   user,
 		System: kernel,
 	}, nil
 }
@@ -422,7 +422,7 @@ func (p *Process) getFromSnapProcess(pid int32) (int32, int32, string, error) {
 }
 
 // Get processes
-func processes() ([]*Process, error) {
+func Processes() ([]*Process, error) {
 	var dst []Win32_Process
 	q := wmi.CreateQuery(&dst, "")
 	err := wmi.Query(q, &dst)
@@ -508,9 +508,9 @@ func getProcessMemoryInfo(h windows.Handle, mem *PROCESS_MEMORY_COUNTERS) (err e
 
 type SYSTEM_TIMES struct {
 	CreateTime syscall.Filetime
-	ExitTime syscall.Filetime
+	ExitTime   syscall.Filetime
 	KernelTime syscall.Filetime
-	UserTime syscall.Filetime
+	UserTime   syscall.Filetime
 }
 
 func getProcessCPUTimes(pid int32) (SYSTEM_TIMES, error) {


### PR DESCRIPTION
We currently provide a 'list all pids' function which provides this
(or related) functionality, so if you wanted to collect data on all
running processes, we would end up doing redundant work, when we could
make the function public. 

I also ironed out a few cross-platform inconsistencies.