### PR TITLE
[disk][openbsd] Use fallback for openBSD not on amd64

### DIFF
--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris
+// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris openbsd,!amd64
 
 package disk
 

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -1,4 +1,4 @@
-// +build openbsd
+// +build openbsd,amd64
 
 package disk
 


### PR DESCRIPTION
Currently using this module and building on OpenBSD on any other arch than amd64 results in a build failure. It would be nicer if it used the fallback as unsupported OS', which is what this PR aims to do.