### PR TITLE
Fix undefined process.Processes when building telegraf on Solaris-based system

### DIFF
--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -36,6 +36,14 @@ func PidsWithContext(ctx context.Context) ([]int32, error) {
 	return []int32{}, common.ErrNotImplementedError
 }
 
+func Processes() ([]*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+
 func NewProcess(pid int32) (*Process, error) {
 	return nil, common.ErrNotImplementedError
 }


### PR DESCRIPTION
I attempted to build `telegraf` today on `OmniOS`, which is a `Solaris` derived system, but based on the `Illumos` kernel, and ran into this issue. A bit of digging revealed that nothing builds that would satisfy this requirement. As such, this hack happened.
```
# github.com/influxdata/telegraf/plugins/inputs/procstat
plugins/inputs/procstat/native_finder.go:24:16: undefined: process.Processes
plugins/inputs/procstat/native_finder_notwindows.go:18:16: undefined: process.Processes
plugins/inputs/procstat/native_finder_notwindows.go:43:16: undefined: process.Processes
```
It seems like there's not really much there to support process information on `Solaris` and friends, and I am wondering if there is any demand, and if so, I have done some work to expose but a small subset of what seems to be made available from other operating systems, but perhaps if there is interest, I can at least add a few of those bits as time permits and maybe enhance from there.

Thanks, Sam.