### PR TITLE
[cpu]: return 100 instead 1 if t1 are bigger than t2

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -111,7 +111,7 @@ func calculateBusy(t1, t2 TimesStat) float64 {
 		return 0
 	}
 	if t2All <= t1All {
-		return 1
+		return 100
 	}
 	return math.Min(100, math.Max(0, (t2Busy-t1Busy)/(t2All-t1All)*100))
 }


### PR DESCRIPTION
This PR fixes return value, reported from  [this comment
](https://github.com/shirou/gopsutil/pull/707/files#r296483944
)