### PR TITLE
Update host_darwin.go

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -189,6 +189,16 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 		pver = strings.ToLower(strings.TrimSpace(string(out)))
 	}
 
+	// check if the macos server version file exists
+	_, err := os.Stat("/System/Library/CoreServices/ServerVersion.plist")
+
+	// server file doesn't exist
+	if os.IsNotExist(err) {
+		family = "Standalone Workstation"
+	} else {
+		family = "Server"
+	}
+
 	return platform, family, pver, nil
 }
 

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -190,7 +190,7 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 	}
 
 	// check if the macos server version file exists
-	_, err := os.Stat("/System/Library/CoreServices/ServerVersion.plist")
+	_, err = os.Stat("/System/Library/CoreServices/ServerVersion.plist")
 
 	// server file doesn't exist
 	if os.IsNotExist(err) {


### PR DESCRIPTION
🍎This aims to fix #694 

The `/System/Library/CoreServices/ServerVersion.plist` file exists on macOS servers, but not on a workstation such as my laptop. The actual terminology is mostly borrowed from the [windows equivalent](https://github.com/shirou/gopsutil/blob/master/host/host_windows.go#L223) as @Lomanic suggested. In theory, this should make interpreting the results from the two platforms a bit more consistent.

> **Note:** The macOS server application can be installed on almost any macOS workstation to make it a server that can manage other apple devices.