### PR TITLE
#755 fixes process.Percent return invalid value

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -216,18 +216,18 @@ func (p *Process) PercentWithContext(ctx context.Context, interval time.Duration
 
 	numcpu := runtime.NumCPU()
 	delta := (now.Sub(p.lastCPUTime).Seconds()) * float64(numcpu)
-	ret := calculatePercent(p.lastCPUTimes, cpuTimes, delta, numcpu)
+	ret := calculatePercent(p.lastCPUTimes, cpuTimes, delta)
 	p.lastCPUTimes = cpuTimes
 	p.lastCPUTime = now
 	return ret, nil
 }
 
-func calculatePercent(t1, t2 *cpu.TimesStat, delta float64, numcpu int) float64 {
+func calculatePercent(t1, t2 *cpu.TimesStat, delta float64) float64 {
 	if delta == 0 {
 		return 0
 	}
 	delta_proc := t2.Total() - t1.Total()
-	overall_percent := ((delta_proc / delta) * 100) * float64(numcpu)
+	overall_percent := ((delta_proc / delta) * 100)
 	return math.Min(100, math.Max(0, overall_percent))
 }
 


### PR DESCRIPTION
Hi @Lomanic and @shirou ,

Make it return percent of all cpu core usage which will bewteen 0 and 100.

I think this patch is match both you two's ideas and make the returned value valid.

If you want got the full core usage which was saw in `top` command, you can do this:

```go
percent, _ := process.Percent(0)
percent *= float64(runtime.NumCPU())
```