### PR TITLE
Fix #596 Implement process.Background and process.Foreground functions

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -146,6 +146,19 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 	return false, err
 }
 
+// Background returns true if the process is in background, false otherwise.
+func (p *Process) Background() (bool, error) {
+	return p.BackgroundWithContext(context.Background())
+}
+
+func (p *Process) BackgroundWithContext(ctx context.Context) (bool, error) {
+	fg, err := p.ForegroundWithContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	return !fg, err
+}
+
 // If interval is 0, return difference from last call(non-blocking).
 // If interval > 0, wait interval sec and return diffrence between start and end.
 func (p *Process) Percent(interval time.Duration) (float64, error) {

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -251,7 +251,7 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", string(pid))
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
 	if err != nil {
 		return false, err
 	}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -239,6 +239,25 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return r[0][0], err
 }
+
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	pid := p.Pid
+	ps, err := exec.LookPath("ps")
+	if err != nil {
+		return false, err
+	}
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", string(pid))
+	if err != nil {
+		return false, err
+	}
+	return strings.IndexByte(string(out), '+') != -1, nil
+}
+
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -114,6 +114,13 @@ func (p *Process) Status() (string, error) {
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext() (bool, error) {
+	return false, common.ErrNotImplementedError
+}
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -181,7 +181,7 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", string(pid))
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
 	if err != nil {
 		return false, err
 	}

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	cpu "github.com/shirou/gopsutil/cpu"

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"os/exec"
 	"strings"
 
 	cpu "github.com/shirou/gopsutil/cpu"
@@ -168,6 +169,25 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return s, nil
 }
+
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	pid := p.Pid
+	ps, err := exec.LookPath("ps")
+	if err != nil {
+		return false, err
+	}
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", string(pid))
+	if err != nil {
+		return false, err
+	}
+	return strings.IndexByte(string(out), '+') != -1, nil
+}
+
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -162,6 +162,23 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return s, nil
 }
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	pid := p.Pid
+	ps, err := exec.LookPath("ps")
+	if err != nil {
+		return false, err
+	}
+	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	if err != nil {
+		return false, err
+	}
+	return strings.IndexByte(string(out), '+') != -1, nil
+}
 func (p *Process) Uids() ([]int32, error) {
 	return p.UidsWithContext(context.Background())
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -250,6 +250,15 @@ func (p *Process) Status() (string, error) {
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
+
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
+	return false, common.ErrNotImplementedError
+}
+
 func (p *Process) Username() (string, error) {
 	return p.UsernameWithContext(context.Background())
 }


### PR DESCRIPTION
You can test on Unix by comparing the same output between these two programs (might be interesting to get go-tests for this):

```bash
ps aux | tail -n +2 | awk '$8 !~ /'\\+'/ { print $2 }' # get processes whose status doesn't contain the '+' character, remove the first header line with tail (matches 'PID' otherwise)
```

```go
package main

import (
	"fmt"
	"os"

	"github.com/shirou/gopsutil/process"
)

func main() {
	procs, err := process.Processes()
	if err != nil {
		fmt.Println(err)
		os.Exit(1)
	}
	for _, p := range procs {
		ok, err := process.PidExists(p.Pid)
		if !ok {
			continue
		}
		bg, err := p.Background()
		if err != nil {
			fmt.Println(err)
			os.Exit(2)
		}
		if bg {
			fmt.Println(p.Pid)
		}
	}
}
```

You can also test foreground status with the below scripts, but keep in mind they will also show your current command(s) running if run interactively (two more PIDs for ps+awk, one more for the go program):

```bash
ps aux | awk '$8 ~ /'\\+'/ { print $2 }' # get processes whose status contains the '+' character
```

```go
package main

import (
	"fmt"
	"os"

	"github.com/shirou/gopsutil/process"
)

func main() {
	procs, err := process.Processes()
	if err != nil {
		fmt.Println(err)
		os.Exit(-1)
	}
	for _, p := range procs {
		ok, err := process.PidExists(p.Pid)
		if !ok {
			continue
		}
		fg, err := p.Foreground()
		if err != nil {
			fmt.Println(err)
			os.Exit(-2)
		}
		if fg {
			fmt.Println(p.Pid)
		}
	}
}
```

Tested successfully on Debian 9 amd64 and armv7l. Might need the same testing on BSDs/macOS.