### PR TITLE
Fix for #665

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -635,6 +635,7 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 			return temperatures, err
 		}
 	}
+	var warns Warnings
 
 	// example directory
 	// device/           temp1_crit_alarm  temp2_crit_alarm  temp3_crit_alarm  temp4_crit_alarm  temp5_crit_alarm  temp6_crit_alarm  temp7_crit_alarm
@@ -660,16 +661,19 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		// Get the name of the temperature you are reading
 		name, err := ioutil.ReadFile(filepath.Join(filepath.Dir(file), "name"))
 		if err != nil {
-			return temperatures, err
+			warns.Add(err)
+			continue
 		}
 
 		// Get the temperature reading
 		current, err := ioutil.ReadFile(file)
 		if err != nil {
-			return temperatures, err
+			warns.Add(err)
+			continue
 		}
 		temperature, err := strconv.ParseFloat(strings.TrimSpace(string(current)), 64)
 		if err != nil {
+			warns.Add(err)
 			continue
 		}
 
@@ -679,5 +683,5 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 			Temperature: temperature / 1000.0,
 		})
 	}
-	return temperatures, nil
+	return temperatures, warns.Reference()
 }

--- a/host/types.go
+++ b/host/types.go
@@ -1,0 +1,25 @@
+package host
+
+import (
+	"fmt"
+)
+
+type Warnings struct {
+    List []error
+}
+
+func (w *Warnings) Add(err error) {
+	w.List = append(w.List, err)
+}
+
+func (w *Warnings) Reference() error {
+	if len(w.List) > 0 {
+		return w
+	} else {
+		return nil
+	}
+}
+
+func (w *Warnings) Error() string {
+    return fmt.Sprintf("Number of warnings: %v", len(w.List))
+}


### PR DESCRIPTION
Remains backward compatible.

When encountering non-fatal errors SensorsTemperatures() returns the temperatures for all the sensor we could read successfully. In that case the custom error contains a list of all the non-fatal errors encountered.

Example usage:

	_, err := SensorsTemperatures()
	if err != nil {
		warns, ok := err.(*Warnings)
		if ok {
			fmt.Printf("%v\n", err)
			for i, w := range warns.List {
				fmt.Printf("Warning %v: %v\n", i+1, w)
			}
		} else {
			t.Errorf("%v", err)
		}
	}