### PR TITLE
Use uint64 sysctl when retrieving vfs.bufspace on FreeBSD

### DIFF
--- a/mem/mem_freebsd.go
+++ b/mem/mem_freebsd.go
@@ -39,7 +39,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	if err != nil {
 		return nil, err
 	}
-	buffers, err := unix.SysctlUint32("vfs.bufspace")
+	buffers, err := unix.SysctlUint64("vfs.bufspace")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On some system using a the uint32 function returns the error "cannot allocate memory". https://github.com/influxdata/telegraf/issues/3750

It appears that the size of this field can vary, and sometimes requires additional space.  From `man 3 sysctl`:

> The information is copied into the buffer specified by oldp.  The size of
> the buffer is given by the location specified by oldlenp before the call,
> and that location gives the amount of data copied after a successful call
> and after a call that returns with the error code ENOMEM.  **If the amount
> of data available is greater than the size of the buffer supplied, the
> call supplies as much data as fits in the buffer provided and returns
> with the error code ENOMEM.**  If the old value is not desired, oldp and
> oldlenp should be set to NULL.

It is possible that we should use `func SysctlRaw` instead as it checks the size of the field using the method described here:

> The size of the available data can be determined by calling sysctl() with
> the NULL argument for oldp.  The size of the available data will be
> returned in the location pointed to by oldlenp.  For some operations, the
> amount of space may change often.  For these operations, the system
> attempts to round up so that the returned size is large enough for a call
> to return the data shortly thereafter.

I have not made this larger change.
