### PR TITLE
Skip non-integer meminfo values instead of error

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -20,7 +20,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	lines, _ := common.ReadLines(filename)
 	// flag if MemAvailable is in /proc/meminfo (kernel 3.14+)
 	memavail := false
-
+	
 	ret := &VirtualMemoryStat{}
 	for _, line := range lines {
 		fields := strings.Split(line, ":")
@@ -33,7 +33,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 
 		t, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
-			return ret, err
+			continue
 		}
 		switch key {
 		case "MemTotal":


### PR DESCRIPTION
On some systems(at least DD-WRT Linux) `/proc/meminfo` can contain values that are not an integer, but multiple integers split by space. 
It will be better to skip these values instead of returning an error

I don't know what exactly the meminfo key that has this value. I got this from users' error logs. But it was at the start of the file, so the other results were not populated.