### PR TITLE
Use static initialisation for invoke instances, instead of init funcs

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -54,10 +54,9 @@ type lastPercent struct {
 }
 
 var lastCPUPercent lastPercent
-var invoke common.Invoker
+var invoke common.Invoker = common.Invoke{}
 
 func init() {
-	invoke = common.Invoke{}
 	lastCPUPercent.Lock()
 	lastCPUPercent.lastCPUTimes, _ = Times(false)
 	lastCPUPercent.lastPerCPUTimes, _ = Times(true)

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -6,11 +6,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 type UsageStat struct {
 	Path              string  `json:"path"`

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -10,11 +10,7 @@ import (
 var ErrDockerNotAvailable = errors.New("docker not available")
 var ErrCgroupNotAvailable = errors.New("cgroup not available")
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 type CgroupMemStat struct {
 	ContainerID             string `json:"containerID"`

--- a/host/host.go
+++ b/host/host.go
@@ -6,11 +6,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 // A HostInfoStat describes the host status.
 // This is not in the psutil but it useful.

--- a/load/load.go
+++ b/load/load.go
@@ -6,11 +6,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 type AvgStat struct {
 	Load1  float64 `json:"load1"`

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -6,11 +6,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 // Memory usage statistics. Total, Available and Used contain numbers of bytes
 // for human consumption.

--- a/net/net.go
+++ b/net/net.go
@@ -12,11 +12,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 type IOCountersStat struct {
 	Name        string `json:"name"`        // interface name

--- a/process/process.go
+++ b/process/process.go
@@ -11,11 +11,7 @@ import (
 	"github.com/shirou/gopsutil/mem"
 )
 
-var invoke common.Invoker
-
-func init() {
-	invoke = common.Invoke{}
-}
+var invoke common.Invoker = common.Invoke{}
 
 type Process struct {
 	Pid            int32 `json:"pid"`


### PR DESCRIPTION
The order of init function execution is dependant on the order that the
source files are passed to the compiler. This causes issues when
building under other build systems, such as bazel or buck, as they are
not guarenteed to maintain the same file order as the default go tool.

This is required because other init functions in other files were referring
to this invoke variable, which caused null pointer errors when the init
functions were invoked in a different order.