### PR TITLE
change to use CommandContext.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,21 @@ check:  ## Check
 BUILD_FAIL_PATTERN=grep -v "exec format error" | grep "build failed" && exit 1 || exit 0
 build_test:  ## test only buildable
 	# Supported operating systems
-	GOOS=linux go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=amd64 go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=386 go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=arm go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=arm64 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd go test ./... | $(BUILD_FAIL_PATTERN)
-#	GOOS=openbsd go test ./... | $(BUILD_FAIL_PATTERN)
 	CGO_ENABLED=0 GOOS=darwin go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=windows go test ./... | $(BUILD_FAIL_PATTERN)
 	# Operating systems supported for building only (not implemented error if used)
 	GOOS=solaris go test ./... | $(BUILD_FAIL_PATTERN)
-#	GOOS=dragonfly go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=dragonfly go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=netbsd go test ./... | $(BUILD_FAIL_PATTERN)
+	# cross build to OpenBSD not worked since process has "C"
+#	GOOS=openbsd go test ./... | $(BUILD_FAIL_PATTERN)
+
+ifeq ($(shell uname -s), Darwin)
 	CGO_ENABLED=1 GOOS=darwin go test ./... | $(BUILD_FAIL_PATTERN)
+endif
 	@echo 'Successfully built on all known operating systems'

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -45,7 +45,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	if err != nil {
 		return ret, err
 	}
-	out, err := invoke.Command(sysctl, "machdep.cpu")
+	out, err := invoke.CommandWithContext(ctx, sysctl, "machdep.cpu")
 	if err != nil {
 		return ret, err
 	}
@@ -99,7 +99,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
-	out, err = invoke.Command(sysctl, "hw.cpufrequency")
+	out, err = invoke.CommandWithContext(ctx, sysctl, "hw.cpufrequency")
 	if err != nil {
 		return ret, err
 	}

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -20,7 +20,7 @@ func init() {
 	if err != nil {
 		return
 	}
-	out, err := invoke.Command(getconf, "CLK_TCK")
+	out, err := invoke.CommandWithContext(context.Background(), getconf, "CLK_TCK")
 	// ignore errors
 	if err == nil {
 		i, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -47,7 +47,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot find psrinfo: %s", err)
 	}
-	psrInfoOut, err := invoke.Command(psrInfo, "-p", "-v")
+	psrInfoOut, err := invoke.CommandWithContext(ctx, psrInfo, "-p", "-v")
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute psrinfo: %s", err)
 	}
@@ -56,7 +56,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot find isainfo: %s", err)
 	}
-	isaInfoOut, err := invoke.Command(isaInfo, "-b", "-v")
+	isaInfoOut, err := invoke.CommandWithContext(ctx, isaInfo, "-b", "-v")
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute isainfo: %s", err)
 	}

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -388,7 +388,7 @@ func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
 		return ""
 	}
 
-	out, err := invoke.Command(udevadm, "info", "--query=property", n)
+	out, err := invoke.CommandWithContext(ctx, udevadm, "info", "--query=property", n)
 
 	// does not return error, just an empty string
 	if err != nil {

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -27,7 +27,7 @@ func GetDockerStatWithContext(ctx context.Context) ([]CgroupDockerStat, error) {
 		return nil, ErrDockerNotAvailable
 	}
 
-	out, err := invoke.Command(path, "ps", "-a", "--no-trunc", "--format", "{{.ID}}|{{.Image}}|{{.Names}}|{{.Status}}")
+	out, err := invoke.CommandWithContext(ctx, path, "ps", "-a", "--no-trunc", "--format", "{{.ID}}|{{.Image}}|{{.Names}}|{{.Status}}")
 	if err != nil {
 		return []CgroupDockerStat{}, err
 	}
@@ -68,7 +68,7 @@ func GetDockerIDListWithContext(ctx context.Context) ([]string, error) {
 		return nil, ErrDockerNotAvailable
 	}
 
-	out, err := invoke.Command(path, "ps", "-q", "--no-trunc")
+	out, err := invoke.CommandWithContext(ctx, path, "ps", "-q", "--no-trunc")
 	if err != nil {
 		return []string{}, err
 	}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -40,7 +40,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 
 	uname, err := exec.LookPath("uname")
 	if err == nil {
-		out, err := invoke.Command(uname, "-r")
+		out, err := invoke.CommandWithContext(ctx, uname, "-r")
 		if err == nil {
 			ret.KernelVersion = strings.ToLower(strings.TrimSpace(string(out)))
 		}
@@ -70,7 +70,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 		ret.Procs = uint64(len(procs))
 	}
 
-	values, err := common.DoSysctrl("kern.uuid")
+	values, err := common.DoSysctrlWithContext(ctx, "kern.uuid")
 	if err == nil && len(values) == 1 && values[0] != "" {
 		ret.HostID = strings.ToLower(values[0])
 	}
@@ -90,7 +90,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	if t != 0 {
 		return t, nil
 	}
-	values, err := common.DoSysctrl("kern.boottime")
+	values, err := common.DoSysctrlWithContext(ctx, "kern.boottime")
 	if err != nil {
 		return 0, err
 	}
@@ -188,12 +188,12 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 		return "", "", "", err
 	}
 
-	out, err := invoke.Command(uname, "-s")
+	out, err := invoke.CommandWithContext(ctx, uname, "-s")
 	if err == nil {
 		platform = strings.ToLower(strings.TrimSpace(string(out)))
 	}
 
-	out, err = invoke.Command(sw_vers, "-productVersion")
+	out, err = invoke.CommandWithContext(ctx, sw_vers, "-productVersion")
 	if err == nil {
 		pver = strings.ToLower(strings.TrimSpace(string(out)))
 	}

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -113,12 +113,12 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 		return "", "", "", err
 	}
 
-	out, err := invoke.Command(uname, "-s")
+	out, err := invoke.CommandWithContext(ctx, uname, "-s")
 	if err == nil {
 		platform = strings.ToLower(strings.TrimSpace(string(out)))
 	}
 
-	out, err = invoke.Command(uname, "-r")
+	out, err = invoke.CommandWithContext(ctx, uname, "-r")
 	if err == nil {
 		version = strings.ToLower(strings.TrimSpace(string(out)))
 	}

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -38,7 +38,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 		return nil, err
 	}
 
-	out, err := invoke.Command(uname, "-srv")
+	out, err := invoke.CommandWithContext(ctx, uname, "-srv")
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 		// If everything works, use the current zone ID as the HostID if present.
 		zonename, err := exec.LookPath("/usr/bin/zonename")
 		if err == nil {
-			out, err := invoke.Command(zonename)
+			out, err := invoke.CommandWithContext(ctx, zonename)
 			if err == nil {
 				sc := bufio.NewScanner(bytes.NewReader(out))
 				for sc.Scan() {
@@ -114,7 +114,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 	if result.HostID == "" {
 		hostID, err := exec.LookPath("/usr/bin/hostid")
 		if err == nil {
-			out, err := invoke.Command(hostID)
+			out, err := invoke.CommandWithContext(ctx, hostID)
 			if err == nil {
 				sc := bufio.NewScanner(bytes.NewReader(out))
 				for sc.Scan() {
@@ -156,7 +156,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 
-	out, err := invoke.Command(kstat, "-p", "unix:0:system_misc:boot_time")
+	out, err := invoke.CommandWithContext(ctx, kstat, "-p", "unix:0:system_misc:boot_time")
 	if err != nil {
 		return 0, err
 	}
@@ -220,7 +220,7 @@ func KernelVersionWithContext(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	out, err := invoke.Command(uname, "-srv")
+	out, err := invoke.CommandWithContext(ctx, uname, "-srv")
 	if err != nil {
 		return "", err
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -32,15 +32,19 @@ var (
 
 type Invoker interface {
 	Command(string, ...string) ([]byte, error)
+	CommandWithContext(context.Context, string, ...string) ([]byte, error)
 }
 
 type Invoke struct{}
 
 func (i Invoke) Command(name string, arg ...string) ([]byte, error) {
-	ctxt, cancel := context.WithTimeout(context.Background(), Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 	defer cancel()
+	return i.CommandWithContext(ctx, name, arg...)
+}
 
-	cmd := exec.CommandContext(ctxt, name, arg...)
+func (i Invoke) CommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
@@ -82,6 +86,10 @@ func (i FakeInvoke) Command(name string, arg ...string) ([]byte, error) {
 		return ioutil.ReadFile(fpath)
 	}
 	return []byte{}, fmt.Errorf("could not find testdata: %s", fpath)
+}
+
+func (i FakeInvoke) CommandWithContext(ctx context.Context, name string, arg ...string) ([]byte, error) {
+	return i.Command(name, arg...)
 }
 
 var ErrNotImplementedError = errors.New("not implemented yet")

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -3,6 +3,7 @@
 package common
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
@@ -11,12 +12,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func DoSysctrl(mib string) ([]string, error) {
+func DoSysctrlWithContext(ctx context.Context, mib string) ([]string, error) {
 	sysctl, err := exec.LookPath("/usr/sbin/sysctl")
 	if err != nil {
 		return []string{}, err
 	}
-	cmd := exec.Command(sysctl, "-n", mib)
+	cmd := exec.CommandContext(ctx, sysctl, "-n", mib)
 	cmd.Env = getSysctrlEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -3,12 +3,13 @@
 package common
 
 import (
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
 )
 
-func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
+func CallLsofWithContext(ctx context.Context, invoke Invoker, pid int32, args ...string) ([]string, error) {
 	var cmd []string
 	if pid == 0 { // will get from all processes.
 		cmd = []string{"-a", "-n", "-P"}
@@ -20,7 +21,7 @@ func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-	out, err := invoke.Command(lsof, cmd...)
+	out, err := invoke.CommandWithContext(ctx, lsof, cmd...)
 	if err != nil {
 		// if no pid found, lsof returnes code 1.
 		if err.Error() == "exit status 1" && len(out) == 0 {
@@ -39,14 +40,14 @@ func CallLsof(invoke Invoker, pid int32, args ...string) ([]string, error) {
 	return ret, nil
 }
 
-func CallPgrep(invoke Invoker, pid int32) ([]int32, error) {
+func CallPgrepWithContext(ctx context.Context, invoke Invoker, pid int32) ([]int32, error) {
 	var cmd []string
 	cmd = []string{"-P", strconv.Itoa(int(pid))}
 	pgrep, err := exec.LookPath("pgrep")
 	if err != nil {
 		return []int32{}, err
 	}
-	out, err := invoke.Command(pgrep, cmd...)
+	out, err := invoke.CommandWithContext(ctx, pgrep, cmd...)
 	if err != nil {
 		return []int32{}, err
 	}

--- a/load/load_bsd.go
+++ b/load/load_bsd.go
@@ -49,7 +49,7 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := invoke.Command(bin, "axo", "state")
+	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/load/load_darwin.go
+++ b/load/load_darwin.go
@@ -16,7 +16,7 @@ func Avg() (*AvgStat, error) {
 }
 
 func AvgWithContext(ctx context.Context) (*AvgStat, error) {
-	values, err := common.DoSysctrl("vm.loadavg")
+	values, err := common.DoSysctrlWithContext(ctx, "vm.loadavg")
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := invoke.Command(bin, "axo", "state")
+	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -35,7 +35,7 @@ func SwapMemory() (*SwapMemoryStat, error) {
 func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 	var ret *SwapMemoryStat
 
-	swapUsage, err := common.DoSysctrl("vm.swapusage")
+	swapUsage, err := common.DoSysctrlWithContext(ctx, "vm.swapusage")
 	if err != nil {
 		return ret, err
 	}

--- a/mem/mem_openbsd.go
+++ b/mem/mem_openbsd.go
@@ -99,7 +99,7 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 		return nil, err
 	}
 
-	out, err := invoke.Command(swapctl, "-sk")
+	out, err := invoke.CommandWithContext(ctx, swapctl, "-sk")
 	if err != nil {
 		return &SwapMemoryStat{}, nil
 	}

--- a/mem/mem_solaris.go
+++ b/mem/mem_solaris.go
@@ -57,7 +57,8 @@ func zoneName() (string, error) {
 		return "", err
 	}
 
-	out, err := invoke.Command(zonename)
+	ctx := context.Background()
+	out, err := invoke.CommandWithContext(ctx, zonename)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +74,8 @@ func globalZoneMemoryCapacity() (uint64, error) {
 		return 0, err
 	}
 
-	out, err := invoke.Command(prtconf)
+	ctx := context.Background()
+	out, err := invoke.CommandWithContext(ctx, prtconf)
 	if err != nil {
 		return 0, err
 	}
@@ -99,7 +101,8 @@ func nonGlobalZoneMemoryCapacity() (uint64, error) {
 		return 0, err
 	}
 
-	out, err := invoke.Command(kstat, "-p", "-c", "zone_memory_cap", "memory_cap:*:*:physcap")
+	ctx := context.Background()
+	out, err := invoke.CommandWithContext(ctx, kstat, "-p", "-c", "zone_memory_cap", "memory_cap:*:*:physcap")
 	if err != nil {
 		return 0, err
 	}

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -180,7 +180,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 	}
 
 	// try to get all interface metrics, and hope there won't be any truncated
-	out, err := invoke.Command(netstat, "-ibdnW")
+	out, err := invoke.CommandWithContext(ctx, netstat, "-ibdnW")
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		if err != nil {
 			return nil, err
 		}
-		if out, err = invoke.Command(ifconfig, "-l"); err != nil {
+		if out, err = invoke.CommandWithContext(ctx, ifconfig, "-l"); err != nil {
 			return nil, err
 		}
 		interfaceNames := strings.Fields(strings.TrimRight(string(out), endOfLine))
@@ -227,7 +227,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			}
 			if truncated {
 				// run netstat with -I$ifacename
-				if out, err = invoke.Command(netstat, "-ibdnWI"+interfaceName); err != nil {
+				if out, err = invoke.CommandWithContext(ctx, netstat, "-ibdnWI"+interfaceName); err != nil {
 					return nil, err
 				}
 				parsedIfaces, err := parseNetstatOutput(string(out))

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -21,7 +21,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 	if err != nil {
 		return nil, err
 	}
-	out, err := invoke.Command(netstat, "-ibdnW")
+	out, err := invoke.CommandWithContext(ctx, netstat, "-ibdnW")
 	if err != nil {
 		return nil, err
 	}

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -106,11 +106,11 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 	if err != nil {
 		return nil, err
 	}
-	out, err := invoke.Command(netstat, "-inb")
+	out, err := invoke.CommandWithContext(ctx, netstat, "-inb")
 	if err != nil {
 		return nil, err
 	}
-	out2, err := invoke.Command(netstat, "-ind")
+	out2, err := invoke.CommandWithContext(ctx, netstat, "-ind")
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat,
 	if err != nil {
 		return nil, err
 	}
-	out, err := invoke.Command(netstat, args...)
+	out, err := invoke.CommandWithContext(ctx, netstat, args...)
 
 	if err != nil {
 		return nil, err

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -66,7 +66,7 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 		return ret, common.ErrNotImplementedError
 	}
 
-	r, err := common.CallLsof(invoke, pid, args...)
+	r, err := common.CallLsofWithContext(ctx, invoke, pid, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -51,7 +51,7 @@ func Pids() ([]int32, error) {
 func PidsWithContext(ctx context.Context) ([]int32, error) {
 	var ret []int32
 
-	pids, err := callPs("pid", 0, false)
+	pids, err := callPsWithContext(ctx, "pid", 0, false)
 	if err != nil {
 		return ret, err
 	}
@@ -72,7 +72,7 @@ func (p *Process) Ppid() (int32, error) {
 }
 
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
-	r, err := callPs("ppid", p.Pid, false)
+	r, err := callPsWithContext(ctx, "ppid", p.Pid, false)
 	if err != nil {
 		return 0, err
 	}
@@ -119,9 +119,9 @@ func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	lsof := exec.Command(lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
-	awk := exec.Command(awk_bin, "NR==5{print}")
-	sed := exec.Command(sed_bin, "s/n\\//\\//")
+	lsof := exec.CommandContext(ctx, lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
+	awk := exec.CommandContext(ctx, awk_bin, "NR==5{print}")
+	sed := exec.CommandContext(ctx, sed_bin, "s/n\\//\\//")
 
 	output, _, err := common.Pipeline(lsof, awk, sed)
 
@@ -141,7 +141,7 @@ func (p *Process) Cmdline() (string, error) {
 }
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
-	r, err := callPs("command", p.Pid, false)
+	r, err := callPsWithContext(ctx, "command", p.Pid, false)
 	if err != nil {
 		return "", err
 	}
@@ -158,7 +158,7 @@ func (p *Process) CmdlineSlice() ([]string, error) {
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
-	r, err := callPs("command", p.Pid, false)
+	r, err := callPsWithContext(ctx, "command", p.Pid, false)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (p *Process) CreateTime() (int64, error) {
 }
 
 func (p *Process) CreateTimeWithContext(ctx context.Context) (int64, error) {
-	r, err := callPs("etime", p.Pid, false)
+	r, err := callPsWithContext(ctx, "etime", p.Pid, false)
 	if err != nil {
 		return 0, err
 	}
@@ -210,7 +210,7 @@ func (p *Process) Parent() (*Process, error) {
 }
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
-	rr, err := common.CallLsof(invoke, p.Pid, "-FR")
+	rr, err := common.CallLsofWithContext(ctx, invoke, p.Pid, "-FR")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (p *Process) Status() (string, error) {
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
-	r, err := callPs("state", p.Pid, false)
+	r, err := callPsWithContext(ctx, "state", p.Pid, false)
 	if err != nil {
 		return "", err
 	}
@@ -350,7 +350,7 @@ func (p *Process) NumThreads() (int32, error) {
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
-	r, err := callPs("utime,stime", p.Pid, true)
+	r, err := callPsWithContext(ctx, "utime,stime", p.Pid, true)
 	if err != nil {
 		return 0, err
 	}
@@ -395,7 +395,7 @@ func (p *Process) Times() (*cpu.TimesStat, error) {
 }
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
-	r, err := callPs("utime,stime", p.Pid, false)
+	r, err := callPsWithContext(ctx, "utime,stime", p.Pid, false)
 
 	if err != nil {
 		return nil, err
@@ -429,7 +429,7 @@ func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
-	r, err := callPs("rss,vsize,pagein", p.Pid, false)
+	r, err := callPsWithContext(ctx, "rss,vsize,pagein", p.Pid, false)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +467,7 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	pids, err := common.CallPgrep(invoke, p.Pid)
+	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func NewProcess(pid int32) (*Process, error) {
 // Return value deletes Header line(you must not input wrong arg).
 // And splited by Space. Caller have responsibility to manage.
 // If passed arg pid is 0, get information from all process.
-func callPs(arg string, pid int32, threadOption bool) ([][]string, error) {
+func callPsWithContext(ctx context.Context, arg string, pid int32, threadOption bool) ([][]string, error) {
 	bin, err := exec.LookPath("ps")
 	if err != nil {
 		return [][]string{}, err
@@ -623,7 +623,7 @@ func callPs(arg string, pid int32, threadOption bool) ([][]string, error) {
 	} else {
 		cmd = []string{"-x", "-o", arg, "-p", strconv.Itoa(int(pid))}
 	}
-	out, err := invoke.Command(bin, cmd...)
+	out, err := invoke.CommandWithContext(ctx, bin, cmd...)
 	if err != nil {
 		return [][]string{}, err
 	}

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -355,7 +355,7 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	pids, err := common.CallPgrep(invoke, p.Pid)
+	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -462,7 +462,7 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	pids, err := common.CallPgrep(invoke, p.Pid)
+	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
 	if err != nil {
 		if pids == nil || len(pids) == 0 {
 			return nil, ErrorNoChildren

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -5,6 +5,7 @@ package process
 import (
 	"C"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"strings"
 	"unsafe"
@@ -15,7 +16,6 @@ import (
 	net "github.com/shirou/gopsutil/net"
 	"golang.org/x/sys/unix"
 )
-import "context"
 
 // MemoryInfoExStat is different between OSes
 type MemoryInfoExStat struct {
@@ -345,7 +345,7 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	pids, err := common.CallPgrep(invoke, p.Pid)
+	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A few months ago, `WithContext` functions are introduced(#480). But in internal, that is not used. This PR changes to use `exec.CommandContext()` and it enables `context` power.