### PR TITLE
Add support fo Solaris cpu times (idle, sys, user, iowait) in cpu_solaris

### DIFF
--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -1,7 +1,6 @@
 package cpu
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -59,7 +58,7 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 		return nil, fmt.Errorf("cannot execute kstat: %s", err)
 	}
 	re := regexp.MustCompile(`[:\s]+`)
-	for _, line := range strings.Split(bytes.NewBuffer(kstatSysOut).String(), "\n") {
+	for _, line := range strings.Split(string(kstatSysOut), "\n") {
 		fields := re.Split(line, -1)
 		if fields[0] != "cpu_stat" {
 			continue

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -54,12 +54,13 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 	kern := make(map[float64]float64)
 	iowt := make(map[float64]float64)
 	//swap := make(map[float64]float64)
-	kstatSysOut, err := invoke.CommandWithContext(ctx, kstatSys, "-C", "cpu_stat:*:*:/^idle$|^user$|^kernel$|^iowait$|^swap$/")
+	kstatSysOut, err := invoke.CommandWithContext(ctx, kstatSys, "-p", "cpu_stat:*:*:/^idle$|^user$|^kernel$|^iowait$|^swap$/")
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute kstat: %s", err)
 	}
+	re := regexp.MustCompile(`[:\s]+`)
 	for _, line := range strings.Split(bytes.NewBuffer(kstatSysOut).String(), "\n") {
-		fields := strings.Split(line, ":")
+		fields := re.Split(line, -1)
 		if fields[0] != "cpu_stat" {
 			continue
 		}


### PR DESCRIPTION
This is an attempt to extent cpu_solaris to support cpu time metrics.  I've tested vi Telegraf on Solaris 10, 11 and OpenIndiana.