### PR TITLE
add CgroupCPUUsageDocker just like CgroupCPUDocker

### DIFF
--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -149,6 +149,10 @@ func CgroupCPUDocker(containerid string) (*cpu.TimesStat, error) {
 	return CgroupCPUDockerWithContext(context.Background(), containerid)
 }
 
+func CgroupCPUUsageDocker(containerid string) (float64, error) {
+	return CgroupCPUDockerUsageWithContext(context.Background(), containerid)
+}
+
 func CgroupCPUDockerWithContext(ctx context.Context, containerid string) (*cpu.TimesStat, error) {
 	return CgroupCPU(containerid, common.HostSys("fs/cgroup/cpuacct/docker"))
 }


### PR DESCRIPTION
In line with CgroupCPUDocker, because I used :

CgroupCPUDockerUsageWithContext(context.Background(), containerid)

But I do not want to import extra package like context.

Feel free to close it if you think this is not necessary