### PR TITLE
Eliminate call to uname on FreeBSD

### DIFF
--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -168,25 +167,17 @@ func PlatformInformation() (string, string, string, error) {
 }
 
 func PlatformInformationWithContext(ctx context.Context) (string, string, string, error) {
-	platform := ""
-	family := ""
-	version := ""
-	uname, err := exec.LookPath("uname")
+	platform, err := unix.Sysctl("kern.ostype")
 	if err != nil {
 		return "", "", "", err
 	}
 
-	out, err := invoke.Command(uname, "-s")
-	if err == nil {
-		platform = strings.ToLower(strings.TrimSpace(string(out)))
+	version, err := unix.Sysctl("kern.osrelease")
+	if err != nil {
+		return "", "", "", err
 	}
 
-	out, err = invoke.Command(uname, "-r")
-	if err == nil {
-		version = strings.ToLower(strings.TrimSpace(string(out)))
-	}
-
-	return platform, family, version, nil
+	return strings.ToLower(platform), "", strings.ToLower(version), nil
 }
 
 func Virtualization() (string, string, error) {

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -148,3 +148,15 @@ func TestKernelVersion(t *testing.T) {
 
 	t.Logf("KernelVersion(): %s", version)
 }
+
+func TestPlatformInformation(t *testing.T) {
+	platform, family, version, err := PlatformInformation()
+	if err != nil {
+		t.Errorf("PlatformInformation() failed, %v", err)
+	}
+	if platform == "" {
+		t.Errorf("PlatformInformation() retuns empty: %v", platform)
+	}
+
+	t.Logf("PlatformInformation(): %v, %v, %v", platform, family, version)
+}


### PR DESCRIPTION
Improve performance by eliminating the fork out to uname on FreeBSD which also helps prevent crashes / hangs due to the outstanding fork crash bug:
golang/go#15658

Also added a test for PlatformInformation.