### PR TITLE
Revert "[disk][openbsd] Use fallback for openBSD not on amd64"

### DIFF
--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris openbsd,!amd64
+// +build !darwin,!linux,!freebsd,!openbsd,!windows,!solaris
 
 package disk
 

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -1,4 +1,4 @@
-// +build openbsd,amd64
+// +build openbsd
 
 package disk
 


### PR DESCRIPTION
This reverts commit 3aa75af2ac502b28e078f653497a24d3809c63d4

Merging both #720 and #721 resulted in the new i386 support to be disabled -> revert my build constraint changes.