### PR TITLE
trim quotes when reading from os-release

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -237,10 +237,20 @@ func GetOSRelease() (platform string, version string, err error) {
 		}
 		switch field[0] {
 		case "ID": // use ID for lowercase
-			platform = field[1]
+			platform = trimQuotes(field[1])
 		case "VERSION":
-			version = field[1]
+			version = trimQuotes(field[1])
 		}
 	}
 	return platform, version, nil
+}
+
+// Remove quotes of the source string
+func trimQuotes(s string) string {
+	if len(s) >= 2 {
+		if s[0] == '"' && s[len(s)-1] == '"' {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }


### PR DESCRIPTION
When reading OS-REALEASE is getting the strings for "platform" and ''version"  with quotes. See code here: https://github.com/shirou/gopsutil/blob/master/internal/common/common_linux.go#L228
This leads to that it doesn't match when getting the "platform family" in this switch case:
https://github.com/shirou/gopsutil/blob/master/host/host_linux.go#L338

This is a follow-up of the following PR #691