### PR TITLE
SReclaimable should be summed to Cached Memory

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -44,7 +44,7 @@ type VirtualMemoryStat struct {
 
 	// FreeBSD specific numbers:
 	// https://reviews.freebsd.org/D8467
-	Laundry  uint64 `json:"laundry"`
+	Laundry uint64 `json:"laundry"`
 
 	// Linux specific numbers
 	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
@@ -57,6 +57,7 @@ type VirtualMemoryStat struct {
 	WritebackTmp   uint64 `json:"writebacktmp"`
 	Shared         uint64 `json:"shared"`
 	Slab           uint64 `json:"slab"`
+	SReclaimable   uint64 `json:"sreclaimable"`
 	PageTables     uint64 `json:"pagetables"`
 	SwapCached     uint64 `json:"swapcached"`
 	CommitLimit    uint64 `json:"commitlimit"`

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -61,6 +61,8 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 			ret.Shared = t * 1024
 		case "Slab":
 			ret.Slab = t * 1024
+		case "SReclaimable":
+			ret.SReclaimable = t * 1024
 		case "PageTables":
 			ret.PageTables = t * 1024
 		case "SwapCached":
@@ -97,6 +99,9 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 			ret.HugePageSize = t * 1024
 		}
 	}
+
+	ret.Cached += ret.SReclaimable
+
 	if !memavail {
 		ret.Available = ret.Free + ret.Buffers + ret.Cached
 	}

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -71,7 +71,7 @@ func TestVirtualMemoryStat_String(t *testing.T) {
 		UsedPercent: 30.1,
 		Free:        40,
 	}
-	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"pagetables":0,"swapcached":0,"commitlimit":0,"committedas":0,"hightotal":0,"highfree":0,"lowtotal":0,"lowfree":0,"swaptotal":0,"swapfree":0,"mapped":0,"vmalloctotal":0,"vmallocused":0,"vmallocchunk":0,"hugepagestotal":0,"hugepagesfree":0,"hugepagesize":0}`
+	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeback":0,"dirty":0,"writebacktmp":0,"shared":0,"slab":0,"sreclaimable":0,"pagetables":0,"swapcached":0,"commitlimit":0,"committedas":0,"hightotal":0,"highfree":0,"lowtotal":0,"lowfree":0,"swaptotal":0,"swapfree":0,"mapped":0,"vmalloctotal":0,"vmallocused":0,"vmallocchunk":0,"hugepagestotal":0,"hugepagesfree":0,"hugepagesize":0}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("VirtualMemoryStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
psutil sums `SReclaimable` metric to `Cached` when calculating cached metric on linux. And Free command also  sums SReclaimable to Cached.
SReclaimable can be get back and reclaim if under memory pressure, that means SReclaimable can be consider a kind of cached memory.

* psuti https://github.com/giampaolo/psutil/issues?utf8=%E2%9C%93&q=is%3Aissue+slab
```python
 # "free" cmdline utility sums reclaimable to cached.
# Older versions of procps used to add slab memory instead.
# This got changed in:
# https://gitlab.com/procps-ng/procps/commit/
#     05d751c4f076a2f0118b914c5e51cfbb4762ad8e
cached += mems.get(b"SReclaimable:", 0)  # since kernel 2.6.19
```

* procps(free) https://gitlab.com/procps-ng/procps/commit/05d751c4f076a2f0118b914c5e51cfbb4762ad8e
