### PR TITLE
add the ability to query for windows processes by Name and by cmdline

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -145,6 +145,32 @@ func GetWin32Proc(pid int32) ([]Win32_Process, error) {
 	return dst, nil
 }
 
+func GetWin32ProcsByCmdLine(cmdLine string) ([]Win32_Process, error) {
+	var dst []Win32_Process
+	query := fmt.Sprint("WHERE CommandLine LIKE \"%", cmdLine, "%\"")
+	q := wmi.CreateQuery(&dst, query)
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+	err := common.WMIQueryWithContext(ctx, q, &dst)
+	if err != nil {
+		return []Win32_Process{}, fmt.Errorf("could not get win32Proc: %s", err)
+	}
+	return dst, nil
+}
+
+func GetWin32ProcsByName(name string) ([]Win32_Process, error) {
+	var dst []Win32_Process
+	query := fmt.Sprint("WHERE Name LIKE \"%", name, "%\"")
+	q := wmi.CreateQuery(&dst, query)
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+	err := common.WMIQueryWithContext(ctx, q, &dst)
+	if err != nil {
+		return []Win32_Process{}, fmt.Errorf("could not get win32Proc: %s", err)
+	}
+	return dst, nil
+}
+
 func (p *Process) Name() (string, error) {
 	_, _, name, err := getFromSnapProcess(p.Pid)
 	if err != nil {

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -145,9 +145,9 @@ func GetWin32Proc(pid int32) ([]Win32_Process, error) {
 	return dst, nil
 }
 
-func GetWin32ProcsByCmdLine(cmdLine string) ([]Win32_Process, error) {
+func GetWin32ProcsByCmdLine(cmdLinePattern string) ([]Win32_Process, error) {
 	var dst []Win32_Process
-	query := fmt.Sprint("WHERE CommandLine LIKE \"%", cmdLine, "%\"")
+	query := fmt.Sprint("WHERE CommandLine LIKE \"", cmdLinePattern, "\"")
 	q := wmi.CreateQuery(&dst, query)
 	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
 	defer cancel()
@@ -158,9 +158,9 @@ func GetWin32ProcsByCmdLine(cmdLine string) ([]Win32_Process, error) {
 	return dst, nil
 }
 
-func GetWin32ProcsByName(name string) ([]Win32_Process, error) {
+func GetWin32ProcsByName(namePattern string) ([]Win32_Process, error) {
 	var dst []Win32_Process
-	query := fmt.Sprint("WHERE Name LIKE \"%", name, "%\"")
+	query := fmt.Sprint("WHERE Name LIKE \"", namePattern, "\"")
 	q := wmi.CreateQuery(&dst, query)
 	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
 	defer cancel()


### PR DESCRIPTION
I need the ability to query for processes on windows through WMI by command or by process name. getting all Processes and then filtering takes over 6 seconds on my i7 7700k 32gb system. When I change it to filter through the WMI query I get the processes back in 0.04s. 