### PR TITLE
ignore /proc/filesystems errors on android

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -244,7 +245,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs, err := getFileSystems()
-	if err != nil {
+	if err != nil && runtime.GOOS != "android" {
 		return nil, err
 	}
 

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -245,7 +245,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs, err := getFileSystems()
-	if err != nil && runtime.GOOS != "android" {
+	if err != nil && all {
 		return nil, err
 	}
 


### PR DESCRIPTION
fixes #727 and makes `disk.Partitions(true)` work on Android O again.