### PR TITLE
[net] linux: skip if not exist error on getProcInodesAll

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -541,8 +541,8 @@ func getProcInodesAll(root string, max int) (map[string][]inodeMap, error) {
 	for _, pid := range pids {
 		t, err := getProcInodes(root, pid, max)
 		if err != nil {
-			// skip if permission error
-			if os.IsPermission(err) {
+			// skip if permission error or no longer exists
+			if os.IsPermission(err) || os.IsNotExist(err) {
 				continue
 			}
 			return ret, err


### PR DESCRIPTION
In https://github.com/shirou/gopsutil/commit/e01a14e318951de4782908fbdb2b66a652a22065 we added skipping of permission errors, but I am getting reports of errors like the following:
```
cound not get pid(s), 0: open /rootfs/proc/32665/fd: no such file or directory
```

I think this is caused by `Pids()` returning a pid which exits before `getProcInodes()` can process it.