### PR TITLE
Fixes a problem when using Docker on a host with an encrypted LLVM root.

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -302,10 +302,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 
 			if strings.HasPrefix(d.Device, "/dev/mapper/") {
 				devpath, err := filepath.EvalSymlinks(d.Device)
-				if err != nil {
-					return nil, err
+				if err == nil {
+					d.Device = devpath
 				}
-				d.Device = devpath
 			}
 
 			// /dev/root is not the real device name


### PR DESCRIPTION
A docker container with a volume mounted from the host will see /dev/mapper in its mount info file, but will not be able to read it. This will allow processes running in these docker containers to just use /dev/mapper/ names instead of bailing out when it fails to read the symlink.