### PR TITLE
[Darwin][process]Add hour handling in convertCPUTimes function

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -389,12 +389,31 @@ func convertCPUTimes(s string) (ret float64, err error) {
 	var _tmp string
 	if strings.Contains(s, ":") {
 		_t := strings.Split(s, ":")
-		hour, err := strconv.Atoi(_t[0])
-		if err != nil {
-			return ret, err
-		}
-		t += hour * 60 * 100
-		_tmp = _t[1]
+		if len(_t) > 3 {
+            return ret, err
+        } else if len(_t) == 3 {
+            hour, err := strconv.Atoi(_t[0])
+            if err != nil {
+                return ret, err
+            }
+            t += hour * 60 * 60 * ClockTicks
+
+            mins, err := strconv.Atoi(_t[1])
+            if err != nil {
+                return ret, err
+            }
+            t += mins * 60 * ClockTicks
+            _tmp = _t[2]
+        } else if len(_t) == 2 {
+            mins, err := strconv.Atoi(_t[0])
+            if err != nil {
+                return ret, err
+            }
+            t += mins * 60 * ClockTicks
+            _tmp = _t[1]
+        } else {
+            _tmp = s
+        }
 	} else {
 		_tmp = s
 	}
@@ -404,7 +423,7 @@ func convertCPUTimes(s string) (ret float64, err error) {
 		return ret, err
 	}
 	h, err := strconv.Atoi(_t[0])
-	t += h * 100
+	t += h * ClockTicks
 	h, err = strconv.Atoi(_t[1])
 	t += h
 	return float64(t) / ClockTicks, nil

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -390,30 +390,30 @@ func convertCPUTimes(s string) (ret float64, err error) {
 	if strings.Contains(s, ":") {
 		_t := strings.Split(s, ":")
 		if len(_t) > 3 {
-            return ret, err
-        } else if len(_t) == 3 {
-            hour, err := strconv.Atoi(_t[0])
-            if err != nil {
-                return ret, err
-            }
-            t += hour * 60 * 60 * ClockTicks
+			return ret, err
+		} else if len(_t) == 3 {
+			hour, err := strconv.Atoi(_t[0])
+			if err != nil {
+				return ret, err
+			}
+			t += hour * 60 * 60 * ClockTicks
 
-            mins, err := strconv.Atoi(_t[1])
-            if err != nil {
-                return ret, err
-            }
-            t += mins * 60 * ClockTicks
-            _tmp = _t[2]
-        } else if len(_t) == 2 {
-            mins, err := strconv.Atoi(_t[0])
-            if err != nil {
-                return ret, err
-            }
-            t += mins * 60 * ClockTicks
-            _tmp = _t[1]
-        } else {
-            _tmp = s
-        }
+			mins, err := strconv.Atoi(_t[1])
+			if err != nil {
+				return ret, err
+			}
+			t += mins * 60 * ClockTicks
+			_tmp = _t[2]
+		} else if len(_t) == 2 {
+			mins, err := strconv.Atoi(_t[0])
+			if err != nil {
+				return ret, err
+			}
+			t += mins * 60 * ClockTicks
+			_tmp = _t[1]
+		} else {
+			_tmp = s
+		}
 	} else {
 		_tmp = s
 	}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -389,9 +389,8 @@ func convertCPUTimes(s string) (ret float64, err error) {
 	var _tmp string
 	if strings.Contains(s, ":") {
 		_t := strings.Split(s, ":")
-		if len(_t) > 3 {
-			return ret, err
-		} else if len(_t) == 3 {
+		switch len(_t) {
+		case 3:
 			hour, err := strconv.Atoi(_t[0])
 			if err != nil {
 				return ret, err
@@ -404,15 +403,17 @@ func convertCPUTimes(s string) (ret float64, err error) {
 			}
 			t += mins * 60 * ClockTicks
 			_tmp = _t[2]
-		} else if len(_t) == 2 {
+		case 2:
 			mins, err := strconv.Atoi(_t[0])
 			if err != nil {
 				return ret, err
 			}
 			t += mins * 60 * ClockTicks
 			_tmp = _t[1]
-		} else {
+		case 1, 0:
 			_tmp = s
+		default:
+			return ret, err
 		}
 	} else {
 		_tmp = s

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -413,7 +413,7 @@ func convertCPUTimes(s string) (ret float64, err error) {
 		case 1, 0:
 			_tmp = s
 		default:
-			return ret, err
+			return ret, fmt.Errorf("wrong cpu time string")
 		}
 	} else {
 		_tmp = s


### PR DESCRIPTION
Address #654 

This commit add hour handling in convertCPUTimes function.

The time string usually comes from macOS command line:
ps -a -o stime,utime -p <pid>

which could contain hour string.