### PR TITLE
[Darwin][CPU] retrieve a cpu count depends on an boolean argument

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -88,5 +88,18 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 }
 
 func CountsWithContext(ctx context.Context, logical bool) (int, error) {
-	return runtime.NumCPU(), nil
+	var cpuArgument string
+	if logical {
+		cpuArgument = "hw.logicalcpu"
+	} else {
+		cpuArgument = "hw.physicalcpu"
+	}
+
+	count, err := unix.SysctlUint32(cpuArgument)
+
+	if err != nil {
+		return runtime.NumCPU(), nil
+	}
+
+	return int(count), nil
 }

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -4,7 +4,6 @@ package cpu
 
 import (
 	"context"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -96,9 +95,8 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 	}
 
 	count, err := unix.SysctlUint32(cpuArgument)
-
 	if err != nil {
-		return runtime.NumCPU(), nil
+		return 0, err
 	}
 
 	return int(count), nil


### PR DESCRIPTION
Related to #640, I've implemented darwin cpu count logic based on @Lomanic 's [works](https://github.com/shirou/gopsutil/pull/644).