### PR TITLE
Use HOST_* environment variables for getting disk serial number in Linux

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -395,7 +395,7 @@ func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
 	minor := unix.Minor(uint64(stat.Rdev))
 
 	// Try to get the serial from udev data
-	udevDataPath := fmt.Sprintf("/run/udev/data/b%d:%d", major, minor)
+	udevDataPath := common.HostRun(fmt.Sprintf("udev/data/b%d:%d", major, minor))
 	if udevdata, err := ioutil.ReadFile(udevDataPath); err == nil {
 		scanner := bufio.NewScanner(bytes.NewReader(udevdata))
 		for scanner.Scan() {
@@ -408,7 +408,7 @@ func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
 
 	// Try to get the serial from sysfs, look at the disk device (minor 0) directly
 	// because if it is a partition it is not going to contain any device information
-	devicePath := fmt.Sprintf("/sys/dev/block/%d:0/device", major)
+	devicePath := common.HostSys(fmt.Sprintf("dev/block/%d:0/device", major))
 	model, _ := ioutil.ReadFile(filepath.Join(devicePath, "model"))
 	serial, _ := ioutil.ReadFile(filepath.Join(devicePath, "serial"))
 	if len(model) > 0 && len(serial) > 0 {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -328,6 +328,10 @@ func HostVar(combineWith ...string) string {
 	return GetEnv("HOST_VAR", "/var", combineWith...)
 }
 
+func HostRun(combineWith ...string) string {
+	return GetEnv("HOST_RUN", "/run", combineWith...)
+}
+
 // https://gist.github.com/kylelemons/1525278
 func Pipeline(cmds ...*exec.Cmd) ([]byte, []byte, error) {
 	// Require at least one command


### PR DESCRIPTION
Code introduced in #532 was not making use of these environment variables.