### PR TITLE
[disk]linux: use basename such as sda1 for IOCounters

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -5,6 +5,7 @@ package disk
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -279,6 +280,11 @@ func IOCounters(names ...string) (map[string]IOCountersStat, error) {
 	}
 	ret := make(map[string]IOCountersStat, 0)
 	empty := IOCountersStat{}
+
+	// use only basename such as "/dev/sda1" to "sda1"
+	for i, name := range names {
+		names[i] = filepath.Base(name)
+	}
 
 	for _, line := range lines {
 		fields := strings.Fields(line)

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -25,6 +25,8 @@ func TestDisk_partitions(t *testing.T) {
 	if err != nil || len(ret) == 0 {
 		t.Errorf("error %v", err)
 	}
+	t.Log(ret)
+
 	empty := PartitionStat{}
 	if len(ret) == 0 {
 		t.Errorf("ret is empty")
@@ -46,6 +48,7 @@ func TestDisk_io_counters(t *testing.T) {
 	}
 	empty := IOCountersStat{}
 	for part, io := range ret {
+		t.Log(part, io)
 		if io == empty {
 			t.Errorf("io_counter error %v, %v", part, io)
 		}


### PR DESCRIPTION
use Basename for accept both "/dev/sda1" and "sda1" for `disk.IOCounters()`

This fixes #479 