### PR TITLE
use /proc/buc/pci/devices to identify a VM is a guest

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -566,6 +566,17 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 		}
 	}
 
+	filename = common.HostProc("bus/pci/devices")
+	if common.PathExists(filename) {
+		contents, err := common.ReadLines(filename)
+		if err == nil {
+			if common.StringsContains(contents, "virtio-pci") {
+				system = "kvm"
+				role = "guest"
+			}
+		}
+	}
+
 	filename = common.HostProc()
 	if common.PathExists(filepath.Join(filename, "bc", "0")) {
 		system = "openvz"

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -571,7 +571,6 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 		contents, err := common.ReadLines(filename)
 		if err == nil {
 			if common.StringsContains(contents, "virtio-pci") {
-				system = "kvm"
 				role = "guest"
 			}
 		}


### PR DESCRIPTION
I tested gopsutil on openstack VMs and Physical Machines. Current code will idenetify a VM with system is **kvm** and role is **host**. it should be guest

so, I use /proc/buc/pci/devices  to identify this machine is host or guest role