### PR TITLE
[process][windows] Use win32 API in process.Children() instead of slow WMI call

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -250,6 +250,7 @@ func (p *Process) Status() (string, error) {
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
+
 func (p *Process) Username() (string, error) {
 	return p.UsernameWithContext(context.Background())
 }
@@ -456,22 +457,33 @@ func (p *Process) Children() ([]*Process, error) {
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	var dst []Win32_Process
-	query := wmi.CreateQuery(&dst, fmt.Sprintf("Where ParentProcessId = %d", p.Pid))
-	err := common.WMIQueryWithContext(ctx, query, &dst)
-	if err != nil {
-		return nil, err
-	}
-
 	out := []*Process{}
-	for _, proc := range dst {
-		p, err := NewProcess(int32(proc.ProcessID))
-		if err != nil {
-			continue
-		}
-		out = append(out, p)
+	snap := w32.CreateToolhelp32Snapshot(w32.TH32CS_SNAPPROCESS, uint32(0))
+	if snap == 0 {
+		return out, windows.GetLastError()
+	}
+	defer w32.CloseHandle(snap)
+	var pe32 w32.PROCESSENTRY32
+	pe32.DwSize = uint32(unsafe.Sizeof(pe32))
+	if w32.Process32First(snap, &pe32) == false {
+		return out, windows.GetLastError()
 	}
 
+	if pe32.Th32ParentProcessID == uint32(p.Pid) {
+		p, err := NewProcess(int32(pe32.Th32ProcessID))
+		if err == nil {
+			out = append(out, p)
+		}
+	}
+
+	for w32.Process32Next(snap, &pe32) {
+		if pe32.Th32ParentProcessID == uint32(p.Pid) {
+			p, err := NewProcess(int32(pe32.Th32ProcessID))
+			if err == nil {
+				out = append(out, p)
+			}
+		}
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
The CreateToolhelp32Snapshot+Process32First+Process32Next combo already
iterates over all processes, so it would be inefficient to enumerate all
processes with process.Processes() and then calling p.Ppid() on each of
them: we just use this combo to get all processes and their ppid in a
single iteration.

This is faster by a factor of 25 compared to the previous WMI call.

Benchmark program:

```go
package main

import (
	"fmt"
	"github.com/shirou/gopsutil/process"
	"os"
	"time"
)

func main() {
	start := time.Now()
	procs, err := process.Processes()
	if err != nil {
		fmt.Println("1", err)
		os.Exit(1)
	}
	for _, p := range procs {
		children, err := p.Children()
		if err != nil {
			fmt.Println("2", err)
			os.Exit(1)
		}
		fmt.Println(p.Pid, children)
	}
	elapsed := time.Now().Sub(start)
	fmt.Println("Elapsed time", elapsed, "(", elapsed/(time.Duration(len(procs))), "per process)")
}
```

Results:

* before patch (wmi): `Elapsed time 6.5693758s ( 56.148511ms per process)`
* after patch (win32): `Elapsed time 251.0143ms ( 2.127239ms per process)`