### PR TITLE
[process][windows] Fix #586 use win32 API in process.Exe() instead of slow WMI call

### DIFF
--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -4,6 +4,9 @@ package common
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
+	"syscall"
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
@@ -59,6 +62,8 @@ var (
 	PdhCollectQueryData          = ModPdh.NewProc("PdhCollectQueryData")
 	PdhGetFormattedCounterValue  = ModPdh.NewProc("PdhGetFormattedCounterValue")
 	PdhCloseQuery                = ModPdh.NewProc("PdhCloseQuery")
+
+	procQueryDosDeviceW = Modkernel32.NewProc("QueryDosDeviceW")
 )
 
 type FILETIME struct {
@@ -132,4 +137,24 @@ func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, con
 	case err := <-errChan:
 		return err
 	}
+}
+
+// Convert paths using native DOS format like:
+//   "\Device\HarddiskVolume1\Windows\systemew\file.txt"
+// into:
+//   "C:\Windows\systemew\file.txt"
+func ConvertDOSPath(p string) string {
+	rawDrive := strings.Join(strings.Split(p, `\`)[:3], `\`)
+
+	for d := 'A'; d <= 'Z'; d++ {
+		szDeviceName := string(d) + ":"
+		szTarget := make([]uint16, 512)
+		ret, _, _ := procQueryDosDeviceW.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(szDeviceName))),
+			uintptr(unsafe.Pointer(&szTarget[0])),
+			uintptr(len(szTarget)))
+		if ret != 0 && windows.UTF16ToString(szTarget[:]) == rawDrive {
+			return filepath.Join(szDeviceName, p[len(rawDrive):])
+		}
+	}
+	return p
 }


### PR DESCRIPTION
This is faster by a factor of 100.

References:
https://github.com/giampaolo/psutil/blob/5f4287d17fc6aa2643c4c6e3589c12abd0f1ded9/psutil/_pswindows.py#L221
https://github.com/giampaolo/psutil/blob/921870d54091f399cd2b129db19530cc486b5700/psutil/_psutil_windows.c#L1211
https://github.com/giampaolo/psutil/blob/921870d54091f399cd2b129db19530cc486b5700/psutil/_psutil_windows.c#L626