### PR TITLE
[process][windows] Implement Connections() using net.ConnectionsPid()

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -640,7 +640,7 @@ func (p *Process) Connections() ([]net.ConnectionStat, error) {
 }
 
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
-	return nil, common.ErrNotImplementedError
+	return net.ConnectionsPidWithContext(ctx, "all", p.Pid)
 }
 
 func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {


### PR DESCRIPTION
This now makes Connections test (as changed in #758) pass successfully on windows.