### PR TITLE
[net][linux] Support socket tables in nested namespaces

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -393,7 +393,11 @@ func statsFromInodes(root string, pid int32, tmap []netConnectionKindType, inode
 		var path string
 		var connKey string
 		var ls []connTmp
-		path = fmt.Sprintf("%s/net/%s", root, t.filename)
+		if pid == 0 {
+			path = fmt.Sprintf("%s/net/%s", root, t.filename)
+		} else {
+			path = fmt.Sprintf("%s/%d/net/%s", root, pid, t.filename)
+		}
 		switch t.family {
 		case syscall.AF_INET, syscall.AF_INET6:
 			ls, err = processInet(path, t, inodes, pid)


### PR DESCRIPTION
Support dumping the sockets for nested namespaces.

Previously only sockets in the root network namespace would be dumped. Now, if the PID is nonzero, attempt to dump the sockets associated with the network namespace of the PID. This may be the same if the PID is in the root network namespace, or may be different if it uses a different network namespace.