### PR TITLE
Support for unix sockets in ConnectionsPid()

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -71,6 +71,7 @@ type FilterStat struct {
 }
 
 var constMap = map[string]int{
+	"unix": syscall.AF_UNIX,
 	"TCP":  syscall.SOCK_STREAM,
 	"UDP":  syscall.SOCK_DGRAM,
 	"IPv4": syscall.AF_INET,
@@ -178,8 +179,13 @@ func getIOCountersAll(n []IOCountersStat) ([]IOCountersStat, error) {
 
 func parseNetLine(line string) (ConnectionStat, error) {
 	f := strings.Fields(line)
-	if len(f) < 9 {
+	if len(f) < 8 {
 		return ConnectionStat{}, fmt.Errorf("wrong line,%s", line)
+	}
+
+	if len(f) == 8 {
+		f = append(f, f[7])
+		f[7] = "unix"
 	}
 
 	pid, err := strconv.Atoi(f[1])
@@ -199,9 +205,14 @@ func parseNetLine(line string) (ConnectionStat, error) {
 		return ConnectionStat{}, fmt.Errorf("unknown type, %s", f[7])
 	}
 
-	laddr, raddr, err := parseNetAddr(f[8])
-	if err != nil {
-		return ConnectionStat{}, fmt.Errorf("failed to parse netaddr, %s", f[8])
+	var laddr, raddr Addr
+	if f[7] == "unix" {
+		laddr.IP = f[8]
+	} else {
+		laddr, raddr, err = parseNetAddr(f[8])
+		if err != nil {
+			return ConnectionStat{}, fmt.Errorf("failed to parse netaddr, %s", f[8])
+		}
 	}
 
 	n := ConnectionStat{

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -63,7 +63,7 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 	case "udp6":
 		args = append(args, "6udp")
 	case "unix":
-		return ret, common.ErrNotImplementedError
+		args = []string{"-U"}
 	}
 
 	r, err := common.CallLsofWithContext(ctx, invoke, pid, args...)


### PR DESCRIPTION
Currently:
```golang
	case "unix":
		return ret, common.ErrNotImplementedError
```
 With `-U` option passed to `lsof` we can get the list of unix sockets so we can change this to:
```patch
 	case "unix":
-		return ret, common.ErrNotImplementedError
+		args = []string{"-U"}
 	}
```
However I'm not really sure about some other required changes... maybe someone could help me with this PR?

Right now it works but take a look at the code. An example output below.
```go
import (
        "fmt"
        "log"

        "github.com/shirou/gopsutil/net"
        "github.com/shirou/gopsutil/process"
)

func main() {
        pids, err := process.Pids()
        if err != nil {
                panic(err)
        }
        for _, pid := range pids {
                proc, err := process.NewProcess(pid)
                if err != nil {
                        log.Println(err)
                        continue
                }
                if procName, err := proc.Name(); err != nil {
                        log.Println(err)
                        continue
                } else {
                        if procName == "mysqld" {
                                cons, err := net.ConnectionsPid("unix", pid)
                                if err != nil {
                                        log.Fatal(err)
                                }
                                if len(cons) > 0 {
                                        fmt.Printf("mysql with PID %d is using socket: %s\n", pid, cons[0].Laddr.IP)
                                }
                        }
                }
        }
}
```
```sh
# go run main.go
mysql with PID 15612 is using socket: ->0x6be97f0b39f04933
mysql with PID 15612 is using socket: ->0x6be97f0b39f05d83
mysql with PID 15612 is using socket: /tmp/mysql.sock
mysql with PID 15612 is using socket: /tmp/mysqlx.sock
```