### PR TITLE
[cpu][linux] Add support for logical arg in Counts #640 #628

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -63,12 +62,9 @@ func init() {
 	lastCPUPercent.Unlock()
 }
 
+// Counts returns the number of physical or logical cores in the system
 func Counts(logical bool) (int, error) {
 	return CountsWithContext(context.Background(), logical)
-}
-
-func CountsWithContext(ctx context.Context, logical bool) (int, error) {
-	return runtime.NumCPU(), nil
 }
 
 func (c TimesStat) String() string {

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -4,6 +4,7 @@ package cpu
 
 import (
 	"context"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -84,4 +85,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }

--- a/cpu/cpu_fallback.go
+++ b/cpu/cpu_fallback.go
@@ -4,6 +4,7 @@ package cpu
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -22,4 +23,8 @@ func Info() ([]InfoStat, error) {
 
 func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	return []InfoStat{}, common.ErrNotImplementedError
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }

--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -165,4 +166,8 @@ func parseDmesgBoot(fileName string) (InfoStat, int, error) {
 	}
 
 	return c, cpuNum, nil
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -304,10 +303,8 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 			if err != nil {
 				return 0, err
 			}
-			re := regexp.MustCompile(`cpu\d`)
 			for _, line := range lines {
-				line = strings.Split(line, " ")[0]
-				if re.MatchString(line) {
+				if len(line) >= 4 && strings.HasPrefix(line, "cpu") && '0' <= line[3] && line[3] <= '9' { // `^cpu\d` regexp matching
 					ret++
 				}
 			}
@@ -342,7 +339,6 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 		if fields[0] == "physical id" || fields[0] == "cpu cores" {
 			val, err := strconv.Atoi(strings.TrimSpace(fields[1]))
 			if err != nil {
-				fmt.Println(err)
 				continue
 			}
 			currentInfo[fields[0]] = val

--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -144,4 +145,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	}
 
 	return append(ret, c), nil
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -195,4 +196,8 @@ func parseProcessorInfo(cmdOutput string) ([]InfoStat, error) {
 		}
 	}
 	return result, nil
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -5,6 +5,7 @@ package cpu
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
@@ -198,4 +199,8 @@ func perfInfo() ([]win32_SystemProcessorPerformanceInformation, error) {
 	resultBuffer = resultBuffer[:numReturnedElements]
 
 	return resultBuffer, nil
+}
+
+func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+	return runtime.NumCPU(), nil
 }


### PR DESCRIPTION
* move cpu.Counts to OS-specific files
* implement logical arg in cpu.Counts according to python psutil on Linux

Tested OK on Debian 9 x64