### PR TITLE
cpu: change Win32_Processor struct to use NumberOfCores

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -14,14 +14,14 @@ import (
 )
 
 type Win32_Processor struct {
-	LoadPercentage            *uint16
-	Family                    uint16
-	Manufacturer              string
-	Name                      string
-	NumberOfLogicalProcessors uint32
-	ProcessorID               *string
-	Stepping                  *string
-	MaxClockSpeed             uint32
+	LoadPercentage *uint16
+	Family         uint16
+	Manufacturer   string
+	Name           string
+	NumberOfCores  uint32
+	ProcessorID    *string
+	Stepping       *string
+	MaxClockSpeed  uint32
 }
 
 // SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
@@ -117,7 +117,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			Family:     fmt.Sprintf("%d", l.Family),
 			VendorID:   l.Manufacturer,
 			ModelName:  l.Name,
-			Cores:      int32(l.NumberOfLogicalProcessors),
+			Cores:      int32(l.NumberOfCores),
 			PhysicalID: procID,
 			Mhz:        float64(l.MaxClockSpeed),
 			Flags:      []string{},


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I am using gopsutil to query number of physical cores on windows machines. 

**Describe the solution**
This change will report the number of physical cores now instead of logical.
Logical number of processors can still be acquired by using the `CountsWithContext` function call in this package, which uses the go runtime package call NumCPU(), which will return the logical number of processors, per https://golang.org/pkg/runtime/#NumCPU

**Alternatives**
If there is another way to get the physical number of cores on windows using your library that I have missed, please let me know.