### PR TITLE
Fixes issue #730

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -43,7 +43,15 @@ func NumProcs() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint64(len(list)), err
+	var cnt uint64
+
+	for _, v := range list {
+		if _, err = strconv.ParseUint(v, 10, 64); err == nil {
+			cnt++
+		}
+	}
+
+	return cnt, nil
 }
 
 // cachedBootTime must be accessed via atomic.Load/StoreUint64


### PR DESCRIPTION
In common.NumProcs add a loop that attempts to parse /proc/<dirs> as uint64s and only report the number that are actual base 10 integers.  This should fix the issue of improper reporting of Process counts in host.Info