### PR TITLE
Implement disk.GetDiskSerialNumber for Windows via WMI

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -32,13 +32,11 @@ type Win32_PerfFormattedData struct {
 	AvgDisksecPerRead       uint64
 	AvgDisksecPerWrite      uint64
 }
-type Win32_DiskDrive struct {
-	DeviceID         string
-	FirmwareRevision string
-	InterfaceType    string
-	SerialNumber     string
+type win32_DiskDrive struct {
+	DeviceID     string
+	SerialNumber string
 }
-type Win32_DiskPartition struct {
+type win32_DiskPartition struct {
 	DeviceID string
 }
 
@@ -187,8 +185,8 @@ func GetDiskSerialNumber(name string) string {
 }
 
 func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
-	var diskPart []Win32_DiskPartition
-	var diskDrive []Win32_DiskDrive
+	var diskPart []win32_DiskPartition
+	var diskDrive []win32_DiskDrive
 	err := common.WMIQueryWithContext(ctx, "Associators of {Win32_LogicalDisk.DeviceID='"+name+"'} where AssocClass=Win32_LogicalDiskToPartition", &diskPart)
 	if err != nil || len(diskPart) <= 0 {
 		return ""

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -176,7 +176,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 			WriteTime:  d.AvgDisksecPerWrite,
 		}
 		tmpIO.SerialNumber = GetDiskSerialNumber(d.Name)
-		ret[d.Name] = d
+		ret[d.Name] = tmpIO
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Fix [shirou/gopsutil#435](https://github.com/shirou/gopsutil/issues/435). Parameter should be drive letter, so it can be used in IOCountersStat directly. See last part of https://msdn.microsoft.com/en-us/library/windows/desktop/aa394592(v=vs.85).aspx.