### PR TITLE
Fix IOCounters for OpenBSD

### DIFF
--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -66,7 +66,7 @@ func Partitions(all bool) ([]PartitionStat, error) {
 func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	ret := make(map[string]IOCountersStat)
 
-	r, err := unix.Sysctl("hw.diskstats")
+	r, err := unix.SysctlRaw("hw.diskstats")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use SysctlRaw instead of Sysctl.
The latter assumes NUL terminated strings
which returns the lenght off by one.
Therefore, only n-1 disks where reported.