### PR TITLE
disk: trim the device mapper name.

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -433,7 +433,7 @@ func GetLabel(name string) string {
 	if err != nil {
 		return ""
 	} else {
-		return string(dmname)
+		return strings.TrimSpace(string(dmname))
 	}
 }
 


### PR DESCRIPTION
On Linux, while reading the name of a logical volume in the file with `ioutil.ReadFile`, the resulting name is suffixed with a `\n`.

This commit remove trailing spaces in the read device mapper name.

Tested on Ubuntu 18.10
