### PR TITLE
[host] Fix docker uptime parsing (fix #507)

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -146,7 +146,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 			return 0, fmt.Errorf("wrong uptime format")
 		}
 		f := strings.Fields(lines[0])
-		b, err := strconv.ParseInt(f[0], 10, 64)
+		b, err := strconv.ParseFloat(f[0], 64)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
Tested with following `docker version`

```
Client:
 Version:       18.03.0-ce
 API version:   1.37
 Go version:    go1.9.4
 Git commit:    0520e24
 Built: Wed Mar 21 23:10:06 2018
 OS/Arch:       linux/amd64
 Experimental:  false
 Orchestrator:  swarm

Server:
 Engine:
  Version:      18.03.0-ce
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.4
  Git commit:   0520e24
  Built:        Wed Mar 21 23:08:35 2018
  OS/Arch:      linux/amd64
  Experimental: false
```