### PR TITLE
Change access right for GetProcessTimes call

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -777,7 +777,7 @@ func getProcInfo(pid int32) (*SystemProcessInformation, error) {
 func getRusage(pid int32) (*windows.Rusage, error) {
 	var CPU windows.Rusage
 
-	c, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, uint32(pid))
+	c, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GetProcessTimes requires lower rights.  Now you can get times from the system process, for example from the process with PID 4.


See https://devblogs.microsoft.com/oldnewthing/20151210-00/?p=92451