### PR TITLE
Check for error objects

### DIFF
--- a/cpu/cpu_solaris_test.go
+++ b/cpu/cpu_solaris_test.go
@@ -102,6 +102,9 @@ func TestParseProcessorInfo(t *testing.T) {
 		}
 
 		cpus, err := parseProcessorInfo(string(content))
+		if err != nil {
+			t.Errorf("cannot parse processor info: %s", err)
+		}
 
 		if !reflect.DeepEqual(tc.expected, cpus) {
 			t.Fatalf("Bad Processor Info\nExpected: %v\n   Actual: %v", tc.expected, cpus)

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -23,7 +23,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		return ret, err
 	}
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MntWait)
+	if _, err = Getfsstat(fs, MntWait); err != nil {
+		return ret, err
+	}
 	for _, stat := range fs {
 		opts := "rw"
 		if stat.Flags&MntReadOnly != 0 {

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -29,7 +29,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MNT_WAIT)
+	if _, err = Getfsstat(fs, MNT_WAIT); err != nil {
+		return ret, err
+	}
 
 	for _, stat := range fs {
 		opts := "rw"

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -27,7 +27,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MNT_WAIT)
+	if _, err = Getfsstat(fs, MNT_WAIT); err != nil {
+		return ret, err
+	}
 
 	for _, stat := range fs {
 		opts := "rw"

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -51,6 +51,9 @@ func TestBoot_time(t *testing.T) {
 	t.Logf("first boot time: %d", v)
 
 	v2, err := BootTime()
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
 	if v != v2 {
 		t.Errorf("cached boot time is different")
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -61,6 +61,9 @@ func TestNetConnectionStatString(t *testing.T) {
 
 func TestNetIOCountersAll(t *testing.T) {
 	v, err := IOCounters(false)
+	if err != nil {
+		t.Errorf("Could not get NetIOCounters: %v", err)
+	}
 	per, err := IOCounters(true)
 	if err != nil {
 		t.Errorf("Could not get NetIOCounters: %v", err)

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1175,6 +1175,9 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 	createTime := int64(ctime * 1000)
 
 	rtpriority, err := strconv.ParseInt(fields[i+16], 10, 32)
+	if err != nil {
+		return 0, 0, nil, 0, 0, 0, err
+	}
 	if rtpriority < 0 {
 		rtpriority = rtpriority*-1 - 1
 	} else {

--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -26,6 +26,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	defer d.Close()
 
 	devnames, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
 	for _, devname := range devnames {
 		if strings.HasPrefix(devname, "/dev/tty") {
 			termfiles = append(termfiles, "/dev/tty/"+devname)
@@ -45,6 +48,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	if ptsnames == nil {
 		defer ptsd.Close()
 		ptsnames, err = ptsd.Readdirnames(-1)
+		if err != nil {
+			return nil, err
+		}
 		for _, ptsname := range ptsnames {
 			termfiles = append(termfiles, "/dev/pts/"+ptsname)
 		}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -85,6 +85,9 @@ func Test_Process_memory_maps(t *testing.T) {
 	checkPid := os.Getpid()
 
 	ret, err := NewProcess(int32(checkPid))
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
 
 	mmaps, err := ret.MemoryMaps(false)
 	if err != nil {

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -270,6 +270,9 @@ func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {
 	}
 	defer token.Close()
 	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
 
 	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
 	return domain + "\\" + user, err


### PR DESCRIPTION
This PR fixes all ineffectual assignments of `err` object where it wasn't checked.