### PR TITLE
net: use multi-value case clause instead of fallthrough

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -395,9 +395,7 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 		var ls []connTmp
 		path = fmt.Sprintf("%s/net/%s", root, t.filename)
 		switch t.family {
-		case syscall.AF_INET:
-			fallthrough
-		case syscall.AF_INET6:
+		case syscall.AF_INET, syscall.AF_INET6:
 			ls, err = processInet(path, t, inodes, pid)
 		case syscall.AF_UNIX:
 			ls, err = processUnix(path, t, inodes, pid)


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#emptyFallthrough-ref