### PR TITLE
add bedrock linux support 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.9
-    working_directory: /home/circleci/go/src/github.com/shirou/gopsutil
+    working_directory: /home/circleci/go/src/github.com/superwhiskers/gopsutil
     environment:
       GOPATH: /home/circleci/go
     steps:

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ gopsutil: psutil for golang
 .. image:: https://coveralls.io/repos/shirou/gopsutil/badge.svg?branch=master
         :target: https://coveralls.io/r/shirou/gopsutil?branch=master
 
-.. image:: https://godoc.org/github.com/shirou/gopsutil?status.svg
-        :target: http://godoc.org/github.com/shirou/gopsutil
+.. image:: https://godoc.org/github.com/superwhiskers/gopsutil?status.svg
+        :target: http://godoc.org/github.com/superwhiskers/gopsutil
 
 This is a port of psutil (https://github.com/giampaolo/psutil). The challenge is porting all
 psutil functions on some architectures.
@@ -61,7 +61,7 @@ Note: gopsutil v2 breaks compatibility. If you want to stay with compatibility, 
    import (
        "fmt"
 
-       "github.com/shirou/gopsutil/mem"
+       "github.com/superwhiskers/gopsutil/mem"
    )
 
    func main() {
@@ -92,7 +92,7 @@ You can set an alternative location to :code:`/var` by setting the :code:`HOST_V
 Documentation
 ------------------------
 
-see http://godoc.org/github.com/shirou/gopsutil
+see http://godoc.org/github.com/superwhiskers/gopsutil
 
 Requirements
 -----------------

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // TimesStat contains the amounts of time the CPU has spent performing different

--- a/cpu/cpu_darwin_nocgo.go
+++ b/cpu/cpu_darwin_nocgo.go
@@ -3,7 +3,7 @@
 
 package cpu
 
-import "github.com/shirou/gopsutil/internal/common"
+import "github.com/superwhiskers/gopsutil/internal/common"
 
 func perCPUTimes() ([]TimesStat, error) {
 	return []TimesStat{}, common.ErrNotImplementedError

--- a/cpu/cpu_fallback.go
+++ b/cpu/cpu_fallback.go
@@ -5,7 +5,7 @@ package cpu
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Times(percpu bool) ([]TimesStat, error) {

--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/cpu/cpu_freebsd_test.go
+++ b/cpu/cpu_freebsd_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func TestParseDmesgBoot(t *testing.T) {

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var CPUTick = float64(100)

--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var ClocksPerSec = float64(128)

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -8,7 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/windows"
 )
 

--- a/disk/disk.go
+++ b/disk/disk.go
@@ -3,7 +3,7 @@ package disk
 import (
 	"encoding/json"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var invoke common.Invoker = common.Invoke{}

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/disk/disk_darwin_cgo.go
+++ b/disk/disk_darwin_cgo.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func IOCounters(names ...string) (map[string]IOCountersStat, error) {

--- a/disk/disk_darwin_nocgo.go
+++ b/disk/disk_darwin_nocgo.go
@@ -6,7 +6,7 @@ package disk
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func IOCounters(names ...string) (map[string]IOCountersStat, error) {

--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -5,7 +5,7 @@ package disk
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func IOCounters(names ...string) (map[string]IOCountersStat, error) {

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -12,7 +12,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Partitions(all bool) ([]PartitionStat, error) {

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -14,7 +14,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 const (

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -27,14 +27,14 @@ var (
 	// A blacklist of read-only virtual filesystems.  Writable filesystems are of
 	// operational concern and must not be included in this list.
 	fsTypeBlacklist = map[string]struct{}{
-		"ctfs":   struct{}{},
-		"dev":    struct{}{},
-		"fd":     struct{}{},
-		"lofs":   struct{}{},
-		"lxproc": struct{}{},
-		"mntfs":  struct{}{},
-		"objfs":  struct{}{},
-		"proc":   struct{}{},
+		"ctfs":   {},
+		"dev":    {},
+		"fd":     {},
+		"lofs":   {},
+		"lxproc": {},
+		"mntfs":  {},
+		"objfs":  {},
+		"proc":   {},
 	}
 )
 

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -51,7 +51,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 		ret.UsedPercent = 0
 	} else {
 		// We don't use ret.Total to calculate percent.
-		// see https://github.com/shirou/gopsutil/issues/562
+		// see https://github.com/superwhiskers/gopsutil/issues/562
 		ret.UsedPercent = (float64(ret.Used) / float64(ret.Used+ret.Free)) * 100.0
 	}
 

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/windows"
 )
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var ErrDockerNotAvailable = errors.New("docker not available")

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	cpu "github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
+	cpu "github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // GetDockerStat returns a list of Docker basic stats.

--- a/docker/docker_notlinux.go
+++ b/docker/docker_notlinux.go
@@ -5,8 +5,8 @@ package docker
 import (
 	"context"
 
-	cpu "github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
+	cpu "github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // GetDockerStat returns a list of Docker basic stats.

--- a/host/host.go
+++ b/host/host.go
@@ -3,7 +3,7 @@ package host
 import (
 	"encoding/json"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var invoke common.Invoker = common.Invoke{}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -16,8 +16,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/process"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/process"
 	"golang.org/x/sys/unix"
 )
 

--- a/host/host_fallback.go
+++ b/host/host_fallback.go
@@ -5,7 +5,7 @@ package host
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Info() (*InfoStat, error) {

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -15,8 +15,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/process"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/process"
 	"golang.org/x/sys/unix"
 )
 

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -247,8 +247,8 @@ func getOSRelease() (platform string, version string, err error) {
 		switch field[0] {
 		case "ID": // use ID for lowercase
 			platform = field[1]
-		case "VERSION":
-			version = field[1]
+		case "VERSION", "VERISON":
+			version = strings.Trim(field[1], "\"")
 		}
 	}
 	return platform, version, nil
@@ -318,10 +318,10 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	if err != nil {
 		lsb = &LSB{}
 	}
-	
-	platf, vers, err := getOSRelease()
+
+	_, vers, err := getOSRelease()
 	if err != nil {
-		platf, vers = "", ""
+		vers = ""
 	}
 
 	if common.PathExists(common.HostEtc("oracle-release")) {
@@ -445,7 +445,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	case "bedrock":
 		family = "bedrock"
 	default:
-		family = "unknown"	
+		family = "unknown"
 	}
 
 	return platform, family, version, nil

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -318,6 +318,11 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	if err != nil {
 		lsb = &LSB{}
 	}
+	
+	platf, vers, err := getOSRelease()
+	if err != nil {
+		platf, vers = "", ""
+	}
 
 	if common.PathExists(common.HostEtc("oracle-release")) {
 		platform = "oracle"
@@ -356,6 +361,9 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 				version = contents[0]
 			}
 		}
+	} else if common.PathExists(common.HostEtc("bedrock-release")) {
+		platform = "bedrock"
+		version = vers
 	} else if common.PathExists(common.HostEtc("redhat-release")) {
 		contents, err := common.ReadLines(common.HostEtc("redhat-release"))
 		if err == nil {
@@ -434,6 +442,10 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "alpine"
 	case "coreos":
 		family = "coreos"
+	case "bedrock":
+		family = "bedrock"
+	default:
+		family = "unknown"	
 	}
 
 	return platform, family, version, nil

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -18,7 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 type LSB struct {

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -14,8 +14,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/process"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/process"
 	"golang.org/x/sys/unix"
 )
 

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Info() (*InfoStat, error) {

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -15,8 +15,8 @@ import (
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-	"github.com/shirou/gopsutil/internal/common"
-	process "github.com/shirou/gopsutil/process"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	process "github.com/superwhiskers/gopsutil/process"
 	"golang.org/x/sys/windows"
 )
 
@@ -102,7 +102,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 }
 
 func getMachineGuid() (string, error) {
-	// there has been reports of issues on 32bit using golang.org/x/sys/windows/registry, see https://github.com/shirou/gopsutil/pull/312#issuecomment-277422612
+	// there has been reports of issues on 32bit using golang.org/x/sys/windows/registry, see https://github.com/superwhiskers/gopsutil/pull/312#issuecomment-277422612
 	// for rationale of using windows.RegOpenKeyEx/RegQueryValueEx instead of registry.OpenKey/GetStringValue
 	var h windows.Handle
 	err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, windows.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &h)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -301,22 +301,26 @@ func GetEnv(key string, dfault string, combineWith ...string) string {
 	switch len(combineWith) {
 	case 0:
 		return value
+	case 1:
+		return filepath.Join(value, combineWith[0])
 	default:
-		return filepath.Join(value, combineWith...)
+		all := make([]string, len(combineWith)+1)
+		all[0] = value
+		copy(all[1:], combineWith)
+		return filepath.Join(all...)
 	}
-	panic("invalid switch case")
 }
 
 //InclusionaryPath retrieves the proper path for a file, resepecting a Bedrock Linux install with the provided environment variables over all else
 func InclusionaryPath(key string, dfault string, fpath string) string {
-	if os.Getenv(key) !== "" {
-		if PathExists(filepath.Join("/bedrock", dfault, filepath)) {
-			return filepath.Join("/bedrock", dfault, filepath)
+	if os.Getenv(key) == "" {
+		if PathExists(filepath.Join("/bedrock", dfault, fpath)) {
+			return filepath.Join("/bedrock", dfault, fpath)
 		} else {
-			return filepath.Join(dfault, filepath)
+			return filepath.Join(dfault, fpath)
 		}
 	} else {
-		return GetEnv(key, "", filepath)
+		return GetEnv(key, "", fpath)
 	}
 }
 
@@ -329,15 +333,15 @@ func HostSys(combineWith ...string) string {
 }
 
 func HostEtc(combineWith ...string) string {
-	return InclusionaryPath("HOST_ETC", "/etc", combineWith...)
+	return InclusionaryPath("HOST_ETC", "/etc", filepath.Join(combineWith...))
 }
 
 func HostVar(combineWith ...string) string {
-	return InclusionaryPath("HOST_VAR", "/var", combineWith...)
+	return InclusionaryPath("HOST_VAR", "/var", filepath.Join(combineWith...))
 }
 
 func HostRun(combineWith ...string) string {
-	return InclusionaryPath("HOST_RUN", "/run", combineWith...)
+	return InclusionaryPath("HOST_RUN", "/run", filepath.Join(combineWith...))
 }
 
 // https://gist.github.com/kylelemons/1525278

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -301,15 +301,23 @@ func GetEnv(key string, dfault string, combineWith ...string) string {
 	switch len(combineWith) {
 	case 0:
 		return value
-	case 1:
-		return filepath.Join(value, combineWith[0])
 	default:
-		all := make([]string, len(combineWith)+1)
-		all[0] = value
-		copy(all[1:], combineWith)
-		return filepath.Join(all...)
+		return filepath.Join(value, combineWith...)
 	}
 	panic("invalid switch case")
+}
+
+//InclusionaryPath retrieves the proper path for a file, resepecting a Bedrock Linux install with the provided environment variables over all else
+func InclusionaryPath(key string, dfault string, fpath string) string {
+	if os.Getenv(key) !== "" {
+		if PathExists(filepath.Join("/bedrock", dfault, filepath)) {
+			return filepath.Join("/bedrock", dfault, filepath)
+		} else {
+			return filepath.Join(dfault, filepath)
+		}
+	} else {
+		return GetEnv(key, "", filepath)
+	}
 }
 
 func HostProc(combineWith ...string) string {
@@ -321,15 +329,15 @@ func HostSys(combineWith ...string) string {
 }
 
 func HostEtc(combineWith ...string) string {
-	return GetEnv("HOST_ETC", "/etc", combineWith...)
+	return InclusionaryPath("HOST_ETC", "/etc", combineWith...)
 }
 
 func HostVar(combineWith ...string) string {
-	return GetEnv("HOST_VAR", "/var", combineWith...)
+	return InclusionaryPath("HOST_VAR", "/var", combineWith...)
 }
 
 func HostRun(combineWith ...string) string {
-	return GetEnv("HOST_RUN", "/run", combineWith...)
+	return InclusionaryPath("HOST_RUN", "/run", combineWith...)
 }
 
 // https://gist.github.com/kylelemons/1525278

--- a/load/load.go
+++ b/load/load.go
@@ -3,7 +3,7 @@ package load
 import (
 	"encoding/json"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var invoke common.Invoker = common.Invoke{}

--- a/load/load_darwin.go
+++ b/load/load_darwin.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Avg() (*AvgStat, error) {

--- a/load/load_fallback.go
+++ b/load/load_fallback.go
@@ -5,7 +5,7 @@ package load
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Avg() (*AvgStat, error) {

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Avg() (*AvgStat, error) {

--- a/load/load_windows.go
+++ b/load/load_windows.go
@@ -5,7 +5,7 @@ package load
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func Avg() (*AvgStat, error) {

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -3,7 +3,7 @@ package mem
 import (
 	"encoding/json"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var invoke common.Invoker = common.Invoke{}

--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/mem/mem_fallback.go
+++ b/mem/mem_fallback.go
@@ -5,7 +5,7 @@ package mem
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func VirtualMemory() (*VirtualMemoryStat, error) {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
 )
 

--- a/mem/mem_openbsd.go
+++ b/mem/mem_openbsd.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func GetPageSize() (uint64, error) {

--- a/mem/mem_solaris.go
+++ b/mem/mem_solaris.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // VirtualMemory for Solaris is a minimal implementation which only returns

--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/windows"
 )
 

--- a/net/net.go
+++ b/net/net.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var invoke common.Invoker = common.Invoke{}

--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -5,7 +5,7 @@ package net
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func IOCounters(pernic bool) ([]IOCountersStat, error) {

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func IOCounters(pernic bool) ([]IOCountersStat, error) {

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // NetIOCounters returnes network I/O statistics for every network
@@ -665,7 +665,7 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 	// Read the contents of the /proc file with a single read sys call.
 	// This minimizes duplicates in the returned connections
 	// For more info:
-	// https://github.com/shirou/gopsutil/pull/361
+	// https://github.com/superwhiskers/gopsutil/pull/361
 	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -726,7 +726,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 	// Read the contents of the /proc file with a single read sys call.
 	// This minimizes duplicates in the returned connections
 	// For more info:
-	// https://github.com/shirou/gopsutil/pull/361
+	// https://github.com/superwhiskers/gopsutil/pull/361
 	contents, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -20,10 +20,10 @@ func TestIOCountersByFileParsing(t *testing.T) {
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
 
 	cases := [4][2]string{
-		[2]string{"eth0:   ", "eth1:   "},
-		[2]string{"eth0:0:   ", "eth1:0:   "},
-		[2]string{"eth0:", "eth1:"},
-		[2]string{"eth0:0:", "eth1:0:"},
+		{"eth0:   ", "eth1:   "},
+		{"eth0:0:   ", "eth1:0:   "},
+		{"eth0:", "eth1:"},
+		{"eth0:0:", "eth1:0:"},
 	}
 	for _, testCase := range cases {
 		err = tmpfile.Truncate(0)

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 var portMatch = regexp.MustCompile(`(.*)\.(\d+)$`)

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 func TestAddrString(t *testing.T) {

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 )
 
 // Return a list of network connections opened.

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"golang.org/x/sys/windows"
 )
 

--- a/process/process.go
+++ b/process/process.go
@@ -7,9 +7,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/mem"
+	"github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/mem"
 )
 
 var (

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -13,9 +13,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/net"
+	"github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/net"
 	"golang.org/x/sys/unix"
 )
 
@@ -245,7 +245,7 @@ func (p *Process) Foreground() (bool, error) {
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
-	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	// see https://github.com/superwhiskers/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	ps, err := exec.LookPath("ps")
 	if err != nil {

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"syscall"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/net"
+	"github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/net"
 )
 
 type MemoryMapsStat struct {

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	cpu "github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	net "github.com/shirou/gopsutil/net"
+	cpu "github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	net "github.com/superwhiskers/gopsutil/net"
 	"golang.org/x/sys/unix"
 )
 
@@ -176,7 +176,7 @@ func (p *Process) Foreground() (bool, error) {
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
-	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	// see https://github.com/superwhiskers/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	ps, err := exec.LookPath("ps")
 	if err != nil {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -15,10 +15,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/internal/common"
-	"github.com/shirou/gopsutil/net"
+	"github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/host"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/net"
 	"golang.org/x/sys/unix"
 )
 
@@ -205,7 +205,7 @@ func (p *Process) Foreground() (bool, error) {
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
-	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	// see https://github.com/superwhiskers/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "stat")
 	contents, err := ioutil.ReadFile(statPath)

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"unsafe"
 
-	cpu "github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	mem "github.com/shirou/gopsutil/mem"
-	net "github.com/shirou/gopsutil/net"
+	cpu "github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	mem "github.com/superwhiskers/gopsutil/mem"
+	net "github.com/superwhiskers/gopsutil/net"
 	"golang.org/x/sys/unix"
 )
 
@@ -169,7 +169,7 @@ func (p *Process) Foreground() (bool, error) {
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
-	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
+	// see https://github.com/superwhiskers/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	ps, err := exec.LookPath("ps")
 	if err != nil {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shirou/gopsutil/internal/common"
+	"github.com/superwhiskers/gopsutil/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -12,9 +12,9 @@ import (
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
-	cpu "github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/internal/common"
-	net "github.com/shirou/gopsutil/net"
+	cpu "github.com/superwhiskers/gopsutil/cpu"
+	"github.com/superwhiskers/gopsutil/internal/common"
+	net "github.com/superwhiskers/gopsutil/net"
 	"github.com/shirou/w32"
 	"golang.org/x/sys/windows"
 )


### PR DESCRIPTION
on [bedrock linux](https://bedrocklinux.org/) installs, gopsutil improperly detects the operating system as the operating system of the strata the program is being run from. this pull request adds in another utility function that detects the `/bedrock` folder at the root of the system and if it finds it, it changes the files being read from and properly detects the operating system as being bedrock linux