### PR TITLE
correct param in docker_linux.go for memory.stat

### DIFF
--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -196,43 +196,43 @@ func CgroupMemWithContext(ctx context.Context, containerID string, base string) 
 			ret.Pgfault = v
 		case "pgmajfault":
 			ret.Pgmajfault = v
-		case "inactiveAnon":
+		case "inactiveAnon", "inactive_anon":
 			ret.InactiveAnon = v
-		case "activeAnon":
+		case "activeAnon", "active_anon":
 			ret.ActiveAnon = v
-		case "inactiveFile":
+		case "inactiveFile", "inactive_file":
 			ret.InactiveFile = v
-		case "activeFile":
+		case "activeFile", "active_file":
 			ret.ActiveFile = v
 		case "unevictable":
 			ret.Unevictable = v
-		case "hierarchicalMemoryLimit":
+		case "hierarchicalMemoryLimit", "hierarchical_memory_limit":
 			ret.HierarchicalMemoryLimit = v
-		case "totalCache":
+		case "totalCache", "total_cache":
 			ret.TotalCache = v
-		case "totalRss":
+		case "totalRss", "total_rss":
 			ret.TotalRSS = v
-		case "totalRssHuge":
+		case "totalRssHuge", "total_rss_huge":
 			ret.TotalRSSHuge = v
-		case "totalMappedFile":
+		case "totalMappedFile", "total_mapped_file":
 			ret.TotalMappedFile = v
-		case "totalPgpgin":
+		case "totalPgpgin", "total_pgpgin":
 			ret.TotalPgpgIn = v
-		case "totalPgpgout":
+		case "totalPgpgout", "total_pgpgout":
 			ret.TotalPgpgOut = v
-		case "totalPgfault":
+		case "totalPgfault", "total_pgfault":
 			ret.TotalPgFault = v
-		case "totalPgmajfault":
+		case "totalPgmajfault", "total_pgmajfault":
 			ret.TotalPgMajFault = v
-		case "totalInactiveAnon":
+		case "totalInactiveAnon", "total_inactive_anon":
 			ret.TotalInactiveAnon = v
-		case "totalActiveAnon":
+		case "totalActiveAnon", "total_active_anon":
 			ret.TotalActiveAnon = v
-		case "totalInactiveFile":
+		case "totalInactiveFile", "total_inactive_file":
 			ret.TotalInactiveFile = v
-		case "totalActiveFile":
+		case "totalActiveFile", "total_active_file":
 			ret.TotalActiveFile = v
-		case "totalUnevictable":
+		case "totalUnevictable", "total_unevictable":
 			ret.TotalUnevictable = v
 		}
 	}


### PR DESCRIPTION
 The version of docker on Ubuntu18.04 and Centos7 are old, and the
  parameters in memory.stat on Ubuntu18.04 and Centos7 are as following:

 cat /sys/fs/cgroup/memory/docker/33f962ca254969762d750ced9a97d8deef67535b96b1e8c17abd0939a3f2cbcf/memory.stat

    cache 1110016
    rss 413696
    rss_huge 0
    shmem 0
    mapped_file 1015808
    dirty 0
    writeback 0
    pgpgin 1610
    pgpgout 1238
    pgfault 1923
    pgmajfault 12
    inactive_anon 262144
    active_anon 151552
    inactive_file 0
    active_file 1110016
    unevictable 0
    hierarchical_memory_limit 9223372036854771712
    total_cache 1110016
    total_rss 413696
    total_rss_huge 0
    total_shmem 0
    total_mapped_file 1015808
    total_dirty 0
    total_writeback 0
    total_pgpgin 1610
    total_pgpgout 1238
    total_pgfault 1923
    total_pgmajfault 12
    total_inactive_anon 262144
    total_active_anon 151552
    total_inactive_file 0
    total_active_file 1110016
    total_unevictable 0
