### PR TITLE
added sles to the suse platform family

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -421,7 +421,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "fedora"
 	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm":
 		family = "rhel"
-	case "suse", "opensuse":
+	case "suse", "opensuse", "sles":
 		family = "suse"
 	case "gentoo":
 		family = "gentoo"


### PR DESCRIPTION
Sles15 just have the os-release file. Since the function "getOSRelease" just return the ID attribute, in that case "sles", as a platform there is no matching in the method to get the platform family "PlatformInformationWithContext". Adding "sles" in the switch case will fix the gap.