### PR TITLE
use full cmdline in case of proc renaming

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -985,6 +985,8 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					extendedName := filepath.Base(cmdlineSlice[0])
 					if strings.HasPrefix(extendedName, p.name) {
 						p.name = extendedName
+					} else {
+						p.name = cmdlineSlice[0]
 					}
 				}
 			}


### PR DESCRIPTION
If some process call prctl with PR_SET_NAME it change proc name field. If there is a slash after proc path, filepath.Base() make mess with it. For example: 
1 execute python3.5 ./test.py
2 set proc title to "python3.5 ./test.py [test]"
3 cat /proc/self/stat                                                                                                                                                                        
   1234 (python3.5 ./tes) ...
4 now this code
```go
cmdlineSlice, err := p.CmdlineSlice()
    if strings.HasPrefix(extendedName, p.name) {
	p.name = extendedName
```
is trying to compare extendedName(test.py [test]) with p.name(python3.5 ./tes). And it fail.