### PR TITLE
get docker container cpu usage from cpuacct.usage

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var cpu_tick = float64(100)
+var CPUTick = float64(100)
 
 func init() {
 	getconf, err := exec.LookPath("/usr/bin/getconf")
@@ -25,7 +25,7 @@ func init() {
 	if err == nil {
 		i, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
 		if err == nil {
-			cpu_tick = float64(i)
+			CPUTick = i
 		}
 	}
 }
@@ -251,34 +251,34 @@ func parseStatLine(line string) (*TimesStat, error) {
 
 	ct := &TimesStat{
 		CPU:     cpu,
-		User:    float64(user) / cpu_tick,
-		Nice:    float64(nice) / cpu_tick,
-		System:  float64(system) / cpu_tick,
-		Idle:    float64(idle) / cpu_tick,
-		Iowait:  float64(iowait) / cpu_tick,
-		Irq:     float64(irq) / cpu_tick,
-		Softirq: float64(softirq) / cpu_tick,
+		User:    user / CPUTick,
+		Nice:    nice / CPUTick,
+		System:  system / CPUTick,
+		Idle:    idle / CPUTick,
+		Iowait:  iowait / CPUTick,
+		Irq:     irq / CPUTick,
+		Softirq: softirq / CPUTick,
 	}
 	if len(fields) > 8 { // Linux >= 2.6.11
 		steal, err := strconv.ParseFloat(fields[8], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.Steal = float64(steal) / cpu_tick
+		ct.Steal = steal / CPUTick
 	}
 	if len(fields) > 9 { // Linux >= 2.6.24
 		guest, err := strconv.ParseFloat(fields[9], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.Guest = float64(guest) / cpu_tick
+		ct.Guest = guest / CPUTick
 	}
 	if len(fields) > 10 { // Linux >= 3.2.0
 		guestNice, err := strconv.ParseFloat(fields[10], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.GuestNice = float64(guestNice) / cpu_tick
+		ct.GuestNice = guestNice / CPUTick
 	}
 
 	return ct, nil

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 )
 
@@ -11,6 +12,11 @@ var ErrDockerNotAvailable = errors.New("docker not available")
 var ErrCgroupNotAvailable = errors.New("cgroup not available")
 
 var invoke common.Invoker = common.Invoke{}
+
+type CgroupCPUStat struct {
+	cpu.TimesStat
+	Usage float64
+}
 
 type CgroupMemStat struct {
 	ContainerID             string `json:"containerID"`

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -13,6 +13,8 @@ var ErrCgroupNotAvailable = errors.New("cgroup not available")
 
 var invoke common.Invoker = common.Invoke{}
 
+const nanoseconds = 1e9
+
 type CgroupCPUStat struct {
 	cpu.TimesStat
 	Usage float64

--- a/docker/docker_notlinux.go
+++ b/docker/docker_notlinux.go
@@ -5,6 +5,7 @@ package docker
 import (
 	"context"
 
+	cpu "github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 )
 
@@ -32,19 +33,19 @@ func GetDockerIDListWithContext(ctx context.Context) ([]string, error) {
 // containerid is same as docker id if you use docker.
 // If you use container via systemd.slice, you could use
 // containerid = docker-<container id>.scope and base=/sys/fs/cgroup/cpuacct/system.slice/
-func CgroupCPU(containerid string, base string) (*CgroupCPUStat, error) {
+func CgroupCPU(containerid string, base string) (*cpu.TimesStat, error) {
 	return CgroupCPUWithContext(context.Background(), containerid, base)
 }
 
-func CgroupCPUWithContext(ctx context.Context, containerid string, base string) (*CgroupCPUStat, error) {
+func CgroupCPUWithContext(ctx context.Context, containerid string, base string) (*cpu.TimesStat, error) {
 	return nil, ErrCgroupNotAvailable
 }
 
-func CgroupCPUDocker(containerid string) (*CgroupCPUStat, error) {
+func CgroupCPUDocker(containerid string) (*cpu.TimesStat, error) {
 	return CgroupCPUDockerWithContext(context.Background(), containerid)
 }
 
-func CgroupCPUDockerWithContext(ctx context.Context, containerid string) (*CgroupCPUStat, error) {
+func CgroupCPUDockerWithContext(ctx context.Context, containerid string) (*cpu.TimesStat, error) {
 	return CgroupCPU(containerid, common.HostSys("fs/cgroup/cpuacct/docker"))
 }
 

--- a/docker/docker_notlinux.go
+++ b/docker/docker_notlinux.go
@@ -4,7 +4,7 @@ package docker
 
 import (
 	"context"
-	"github.com/shirou/gopsutil/cpu"
+
 	"github.com/shirou/gopsutil/internal/common"
 )
 
@@ -32,19 +32,19 @@ func GetDockerIDListWithContext(ctx context.Context) ([]string, error) {
 // containerid is same as docker id if you use docker.
 // If you use container via systemd.slice, you could use
 // containerid = docker-<container id>.scope and base=/sys/fs/cgroup/cpuacct/system.slice/
-func CgroupCPU(containerid string, base string) (*cpu.TimesStat, error) {
+func CgroupCPU(containerid string, base string) (*CgroupCPUStat, error) {
 	return CgroupCPUWithContext(context.Background(), containerid, base)
 }
 
-func CgroupCPUWithContext(ctx context.Context, containerid string, base string) (*cpu.TimesStat, error) {
+func CgroupCPUWithContext(ctx context.Context, containerid string, base string) (*CgroupCPUStat, error) {
 	return nil, ErrCgroupNotAvailable
 }
 
-func CgroupCPUDocker(containerid string) (*cpu.TimesStat, error) {
+func CgroupCPUDocker(containerid string) (*CgroupCPUStat, error) {
 	return CgroupCPUDockerWithContext(context.Background(), containerid)
 }
 
-func CgroupCPUDockerWithContext(ctx context.Context, containerid string) (*cpu.TimesStat, error) {
+func CgroupCPUDockerWithContext(ctx context.Context, containerid string) (*CgroupCPUStat, error) {
 	return CgroupCPU(containerid, common.HostSys("fs/cgroup/cpuacct/docker"))
 }
 


### PR DESCRIPTION
This PR for:

* Get cgroup cpu usage from cpuacct.usage, it's a nanoseconds data, so I trans it to seconds.
* Make ```CgroupCPUWithContext``` return same unit like ```cpu.Times```. I saw cpu.Times will trans jiffies to seconds, so here should divide ```CPUTick```.

After this change, we can calculate container CPU percent in host view and container view like this:

```
interval := Seconds
containerCPUStat1 := CgroupCPUDocker(cid)
hostCPUStat1 := cpu.Times(false)[0]
time.sleep(interval)
hostCPUStat2 := cpu.Times(false)[0]
containerCPUStat2 := CgroupCPUDocker(cid)

percentInHostView := (containerCPUStat2.Usage - containerCPUStat1.Usage) / (hostCPUStat2.Total() - hostCPUStat1.Total())

percentInContainerView := percentInHostView * CPUNumbers
```