### PR TITLE
Fix the net.ConnectionsMax BUG

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"io"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -653,7 +654,7 @@ func getProcInodesAll(root string, max int) (map[string][]inodeMap, error) {
 		t, err := getProcInodes(root, pid, max)
 		if err != nil {
 			// skip if permission error or no longer exists
-			if os.IsPermission(err) || os.IsNotExist(err) {
+			if os.IsPermission(err) || os.IsNotExist(err) || err == io.EOF {
 				continue
 			}
 			return ret, err


### PR DESCRIPTION
`connectionsList, err := net.ConnectionsMax("tcp4", 1000)`
when you run net.ConnectionsMax,you will find some connection is not equal with the `netstat -lptn`