### PR TITLE
do not ignore A: and B: drives on windows

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -83,9 +83,6 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	for _, v := range lpBuffer {
 		if v >= 65 && v <= 90 {
 			path := string(v) + ":"
-			if path == "A:" || path == "B:" { // skip floppy drives
-				continue
-			}
 			typepath, _ := windows.UTF16PtrFromString(path)
 			typeret, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(typepath)))
 			if typeret == 0 {


### PR DESCRIPTION
from https://www.howtogeek.com/122891/what-are-the-windows-a-and-b-drives-used-for/

>if your computer does not have floppy disk drives, you can assign A and B to volumes

I ran into an issue where a network drive was mounted as b:\ and would not show up through `disk.Partitions(true)`