### PR TITLE
rename InActive(file) to Inactive(file) in mem_linux.go

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -67,7 +67,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 		case "Active(file)":
 			activeFile = true
 			retEx.ActiveFile = t * 1024
-		case "InActive(file)":
+		case "Inactive(file)":
 			inactiveFile = true
 			retEx.InactiveFile = t * 1024
 		case "Writeback":


### PR DESCRIPTION
FIX:availlable mem is caculated incorrectly in Linux 2.6.32.