### PR TITLE
Use getFromSnapProcess to get process Name and Ppid on Windows instead of slow WMI

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -119,12 +119,11 @@ func Pids() ([]int32, error) {
 }
 
 func (p *Process) Ppid() (int32, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	ppid, _, _, err := getFromSnapProcess(p.Pid)
 	if err != nil {
 		return 0, err
 	}
-
-	return int32(dst[0].ParentProcessID), nil
+	return ppid, nil
 }
 
 func GetWin32Proc(pid int32) ([]Win32_Process, error) {
@@ -144,11 +143,11 @@ func GetWin32Proc(pid int32) ([]Win32_Process, error) {
 }
 
 func (p *Process) Name() (string, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	_, _, name, err := getFromSnapProcess(p.Pid)
 	if err != nil {
 		return "", fmt.Errorf("could not get Name: %s", err)
 	}
-	return dst[0].Name, nil
+	return name, nil
 }
 
 func (p *Process) Exe() (string, error) {
@@ -406,7 +405,7 @@ func (p *Process) Kill() error {
 	return common.ErrNotImplementedError
 }
 
-func (p *Process) getFromSnapProcess(pid int32) (int32, int32, string, error) {
+func getFromSnapProcess(pid int32) (int32, int32, string, error) {
 	snap := w32.CreateToolhelp32Snapshot(w32.TH32CS_SNAPPROCESS, uint32(pid))
 	if snap == 0 {
 		return 0, 0, "", windows.GetLastError()


### PR DESCRIPTION
This is tested functional and way faster than WMI calls. According to git blame this cancels part of d522bf5b7e830fde3915e549989848e956a11bc7 and puts back a refined version of cf4ec6b0fa3667ca4a671a4c0369e2df451fda9d (I compared the results of `wmic process list` and they are the same process Names as this PR, the previous implementation was mislabeling them as Exe()).

Getting the process.Children() this way by looping over every processes and checking their ppid as [here](https://github.com/shirou/gopsutil/commit/d522bf5b7e830fde3915e549989848e956a11bc7#diff-368208843093ee1f90101ba2c46de503R280) is slower than the current single WMI call, hence not replaced in this commit.

Implementing Exe() would require calling [GetProcessImageFileNameW](https://msdn.microsoft.com/fr-fr/library/windows/desktop/ms683217(v=vs.85).aspx), but I'm currently unable to retrieve its result with the error `The data area passed to a system call is too small`. I'm still investigating.

Generally speaking, the rationale should be to prefer the fastest method, be it using psapi.dll syscalls or wmi.