### PR TITLE
Speed up ConnectionStat on Linux by omitting Uids

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -46,6 +46,29 @@ type ConnectionStat struct {
 	Pid    int32   `json:"pid"`
 }
 
+// connectionStatConfig configures what to search for with ConnectionStat
+type connectionStatConfig struct {
+	_               struct{}
+	skipUids        bool
+}
+
+type ConnectionStatConfigurer func(*connectionStatConfig)
+
+func configConnectionStatConfig(config []ConnectionStatConfigurer) connectionStatConfig {
+	var c connectionStatConfig
+	for _, opt := range config {
+		opt(&c)
+	}
+	return c
+}
+
+// SkipUids doesn't collect ConnectionStat.Uids if it is significantly faster to ignore them
+func SkipUids() ConnectionStatConfigurer {
+	return func(config *connectionStatConfig) {
+		config.skipUids = true
+	}
+}
+
 // System wide stats about different network protocols
 type ProtoCountersStat struct {
 	Protocol string           `json:"protocol"`

--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -40,18 +40,18 @@ func ProtoCountersWithContext(ctx context.Context, protocols []string) ([]ProtoC
 	return []ProtoCountersStat{}, common.ErrNotImplementedError
 }
 
-func Connections(kind string) ([]ConnectionStat, error) {
-	return ConnectionsWithContext(context.Background(), kind)
+func Connections(kind string, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
+	return ConnectionsWithContext(context.Background(), kind, config...)
 }
 
-func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat, error) {
+func ConnectionsWithContext(ctx context.Context, kind string, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
 	return []ConnectionStat{}, common.ErrNotImplementedError
 }
 
-func ConnectionsMax(kind string, max int) ([]ConnectionStat, error) {
-	return ConnectionsMaxWithContext(context.Background(), kind, max)
+func ConnectionsMax(kind string, max int, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
+	return ConnectionsMaxWithContext(context.Background(), kind, max, config...)
 }
 
-func ConnectionsMaxWithContext(ctx context.Context, kind string, max int) ([]ConnectionStat, error) {
+func ConnectionsMaxWithContext(ctx context.Context, kind string, max int, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
 	return []ConnectionStat{}, common.ErrNotImplementedError
 }

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -257,11 +257,11 @@ func parseNetstatAddr(local string, remote string, family uint32) (laddr Addr, r
 }
 
 // Return a list of network connections opened.
-func Connections(kind string) ([]ConnectionStat, error) {
-	return ConnectionsWithContext(context.Background(), kind)
+func Connections(kind string, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
+	return ConnectionsWithContext(context.Background(), kind, config...)
 }
 
-func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat, error) {
+func ConnectionsWithContext(ctx context.Context, kind string, config ...ConnectionStatConfigurer) ([]ConnectionStat, error) {
 	var ret []ConnectionStat
 
 	args := []string{"-na"}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -59,6 +59,20 @@ func TestNetConnectionStatString(t *testing.T) {
 
 }
 
+func TestConfigConnectionStatConfig(t *testing.T) {
+	noSkip := connectionStatConfig{skipUids: false}
+	skip := connectionStatConfig{skipUids: true}
+	emptyV := configConnectionStatConfig(nil)
+	if noSkip != emptyV {
+		t.Errorf("No config shouldn't skipUids: %+v", emptyV)
+	}
+	skipV := configConnectionStatConfig([]ConnectionStatConfigurer{SkipUids()})
+	if skip != skipV {
+		t.Errorf("SkipUids() should skipUids: %+v", emptyV)
+	}
+}
+
+
 func TestNetIOCountersAll(t *testing.T) {
 	v, err := IOCounters(false)
 	if err != nil {


### PR DESCRIPTION
Fixes #771 

# Request

Querying Uids has a considerable cost and a caller may not 
require the information it provides. We also don't fail on not 
acquiring `Uids`, so it is an expensive operation that can 
silently fail.

This causes problems in many scenarios, where we may
spike usage if called in a cron.

I didn't get any feedback on my issue, so am happy to
close and modify if another alternative would be
considered.

### Real world usage
The following is a pprof flame graph from a real world
sever showing the relative cost:

![flame graph](https://user-images.githubusercontent.com/15200179/67424419-16f35c00-f5a4-11e9-84e0-fcbcac05d567.png)


`fillFromStatus` calls `ReadFile` and is the majority of the
cost of a `Connections` call.
![flame graph zoomed](https://user-images.githubusercontent.com/15200179/67424029-5c635980-f5a3-11e9-8479-e1319919a32c.png)

Thanks to Chris Donaher for images.

I confirmed that modifying gopsutil to not query
`Uids` drastically improved performance with
pprof, htop, and dstat.

### Implementation
This is a way to enable altering of ConnectionStat querying w/o
having to release a new major version.

The ideal solution would likely have a `BareConnectionStat`
without a Uids field. Then we could create a public method, 
which doesn't include Uids and the existing methods would
enrich that struct by embedding in a `ConnectionStat` with
a Uids field.

### Alternative considered; future proof of implementation

I considered having an environmental variable, but
that could also cause problems because a caller
may want to query without Uids often and rarely
make the full call.

This methodology also allows us to make changes
without releasing a new version for other quirks.
For example if the `Uids` field isn't found we don't
fail, but we could add the following with this
methodology:
net/net.go...
```go
func FailWithoutUids() ConnectionStatConfigurer {
	return func(config *connectionStatConfig) {
		config.failWithoutUids = true
	}
}
```
net/net_linux.go...
```
conn.Uids, uidErr = proc.getUids()
if failOnUid {
    return nil, err
}
```

If gopsutil would accept a new public method
specifically for this use case I would be happy to
do that instead.