### PR TITLE
implement grouped memorymaps output

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -537,6 +537,9 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
 	pid := p.Pid
 	var ret []MemoryMapsStat
+	if grouped {
+        ret = make([]MemoryMapsStat, 1)
+    }
 	smapsPath := common.HostProc(strconv.Itoa(int(pid)), "smaps")
 	contents, err := ioutil.ReadFile(smapsPath)
 	if err != nil {
@@ -599,7 +602,20 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 				if err != nil {
 					return &ret, err
 				}
-				ret = append(ret, g)
+				if grouped {
+				    ret.Size += g.Size
+				    ret.Rss += g.Rss
+				    ret.Pss += g.Pss
+				    ret.SharedClean += g.SharedClean
+				    ret.SharedDirty += g.SharedDirty
+				    ret.PrivateClean += g.PrivateClean
+				    ret.PrivateDirty += g.PrivateDirty
+				    ret.Referenced += g.Referenced
+				    ret.Anonymous += g.Anonymous
+				    ret.Swap += g.Swap
+                } else {
+                    ret = append(ret, g)
+                }
 			}
 			// starts new block
 			blocks = make([]string, 16)

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -603,16 +603,16 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 					return &ret, err
 				}
 				if grouped {
-				    ret.Size += g.Size
-				    ret.Rss += g.Rss
-				    ret.Pss += g.Pss
-				    ret.SharedClean += g.SharedClean
-				    ret.SharedDirty += g.SharedDirty
-				    ret.PrivateClean += g.PrivateClean
-				    ret.PrivateDirty += g.PrivateDirty
-				    ret.Referenced += g.Referenced
-				    ret.Anonymous += g.Anonymous
-				    ret.Swap += g.Swap
+				    ret[0].Size += g.Size
+				    ret[0].Rss += g.Rss
+				    ret[0].Pss += g.Pss
+				    ret[0].SharedClean += g.SharedClean
+				    ret[0].SharedDirty += g.SharedDirty
+				    ret[0].PrivateClean += g.PrivateClean
+				    ret[0].PrivateDirty += g.PrivateDirty
+				    ret[0].Referenced += g.Referenced
+				    ret[0].Anonymous += g.Anonymous
+				    ret[0].Swap += g.Swap
                 } else {
                     ret = append(ret, g)
                 }

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -89,6 +89,7 @@ func Test_Process_memory_maps(t *testing.T) {
 		t.Errorf("error %v", err)
 	}
 
+	// ungrouped memory maps
 	mmaps, err := ret.MemoryMaps(false)
 	if err != nil {
 		t.Errorf("memory map get error %v", err)
@@ -99,6 +100,18 @@ func Test_Process_memory_maps(t *testing.T) {
 			t.Errorf("memory map get error %v", m)
 		}
 	}
+
+	// grouped memory maps
+	mmaps, err := ret.MemoryMaps(true)
+	if err != nil {
+		t.Errorf("memory map get error %v", err)
+	}
+	if len(mmaps) != 1 {
+		t.Errorf("grouped memory maps length (%v) is not equal to 1", len(mmaps))
+	}
+    if mmaps[0] == empty {
+        t.Errorf("memory map is empty")
+    }
 }
 func Test_Process_MemoryInfo(t *testing.T) {
 	p := testGetProcess()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -102,14 +102,14 @@ func Test_Process_memory_maps(t *testing.T) {
 	}
 
 	// grouped memory maps
-	mmaps, err := ret.MemoryMaps(true)
+	mmaps, err = ret.MemoryMaps(true)
 	if err != nil {
 		t.Errorf("memory map get error %v", err)
 	}
-	if len(mmaps) != 1 {
-		t.Errorf("grouped memory maps length (%v) is not equal to 1", len(mmaps))
+	if len(*mmaps) != 1 {
+		t.Errorf("grouped memory maps length (%v) is not equal to 1", len(*mmaps))
 	}
-    if mmaps[0] == empty {
+    if (*mmaps)[0] == empty {
         t.Errorf("memory map is empty")
     }
 }


### PR DESCRIPTION
`MemoryMapsWithContext` has an unused `grouped bool` parameter, which obviously toggles grouped/ungrouped memory maps output. This PR implements the grouping functionality.