### PR TITLE
Adds ConntrackStats (/proc/net/stat/nf_conntrack)

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -213,6 +213,12 @@ func ReadInts(filename string) ([]int64, error) {
 	return ret, nil
 }
 
+// Parse Hex to uint32 without error
+func HexToUint32(hex string) uint32 {
+	vv, _ := strconv.ParseUint(hex, 16, 32)
+	return uint32(vv)
+}
+
 // Parse to int32 without error
 func mustParseInt32(val string) int32 {
 	vv, _ := strconv.ParseInt(val, 10, 32)

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -51,6 +51,12 @@ func TestByteToString(t *testing.T) {
 	}
 }
 
+func TestHexToUint32(t *testing.T) {
+	if HexToUint32("FFFFFFFF") != 4294967295 {
+		t.Error("Could not convert")
+	}
+}
+
 func TestmustParseInt32(t *testing.T) {
 	ret := mustParseInt32("11111")
 	if ret != int32(11111) {

--- a/net/net.go
+++ b/net/net.go
@@ -70,6 +70,96 @@ type FilterStat struct {
 	ConnTrackMax   int64 `json:"conntrackMax"`
 }
 
+// ConntrackStat has conntrack summary info
+type ConntrackStat struct {
+	Entries       uint32 `json:"entries"`        // Number of entries in the conntrack table
+	Searched      uint32 `json:"searched"`       // Number of conntrack table lookups performed
+	Found         uint32 `json:"found"`          // Number of searched entries which were successful
+	New           uint32 `json:"new"`            // Number of entries added which were not expected before
+	Invalid       uint32 `json:"invalid"`        // Number of packets seen which can not be tracked
+	Ignore        uint32 `json:"ignore"`         // Packets seen which are already connected to an entry
+	Delete        uint32 `json:"delete"`         // Number of entries which were removed
+	DeleteList    uint32 `json:"delete_list"`    // Number of entries which were put to dying list
+	Insert        uint32 `json:"insert"`         // Number of entries inserted into the list
+	InsertFailed  uint32 `json:"insert_failed"`  // # insertion attempted but failed (same entry exists)
+	Drop          uint32 `json:"drop"`           // Number of packets dropped due to conntrack failure.
+	EarlyDrop     uint32 `json:"early_drop"`     // Dropped entries to make room for new ones, if maxsize reached
+	IcmpError     uint32 `json:"icmp_error"`     // Subset of invalid. Packets that can't be tracked d/t error
+	ExpectNew     uint32 `json:"expect_new"`     // Entries added after an expectation was already present
+	ExpectCreate  uint32 `json:"expect_create"`  // Expectations added
+	ExpectDelete  uint32 `json:"expect_delete"`  // Expectations deleted
+	SearchRestart uint32 `json:"search_restart"` // Conntrack table lookups restarted due to hashtable resizes
+}
+
+func NewConntrackStat(e uint32, s uint32, f uint32, n uint32, inv uint32, ign uint32, del uint32, dlst uint32, ins uint32, insfail uint32, drop uint32, edrop uint32, ie uint32, en uint32, ec uint32, ed uint32, sr uint32) *ConntrackStat {
+	return &ConntrackStat{
+		Entries:       e,
+		Searched:      s,
+		Found:         f,
+		New:           n,
+		Invalid:       inv,
+		Ignore:        ign,
+		Delete:        del,
+		DeleteList:    dlst,
+		Insert:        ins,
+		InsertFailed:  insfail,
+		Drop:          drop,
+		EarlyDrop:     edrop,
+		IcmpError:     ie,
+		ExpectNew:     en,
+		ExpectCreate:  ec,
+		ExpectDelete:  ed,
+		SearchRestart: sr,
+	}
+}
+
+type ConntrackStatList struct {
+	items []*ConntrackStat
+}
+
+func NewConntrackStatList() *ConntrackStatList {
+	return &ConntrackStatList{
+		items: []*ConntrackStat{},
+	}
+}
+
+func (l *ConntrackStatList) Append(c *ConntrackStat) {
+	l.items = append(l.items, c)
+}
+
+func (l *ConntrackStatList) Items() []ConntrackStat {
+	items := make([]ConntrackStat, len(l.items), len(l.items))
+	for i, el := range l.items {
+		items[i] = *el
+	}
+	return items
+}
+
+// Summary returns a single-element list with totals from all list items.
+func (l *ConntrackStatList) Summary() []ConntrackStat {
+	summary := NewConntrackStat(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	for _, cs := range l.items {
+		summary.Entries += cs.Entries
+		summary.Searched += cs.Searched
+		summary.Found += cs.Found
+		summary.New += cs.New
+		summary.Invalid += cs.Invalid
+		summary.Ignore += cs.Ignore
+		summary.Delete += cs.Delete
+		summary.DeleteList += cs.DeleteList
+		summary.Insert += cs.Insert
+		summary.InsertFailed += cs.InsertFailed
+		summary.Drop += cs.Drop
+		summary.EarlyDrop += cs.EarlyDrop
+		summary.IcmpError += cs.IcmpError
+		summary.ExpectNew += cs.ExpectNew
+		summary.ExpectCreate += cs.ExpectCreate
+		summary.ExpectDelete += cs.ExpectDelete
+		summary.SearchRestart += cs.SearchRestart
+	}
+	return []ConntrackStat{*summary}
+}
+
 var constMap = map[string]int{
 	"unix": syscall.AF_UNIX,
 	"TCP":  syscall.SOCK_STREAM,
@@ -104,6 +194,11 @@ func (n InterfaceStat) String() string {
 }
 
 func (n InterfaceAddr) String() string {
+	s, _ := json.Marshal(n)
+	return string(s)
+}
+
+func (n ConntrackStat) String() string {
 	s, _ := json.Marshal(n)
 	return string(s)
 }

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/shirou/gopsutil/internal/common"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -269,6 +270,14 @@ func FilterCounters() ([]FilterStat, error) {
 
 func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 	return nil, errors.New("NetFilterCounters not implemented for darwin")
+}
+
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return nil, common.ErrNotImplementedError
 }
 
 // NetProtoCounters returns network statistics for the entire system

--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -24,6 +24,14 @@ func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 	return []FilterStat{}, common.ErrNotImplementedError
 }
 
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
 func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
 	return ProtoCountersWithContext(context.Background(), protocols)
 }

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -112,6 +112,14 @@ func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 	return nil, errors.New("NetFilterCounters not implemented for freebsd")
 }
 
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return nil, errors.New("ConntrackStats not implemented for freebsd")
+}
+
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -18,6 +18,26 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
+const ( // Conntrack Column numbers
+	CT_ENTRIES = iota
+	CT_SEARCHED
+	CT_FOUND
+	CT_NEW
+	CT_INVALID
+	CT_IGNORE
+	CT_DELETE
+	CT_DELETE_LIST
+	CT_INSERT
+	CT_INSERT_FAILED
+	CT_DROP
+	CT_EARLY_DROP
+	CT_ICMP_ERROR
+	CT_EXPECT_NEW
+	CT_EXPECT_CREATE
+	CT_EXPECT_DELETE
+	CT_SEARCH_RESTART
+)
+
 // NetIOCounters returnes network I/O statistics for every network
 // interface installed on the system.  If pernic argument is false,
 // return only sum of all information (which name is 'all'). If true,
@@ -230,6 +250,58 @@ func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 
 	stats = append(stats, payload)
 	return stats, nil
+}
+
+// ConntrackStats returns more detailed info about the conntrack table
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+// ConntrackStatsWithContext returns more detailed info about the conntrack table
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return conntrackStatsFromFile(common.HostProc("net/stat/nf_conntrack"), percpu)
+}
+
+// conntrackStatsFromFile returns more detailed info about the conntrack table
+// from `filename`
+// If 'percpu' is false, the result will contain exactly one item with totals/summary
+func conntrackStatsFromFile(filename string, percpu bool) ([]ConntrackStat, error) {
+	lines, err := common.ReadLines(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	statlist := NewConntrackStatList()
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 17 && fields[0] != "entries" {
+			statlist.Append(NewConntrackStat(
+				common.HexToUint32(fields[CT_ENTRIES]),
+				common.HexToUint32(fields[CT_SEARCHED]),
+				common.HexToUint32(fields[CT_FOUND]),
+				common.HexToUint32(fields[CT_NEW]),
+				common.HexToUint32(fields[CT_INVALID]),
+				common.HexToUint32(fields[CT_IGNORE]),
+				common.HexToUint32(fields[CT_DELETE]),
+				common.HexToUint32(fields[CT_DELETE_LIST]),
+				common.HexToUint32(fields[CT_INSERT]),
+				common.HexToUint32(fields[CT_INSERT_FAILED]),
+				common.HexToUint32(fields[CT_DROP]),
+				common.HexToUint32(fields[CT_EARLY_DROP]),
+				common.HexToUint32(fields[CT_ICMP_ERROR]),
+				common.HexToUint32(fields[CT_EXPECT_NEW]),
+				common.HexToUint32(fields[CT_EXPECT_CREATE]),
+				common.HexToUint32(fields[CT_EXPECT_DELETE]),
+				common.HexToUint32(fields[CT_SEARCH_RESTART]),
+			))
+		}
+	}
+
+	if percpu {
+		return statlist.Items(), nil
+	}
+	return statlist.Summary(), nil
 }
 
 // http://students.mimuw.edu.pl/lxr/source/include/net/tcp_states.h

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -156,6 +156,14 @@ func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 	return nil, errors.New("NetFilterCounters not implemented for openbsd")
 }
 
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -206,6 +206,15 @@ func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
 	return nil, errors.New("NetFilterCounters not implemented for windows")
 }
 
+func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
+	return ConntrackStatsWithContext(context.Background(), percpu)
+}
+
+func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise
 // just the protocols in the list are returned.


### PR DESCRIPTION
Provides more in-depth info on the conntrack tables from `/proc/net/stat/nf_conntrack`

I was debating rolling it into the `FilterStat` struct, but opted to keep it separate for now, since it's a separate source of info. Happy to refactor

    per_cpu_results, err := net.ConntrackStats(true)
    if err != nil {
        log.Fatal(err)
    }

    for i, s := range per_cpu_results {
        fmt.Printf("CPU%d has %d insert_failed entries\n", i, s.InsertFailed)
    }

```
// ConntrackStat has conntrack summary info
type ConntrackStat struct {
        Entries       uint32 `json:"entries"`        // Number of entries in the conntrack table
        Searched      uint32 `json:"searched"`       // Number of conntrack table lookups performed
        Found         uint32 `json:"found"`          // Number of searched entries which were successful
        New           uint32 `json:"new"`            // Number of entries added which were not expected before
        Invalid       uint32 `json:"invalid"`        // Number of packets seen which can not be tracked
        Ignore        uint32 `json:"ignore"`         // Packets seen which are already connected to an entry
        Delete        uint32 `json:"delete"`         // Number of entries which were removed
        DeleteList    uint32 `json:"delete_list"`    // Number of entries which were put to dying list
        Insert        uint32 `json:"insert"`         // Number of entries inserted into the list
        InsertFailed  uint32 `json:"insert_failed"`  // # insertion attempted but failed (same entry exists)
        Drop          uint32 `json:"drop"`           // Number of packets dropped due to conntrack failure.
        EarlyDrop     uint32 `json:"early_drop"`     // Dropped entries to make room for new ones, if maxsize reached
        IcmpError     uint32 `json:"icmp_error"`     // Subset of invalid. Packets that can't be tracked d/t error
        ExpectNew     uint32 `json:"expect_new"`     // Entries added after an expectation was already present
        ExpectCreate  uint32 `json:"expect_create"`  // Expectations added
        ExpectDelete  uint32 `json:"expect_delete"`  // Expectations deleted
        SearchRestart uint32 `json:"search_restart"` // Conntrack table lookups restarted due to hashtable resizes
}
```