### PR TITLE
mem[windows]: if no swap, just return 0 used percent default

### DIFF
--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -4,7 +4,6 @@ package mem
 
 import (
 	"context"
-	"errors"
 	"unsafe"
 
 	"github.com/shirou/gopsutil/internal/common"
@@ -80,16 +79,18 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 	}
 	tot := perfInfo.commitLimit * perfInfo.pageSize
 	used := perfInfo.commitTotal * perfInfo.pageSize
-	if tot == 0 || used == 0 {
-		return nil, errors.New("total or used memory is 0")
-	}
-
 	free := tot - used
+	var usedPercent float64
+	if tot == 0 {
+		usedPercent = 0
+	} else {
+		usedPercent = float64(used) / float64(tot)
+	}
 	ret := &SwapMemoryStat{
 		Total:       tot,
 		Used:        used,
 		Free:        free,
-		UsedPercent: float64(used) / float64(tot),
+		UsedPercent: usedPercent,
 	}
 
 	return ret, nil


### PR DESCRIPTION
Just return 0 used percent when swap memory total is zero and the other will be the current zero.

There's no swap total or used is not a error.

fix #525 , please check it, thanks:)