### PR TITLE
Tl/check for logical volumes

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -298,6 +298,14 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 				}
 			}
 
+			if strings.HasPrefix(d.Device, "/dev/mapper/") {
+				devpath, err := os.Readlink(d.Device)
+				if err != nil {
+					return nil, err
+				}
+				d.Device = "/dev/" + filepath.Base(devpath)
+			}
+
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number
 			if d.Device == "/dev/root" {


### PR DESCRIPTION
Adds logic when dealing with device-mapped volumes (ie: /dev/dm-0). Also because the device label is present, this can be mapped back to `/dev/mapper/[label]` for more processing if needed.

Here is a snippet of code that demonstrates with this fix you are now able to get devices that may have been setup using LVM: https://gist.github.com/tonylambiris/86c39693e214a926757c47fc0c9d03ba

Output:
```
➜ go run disk.go
INFO[0000] ([]disk.PartitionStat) (len=6 cap=41) {
 (disk.PartitionStat) {"device":"/dev/dm-4","mountpoint":"/","fstype":"btrfs","opts":"rw,noatime"},
 (disk.PartitionStat) {"device":"/dev/dm-3","mountpoint":"/boot","fstype":"ext4","opts":"rw,noatime"},
 (disk.PartitionStat) {"device":"/dev/nvme0n1p1","mountpoint":"/boot/efi","fstype":"vfat","opts":"rw,noatime"},
 (disk.PartitionStat) {"device":"/dev/dm-0","mountpoint":"/home","fstype":"btrfs","opts":"rw,noatime"},
 (disk.PartitionStat) {"device":"/dev/sdd1","mountpoint":"/run/media/tlambiris/T5","fstype":"ext4","opts":"rw,nosuid,nodev,relatime"},
 (disk.PartitionStat) {"device":"/dev/sdc2","mountpoint":"/run/media/tlambiris/FANTOM","fstype":"hfsplus","opts":"rw,nosuid,nodev,relatime"}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=4) "dm-4": (disk.IOCountersStat) {"readCount":79327,"mergedReadCount":0,"writeCount":226891,"mergedWriteCount":0,"readBytes":6419386880,"writeBytes":3975909376,"readTime":32746,"writeTime":841434,"iopsInProgress":0,"ioTime":125154,"weightedIO":874260,"name":"dm-4","serialNumber":"","label":"arch-root"}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=4) "dm-3": (disk.IOCountersStat) {"readCount":339,"mergedReadCount":0,"writeCount":11,"mergedWriteCount":0,"readBytes":4534272,"writeBytes":9216,"readTime":86,"writeTime":6,"iopsInProgress":0,"ioTime":94,"weightedIO":94,"name":"dm-3","serialNumber":"","label":"arch-boot"}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=9) "nvme0n1p1": (disk.IOCountersStat) {"readCount":1258,"mergedReadCount":0,"writeCount":2,"mergedWriteCount":0,"readBytes":6156288,"writeBytes":1024,"readTime":697,"writeTime":1,"iopsInProgress":0,"ioTime":90,"weightedIO":30,"name":"nvme0n1p1","serialNumber":"","label":""}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=4) "dm-0": (disk.IOCountersStat) {"readCount":321714,"mergedReadCount":0,"writeCount":429239,"mergedWriteCount":0,"readBytes":35064524800,"writeBytes":14717825024,"readTime":315148,"writeTime":749702,"iopsInProgress":0,"ioTime":475594,"weightedIO":1064930,"name":"dm-0","serialNumber":"","label":"data-home"}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=4) "sdd1": (disk.IOCountersStat) {"readCount":1185,"mergedReadCount":85,"writeCount":5,"mergedWriteCount":1,"readBytes":12510208,"writeBytes":24576,"readTime":510,"writeTime":24,"iopsInProgress":0,"ioTime":154,"weightedIO":17,"name":"sdd1","serialNumber":"","label":""}
} 
INFO[0000] (map[string]disk.IOCountersStat) (len=1) {
 (string) (len=4) "sdc2": (disk.IOCountersStat) {"readCount":22786,"mergedReadCount":0,"writeCount":0,"mergedWriteCount":0,"readBytes":96351232,"writeBytes":0,"readTime":6080,"writeTime":0,"iopsInProgress":0,"ioTime":6624,"weightedIO":1804,"name":"sdc2","serialNumber":"","label":""}
} 
```

Thanks!