### PR TITLE
[host][linux] Fix #738 use uname syscall to get version in KernelVersion()

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
+	"golang.org/x/sys/unix"
 )
 
 type LSB struct {
@@ -369,19 +370,12 @@ func KernelVersion() (version string, err error) {
 }
 
 func KernelVersionWithContext(ctx context.Context) (version string, err error) {
-	filename := common.HostProc("sys/kernel/osrelease")
-	if common.PathExists(filename) {
-		contents, err := common.ReadLines(filename)
-		if err != nil {
-			return "", err
-		}
-
-		if len(contents) > 0 {
-			version = contents[0]
-		}
+	var utsname unix.Utsname
+	err = unix.Uname(&utsname)
+	if err != nil {
+		return "", err
 	}
-
-	return version, nil
+	return string(utsname.Release[:]), nil
 }
 
 func getSlackwareVersion(contents []string) string {


### PR DESCRIPTION
[host][linux] Fix #738 use uname syscall to get version in KernelVersion()