### PR TITLE
[mem] Add commit-related stats to VirtualMemoryStat on Linux

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -58,6 +58,8 @@ type VirtualMemoryStat struct {
 	Slab         uint64 `json:"slab"`
 	PageTables   uint64 `json:"pagetables"`
 	SwapCached   uint64 `json:"swapcached"`
+	CommitLimit  uint64 `json:"commitlimit"`
+	CommittedAS  uint64 `json:"committedas"`
 }
 
 type SwapMemoryStat struct {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -60,6 +60,10 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 			ret.PageTables = t * 1024
 		case "SwapCached":
 			ret.SwapCached = t * 1024
+		case "CommitLimit":
+			ret.CommitLimit = t * 1024
+		case "Committed_AS":
+			ret.CommittedAS = t * 1024
 		}
 	}
 	if !memavail {

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -57,7 +57,7 @@ func TestVirtualMemoryStat_String(t *testing.T) {
 		UsedPercent: 30.1,
 		Free:        40,
 	}
-	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"pagetables":0,"swapcached":0}`
+	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"pagetables":0,"swapcached":0,"commitlimit":0,"committedas":0}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("VirtualMemoryStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
Adds 2 memory statistics: `CommitLimit` and `CommittedAs`

### Motivation

Highlighting the docs at https://www.kernel.org/doc/Documentation/filesystems/proc.txt:

> CommitLimit: Based on the overcommit ratio ('vm.overcommit_ratio'), this is the total amount of  memory currently available to be allocated on the system.

> Committed_AS: The amount of memory presently allocated on the system. [...] This is useful if one needs to guarantee that processes will not fail due to lack of memory once that memory has been successfully allocated.
