### PR TITLE
[process][darwin][openbsd][freebsd] Fix #795 don't truncate process names to 16 characters

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -89,8 +90,24 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	name := common.IntToString(k.Proc.P_comm[:])
 
-	return common.IntToString(k.Proc.P_comm[:]), nil
+	if len(name) >= 15 {
+		cmdlineSlice, err := p.CmdlineSliceWithContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(cmdlineSlice) > 0 {
+			extendedName := filepath.Base(cmdlineSlice[0])
+			if strings.HasPrefix(extendedName, p.name) {
+				name = extendedName
+			} else {
+				name = cmdlineSlice[0]
+			}
+		}
+	}
+
+	return name, nil
 }
 func (p *Process) Tgid() (int32, error) {
 	return 0, common.ErrNotImplementedError

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -58,8 +59,24 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	name := common.IntToString(k.Comm[:])
 
-	return common.IntToString(k.Comm[:]), nil
+	if len(name) >= 15 {
+		cmdlineSlice, err := p.CmdlineSliceWithContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(cmdlineSlice) > 0 {
+			extendedName := filepath.Base(cmdlineSlice[0])
+			if strings.HasPrefix(extendedName, p.name) {
+				name = extendedName
+			} else {
+				name = cmdlineSlice[0]
+			}
+		}
+	}
+
+	return name, nil
 }
 func (p *Process) Tgid() (int32, error) {
 	return 0, common.ErrNotImplementedError

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -61,8 +62,24 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	name := common.IntToString(k.Comm[:])
 
-	return common.IntToString(k.Comm[:]), nil
+	if len(name) >= 15 {
+		cmdlineSlice, err := p.CmdlineSliceWithContext(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(cmdlineSlice) > 0 {
+			extendedName := filepath.Base(cmdlineSlice[0])
+			if strings.HasPrefix(extendedName, p.name) {
+				name = extendedName
+			} else {
+				name = cmdlineSlice[0]
+			}
+		}
+	}
+
+	return name, nil
 }
 func (p *Process) Tgid() (int32, error) {
 	return 0, common.ErrNotImplementedError

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"path/filepath"
+	"io/ioutil"
 
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/stretchr/testify/assert"
@@ -288,6 +290,51 @@ func Test_Process_Name(t *testing.T) {
 	if !strings.Contains(n, "process.test") {
 		t.Errorf("invalid Exe %s", n)
 	}
+}
+func Test_Process_Long_Name(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unable to create temp dir %v", err)
+	}
+	defer os.RemoveAll(tmpdir) // clean up
+	tmpfilepath := filepath.Join(tmpdir, "looooooooooooooooooooong.go")
+	tmpfile, err := os.Create(tmpfilepath)
+	if err != nil {
+		t.Fatalf("unable to create temp file %v", err)
+	}
+
+	tmpfilecontent := []byte("package main\nimport(\n\"time\"\n)\nfunc main(){\ntime.Sleep(time.Second)\n}")
+	if _, err := tmpfile.Write(tmpfilecontent); err != nil {
+		tmpfile.Close()
+		t.Fatalf("unable to write temp file %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("unable to close temp file %v", err)
+	}
+
+	err = exec.Command("go", "build", "-o", tmpfile.Name() + ".exe", tmpfile.Name()).Run()
+	if err != nil {
+		t.Fatalf("unable to build temp file %v", err)
+	}
+
+	cmd := exec.Command(tmpfile.Name() + ".exe")
+
+	assert.Nil(t, cmd.Start())
+	time.Sleep(100 * time.Millisecond)
+	p, err := NewProcess(int32(cmd.Process.Pid))
+	skipIfNotImplementedErr(t, err)
+	assert.Nil(t, err)
+	
+	n, err := p.Name()
+	skipIfNotImplementedErr(t, err)
+	if err != nil {
+		t.Fatalf("getting name error %v", err)
+	}
+	basename := filepath.Base(tmpfile.Name() + ".exe")
+	if basename != n {
+		t.Fatalf("%s != %s", basename, n)
+	}
+	cmd.Wait()
 }
 func Test_Process_Exe(t *testing.T) {
 	p := testGetProcess()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -596,8 +596,10 @@ func Test_IsRunning(t *testing.T) {
 	}
 	cmd.Start()
 	p, err := NewProcess(int32(cmd.Process.Pid))
+	skipIfNotImplementedErr(t, err)
 	assert.Nil(t, err)
 	running, err := p.IsRunning()
+	skipIfNotImplementedErr(t, err)
 	if err != nil {
 		t.Fatalf("IsRunning error: %v", err)
 	}
@@ -606,6 +608,7 @@ func Test_IsRunning(t *testing.T) {
 	}
 	cmd.Wait()
 	running, err = p.IsRunning()
+	skipIfNotImplementedErr(t, err)
 	if err != nil {
 		t.Fatalf("IsRunning error: %v", err)
 	}


### PR DESCRIPTION
[process][darwin][openbsd][freebsd] Fix #795 don't truncate process names to 16 characters