### PR TITLE
add support for etime (elapsed time)

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -444,3 +444,15 @@ func Test_Kill(t *testing.T) {
 	assert.Nil(t, p.Kill())
 	wg.Wait()
 }
+
+func Test_Process_ElapsedTime(t *testing.T) {
+	p := testGetProcess()
+	etime, err := p.ElapsedTime()
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+
+	if err == "" {
+		t.Error("elapsed time should not be empty")
+	}
+}


### PR DESCRIPTION
This is the implementation of my feature request #515. 

According to the [ps man page](http://linuxcommand.org/lc3_man_pages/ps1.html):
```
etime  ELAPSED  elapsed time since the process was started, in the form [[dd-]hh:]mm:ss.
```

The `ElapsedTime()` function returns the elapsed time of the process indicating how long process has been running for.


Usage example:
```
package main

import (
	"fmt"

	"github.com/shirou/gopsutil/process"
)

func main() {
	pid := os.Getpid()
	p, err  := process.NewProcess(pid)
        if err != nil {
          log.Fatalf("error: %v", err)
        } 
        etime, err := p.ElapsedTime()
        if err != nil {
          log.Fatalf("error: %v, err)
        }
        fmt.Println("PID: ", pid, "Elapsed Time: ", etime)
}
```