### PR TITLE
Fix: use filename in exec.LookPath instead of full path

### DIFF
--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -26,7 +26,7 @@ var cpuTimesSize int
 var emptyTimes cpuTimes
 
 func init() {
-	getconf, err := exec.LookPath("/usr/bin/getconf")
+	getconf, err := exec.LookPath("getconf")
 	if err != nil {
 		return
 	}

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -16,7 +16,7 @@ import (
 var CPUTick = float64(100)
 
 func init() {
-	getconf, err := exec.LookPath("/usr/bin/getconf")
+	getconf, err := exec.LookPath("getconf")
 	if err != nil {
 		return
 	}

--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -37,7 +37,7 @@ var ClocksPerSec = float64(128)
 
 func init() {
 	func() {
-		getconf, err := exec.LookPath("/usr/bin/getconf")
+		getconf, err := exec.LookPath("getconf")
 		if err != nil {
 			return
 		}

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -17,7 +17,7 @@ import (
 var ClocksPerSec = float64(128)
 
 func init() {
-	getconf, err := exec.LookPath("/usr/bin/getconf")
+	getconf, err := exec.LookPath("getconf")
 	if err != nil {
 		return
 	}
@@ -44,7 +44,7 @@ func Info() ([]InfoStat, error) {
 }
 
 func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
-	psrInfo, err := exec.LookPath("/usr/sbin/psrinfo")
+	psrInfo, err := exec.LookPath("psrinfo")
 	if err != nil {
 		return nil, fmt.Errorf("cannot find psrinfo: %s", err)
 	}
@@ -53,7 +53,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 		return nil, fmt.Errorf("cannot execute psrinfo: %s", err)
 	}
 
-	isaInfo, err := exec.LookPath("/usr/bin/isainfo")
+	isaInfo, err := exec.LookPath("isainfo")
 	if err != nil {
 		return nil, fmt.Errorf("cannot find isainfo: %s", err)
 	}

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -279,7 +279,7 @@ func getLSB() (*LSB, error) {
 			}
 		}
 	} else if common.PathExists("/usr/bin/lsb_release") {
-		lsb_release, err := exec.LookPath("/usr/bin/lsb_release")
+		lsb_release, err := exec.LookPath("lsb_release")
 		if err != nil {
 			return ret, err
 		}

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -33,7 +33,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 	result.Hostname = hostname
 
 	// Parse versions from output of `uname(1)`
-	uname, err := exec.LookPath("/usr/bin/uname")
+	uname, err := exec.LookPath("uname")
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 	switch result.Platform {
 	case "SmartOS":
 		// If everything works, use the current zone ID as the HostID if present.
-		zonename, err := exec.LookPath("/usr/bin/zonename")
+		zonename, err := exec.LookPath("zonename")
 		if err == nil {
 			out, err := invoke.CommandWithContext(ctx, zonename)
 			if err == nil {
@@ -112,7 +112,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 	// this point there are no hardware facilities available.  This behavior
 	// matches that of other supported OSes.
 	if result.HostID == "" {
-		hostID, err := exec.LookPath("/usr/bin/hostid")
+		hostID, err := exec.LookPath("hostid")
 		if err == nil {
 			out, err := invoke.CommandWithContext(ctx, hostID)
 			if err == nil {
@@ -151,7 +151,7 @@ func BootTime() (uint64, error) {
 }
 
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
-	kstat, err := exec.LookPath("/usr/bin/kstat")
+	kstat, err := exec.LookPath("kstat")
 	if err != nil {
 		return 0, err
 	}
@@ -215,7 +215,7 @@ func KernelVersion() (string, error) {
 
 func KernelVersionWithContext(ctx context.Context) (string, error) {
 	// Parse versions from output of `uname(1)`
-	uname, err := exec.LookPath("/usr/bin/uname")
+	uname, err := exec.LookPath("uname")
 	if err != nil {
 		return "", err
 	}

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -13,7 +13,7 @@ import (
 )
 
 func DoSysctrlWithContext(ctx context.Context, mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("/usr/sbin/sysctl")
+	sysctl, err := exec.LookPath("sysctl")
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/common/common_freebsd.go
+++ b/internal/common/common_freebsd.go
@@ -28,7 +28,7 @@ func SysctlUint(mib string) (uint64, error) {
 }
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("/sbin/sysctl")
+	sysctl, err := exec.LookPath("sysctl")
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("/sbin/sysctl")
+	sysctl, err := exec.LookPath("sysctl")
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/common/common_openbsd.go
+++ b/internal/common/common_openbsd.go
@@ -12,7 +12,7 @@ import (
 )
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("/sbin/sysctl")
+	sysctl, err := exec.LookPath("sysctl")
 	if err != nil {
 		return []string{}, err
 	}

--- a/mem/mem_solaris.go
+++ b/mem/mem_solaris.go
@@ -52,7 +52,7 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 }
 
 func zoneName() (string, error) {
-	zonename, err := exec.LookPath("/usr/bin/zonename")
+	zonename, err := exec.LookPath("zonename")
 	if err != nil {
 		return "", err
 	}
@@ -69,7 +69,7 @@ func zoneName() (string, error) {
 var globalZoneMemoryCapacityMatch = regexp.MustCompile(`memory size: ([\d]+) Megabytes`)
 
 func globalZoneMemoryCapacity() (uint64, error) {
-	prtconf, err := exec.LookPath("/usr/sbin/prtconf")
+	prtconf, err := exec.LookPath("prtconf")
 	if err != nil {
 		return 0, err
 	}
@@ -96,7 +96,7 @@ func globalZoneMemoryCapacity() (uint64, error) {
 var kstatMatch = regexp.MustCompile(`([^\s]+)[\s]+([^\s]*)`)
 
 func nonGlobalZoneMemoryCapacity() (uint64, error) {
-	kstat, err := exec.LookPath("/usr/bin/kstat")
+	kstat, err := exec.LookPath("kstat")
 	if err != nil {
 		return 0, err
 	}

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -174,7 +174,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		retIndex int
 	)
 
-	netstat, err := exec.LookPath("/usr/sbin/netstat")
+	netstat, err := exec.LookPath("netstat")
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		}
 	} else {
 		// duplicated interface, list all interfaces
-		ifconfig, err := exec.LookPath("/sbin/ifconfig")
+		ifconfig, err := exec.LookPath("ifconfig")
 		if err != nil {
 			return nil, err
 		}

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -17,7 +17,7 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 }
 
 func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, error) {
-	netstat, err := exec.LookPath("/usr/bin/netstat")
+	netstat, err := exec.LookPath("netstat")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
exec.LookPath searches for the file in the $PATH, which mean giving it an absolute path is against it's own purpose.