### PR TITLE
[host] fix race condition to ret

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -132,6 +132,10 @@ func PerfInfoWithContext(ctx context.Context) ([]Win32_PerfFormattedData_Counter
 	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
 	defer cancel()
 	err := common.WMIQueryWithContext(ctx, q, &ret)
+	if err != nil {
+		return Win32_PerfFormattedData_Counters_ProcessorInformation{}, err
+	}
+
 	return ret, err
 }
 
@@ -147,6 +151,9 @@ func ProcInfoWithContext(ctx context.Context) ([]Win32_PerfFormattedData_PerfOS_
 	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
 	defer cancel()
 	err := common.WMIQueryWithContext(ctx, q, &ret)
+	if err != nil {
+		return Win32_PerfFormattedData_PerfOS_System{}, err
+	}
 	return ret, err
 }
 


### PR DESCRIPTION
Because a go routine is spawned when calling [this](https://github.com/shirou/gopsutil/blob/master/internal/common/common_windows.go#L119-L121):
```common.WMIQueryWithContext(ctx, q, &ret)```


You may actually get an error return [see here](https://github.com/shirou/gopsutil/blob/master/internal/common/common_windows.go#L123-L128), returning from the caller before the go routine has guaranteed completion; this triggers a race condition to read and write from `ret` in the return expression and in the actual StackExchange `wmi` module.

Addressed in the same manner here in the [host subpackage](https://github.com/shirou/gopsutil/blob/master/host/host_windows.go#L123-L126) 