### PR TITLE
Always calculate linux used mem as total-(free+buffered+cache)

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -70,8 +70,8 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	if !memavail {
 		ret.Available = ret.Free + ret.Buffers + ret.Cached
 	}
-	ret.Used = ret.Total - ret.Available
-	ret.UsedPercent = float64(ret.Total-ret.Available) / float64(ret.Total) * 100.0
+	ret.Used = ret.Total - ret.Free - ret.Buffers - ret.Cached
+	ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
 
 	return ret, nil
 }


### PR DESCRIPTION
Used memory was calculated as Total - Available.
For newer kernels (3.14+), available memory is taken from /proc/meminfo,
whereas for older kernels it is computed as free+buffered+cached.

This commit changes that behavior. Available memory is still taken from
/proc/meminfo, if available, but used memory is always computed as
total-free-buffered-cached.

This way, it matches the output of `free` for used memory (in the -/+
buffers/cache line) and other tools.

Prior to this change, I'd see a reported used memory of 600MiB whereas
free, htop and other tools would report a used memory of 1.8GiB. And
adding used, cached, buffered and free memory would leave ~1.2GiB
unaccounted for.