### PR TITLE
Add mem(laundry) numbers on FreeBSD.

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -42,6 +42,10 @@ type VirtualMemoryStat struct {
 	Inactive uint64 `json:"inactive"`
 	Wired    uint64 `json:"wired"`
 
+	// FreeBSD specific numbers:
+	// https://reviews.freebsd.org/D8467
+	Laundry  uint64 `json:"laundry"`
+
 	// Linux specific numbers
 	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
 	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt

--- a/mem/mem_freebsd.go
+++ b/mem/mem_freebsd.go
@@ -19,7 +19,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	if err != nil {
 		return nil, err
 	}
-	pageCount, err := unix.SysctlUint32("vm.stats.vm.v_page_count")
+	physmem, err := unix.SysctlUint64("hw.physmem")
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 
 	p := uint64(pageSize)
 	ret := &VirtualMemoryStat{
-		Total:    uint64(pageCount) * p,
+		Total:    uint64(physmem),
 		Free:     uint64(free) * p,
 		Active:   uint64(active) * p,
 		Inactive: uint64(inactive) * p,

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -33,8 +33,8 @@ func TestVirtual_memory(t *testing.T) {
 		totalStr = "used + available"
 	}
 	if runtime.GOOS == "freebsd" {
-		total = v.Used + v.Free + v.Cached + v.Inactive
-		totalStr = "used + free + cached + inactive"
+		total = v.Used + v.Free + v.Cached + v.Inactive + v.Laundry
+		totalStr = "used + free + cached + inactive + laundry"
 	}
 	assert.Equal(t, v.Total, total,
 		"Total should be computable (%v): %v", totalStr, v)
@@ -71,7 +71,7 @@ func TestVirtualMemoryStat_String(t *testing.T) {
 		UsedPercent: 30.1,
 		Free:        40,
 	}
-	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"pagetables":0,"swapcached":0,"commitlimit":0,"committedas":0,"hightotal":0,"highfree":0,"lowtotal":0,"lowfree":0,"swaptotal":0,"swapfree":0,"mapped":0,"vmalloctotal":0,"vmallocused":0,"vmallocchunk":0,"hugepagestotal":0,"hugepagesfree":0,"hugepagesize":0}`
+	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"pagetables":0,"swapcached":0,"commitlimit":0,"committedas":0,"hightotal":0,"highfree":0,"lowtotal":0,"lowfree":0,"swaptotal":0,"swapfree":0,"mapped":0,"vmalloctotal":0,"vmallocused":0,"vmallocchunk":0,"hugepagestotal":0,"hugepagesfree":0,"hugepagesize":0}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("VirtualMemoryStat string is invalid: %v", v)
 	}

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -32,6 +32,10 @@ func TestVirtual_memory(t *testing.T) {
 		total = v.Used + v.Available
 		totalStr = "used + available"
 	}
+	if runtime.GOOS == "freebsd" {
+		total = v.Used + v.Free + v.Cached + v.Inactive
+		totalStr = "used + free + cached + inactive"
+	}
 	assert.Equal(t, v.Total, total,
 		"Total should be computable (%v): %v", totalStr, v)
 


### PR DESCRIPTION
After FreeBSD 11.1, mem number of `cached` replaced by `laundry`.

https://reviews.freebsd.org/D8302

And Fix FreeBSD total memory. Like this.

FreeBSD: fix total memory giampaolo/psutil@bd9a58b giampaolo/psutil@bd9a58b