### PR TITLE
Support Linux kernels without /proc/self/mountinfo (<2.6.26)

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -226,12 +226,13 @@ func Partitions(all bool) ([]PartitionStat, error) {
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
 	filename := common.HostProc("self/mountinfo")
 	lines, err := common.ReadLines(filename)
+	UseMounts := false
 	if err != nil {
-		UseMounts := true
+		UseMounts = true
 	}
 
 	//if kernel not support self/mountinfo
-	if UseMounts {
+	if UseMounts == true {
 		filename := common.HostProc("self/mounts")
 		lines, err := common.ReadLines(filename)
 		if err != nil {
@@ -252,7 +253,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		// (1) (2) (3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
 
 		// split the mountinfo line by the separator hyphen
-		if UseMounts {
+		if UseMounts == true {
 			fields := strings.Fields(line)
 
 			d := PartitionStat{
@@ -284,12 +285,13 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			}
 		}
 
-		if UseMounts {
-			if all == false {
-				if d.Device == "none" || !common.StringsHas(fs, d.Fstype) {
-					continue
-				}
+		if all == false {
+			if d.Device == "none" || !common.StringsHas(fs, d.Fstype) {
+				continue
 			}
+		}
+
+		if UseMounts == true {
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number
 			if d.Device == "/dev/root" {

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -229,12 +229,12 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	filename := common.HostProc("self/mountinfo")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
+		if err != err.(*os.PathError) {
+			return nil, err
+		}
+		//if kernel not support self/mountinfo
 		useMounts = true
-	}
-
-	//if kernel not support self/mountinfo
-	if useMounts {
-		filename := common.HostProc("self/mounts")
+		filename = common.HostProc("self/mounts")
 		lines, err = common.ReadLines(filename)
 		if err != nil {
 			return nil, err
@@ -248,9 +248,8 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 
 	ret := make([]PartitionStat, 0, len(lines))
 
-	var d PartitionStat
-
 	for _, line := range lines {
+		var d PartitionStat
 		// a line of self/mountinfo has the following structure:
 		// 36  35  98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
 		// (1) (2) (3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -224,16 +224,16 @@ func Partitions(all bool) ([]PartitionStat, error) {
 }
 
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
-	UseMounts := false
+	useMounts := false
 
 	filename := common.HostProc("self/mountinfo")
 	lines, err := common.ReadLines(filename)
 	if err != nil {
-		UseMounts = true
+		useMounts = true
 	}
 
 	//if kernel not support self/mountinfo
-	if UseMounts == true {
+	if useMounts {
 		filename := common.HostProc("self/mounts")
 		lines, err = common.ReadLines(filename)
 		if err != nil {
@@ -256,7 +256,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		// (1) (2) (3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
 
 		// split the mountinfo line by the separator hyphen
-		if UseMounts == true {
+		if useMounts {
 			fields := strings.Fields(line)
 
 			d = PartitionStat{
@@ -266,7 +266,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 				Opts:       fields[3],
 			}
 
-			if all == false {
+			if !all {
 				if d.Device == "none" || !common.StringsHas(fs, d.Fstype) {
 					continue
 				}
@@ -293,7 +293,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 				Opts:       mountOpts,
 			}
 
-			if all == false {
+			if !all {
 				if d.Device == "none" || !common.StringsHas(fs, d.Fstype) {
 					continue
 				}


### PR DESCRIPTION
if /proc/self/mountinfo not found, then use /proc/self/mounts