### PR TITLE
Fix build breakage in disk_linux.go

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -424,9 +424,8 @@ func GetLabel(name string) string {
 	dmname, err := ioutil.ReadFile(dmname_filename)
 	if err != nil {
 		return ""
-	} else {
-		return dmname
 	}
+	return string(dmname)
 }
 
 func getFsType(stat unix.Statfs_t) string {


### PR DESCRIPTION
ignoring the error from ReadFile also does not seem right, but I will leave it as is.