### PR TITLE
Use Getstatfs from golang.org/x/sys/unix for 64-bit inode support on FreeBSD 12

### DIFF
--- a/disk/disk_freebsd_386.go
+++ b/disk/disk_freebsd_386.go
@@ -29,34 +29,6 @@ type (
 	_C_long_double int64
 )
 
-type Statfs struct {
-	Version     uint32
-	Type        uint32
-	Flags       uint64
-	Bsize       uint64
-	Iosize      uint64
-	Blocks      uint64
-	Bfree       uint64
-	Bavail      int64
-	Files       uint64
-	Ffree       int64
-	Syncwrites  uint64
-	Asyncwrites uint64
-	Syncreads   uint64
-	Asyncreads  uint64
-	Spare       [10]uint64
-	Namemax     uint32
-	Owner       uint32
-	Fsid        Fsid
-	Charspare   [80]int8
-	Fstypename  [16]int8
-	Mntfromname [88]int8
-	Mntonname   [88]int8
-}
-type Fsid struct {
-	Val [2]int32
-}
-
 type Devstat struct {
 	Sequence0     uint32
 	Allocated     int32

--- a/disk/disk_freebsd_amd64.go
+++ b/disk/disk_freebsd_amd64.go
@@ -29,34 +29,6 @@ type (
 	_C_long_double int64
 )
 
-type Statfs struct {
-	Version     uint32
-	Type        uint32
-	Flags       uint64
-	Bsize       uint64
-	Iosize      uint64
-	Blocks      uint64
-	Bfree       uint64
-	Bavail      int64
-	Files       uint64
-	Ffree       int64
-	Syncwrites  uint64
-	Asyncwrites uint64
-	Syncreads   uint64
-	Asyncreads  uint64
-	Spare       [10]uint64
-	Namemax     uint32
-	Owner       uint32
-	Fsid        Fsid
-	Charspare   [80]int8
-	Fstypename  [16]int8
-	Mntfromname [88]int8
-	Mntonname   [88]int8
-}
-type Fsid struct {
-	Val [2]int32
-}
-
 type Devstat struct {
 	Sequence0     uint32
 	Allocated     int32

--- a/disk/disk_freebsd_arm.go
+++ b/disk/disk_freebsd_arm.go
@@ -29,34 +29,6 @@ type (
 	_C_long_double int64
 )
 
-type Statfs struct {
-	Version     uint32
-	Type        uint32
-	Flags       uint64
-	Bsize       uint64
-	Iosize      uint64
-	Blocks      uint64
-	Bfree       uint64
-	Bavail      int64
-	Files       uint64
-	Ffree       int64
-	Syncwrites  uint64
-	Asyncwrites uint64
-	Syncreads   uint64
-	Asyncreads  uint64
-	Spare       [10]uint64
-	Namemax     uint32
-	Owner       uint32
-	Fsid        Fsid
-	Charspare   [80]int8
-	Fstypename  [16]int8
-	Mntfromname [88]int8
-	Mntonname   [88]int8
-}
-type Fsid struct {
-	Val [2]int32
-}
-
 type Devstat struct {
 	Sequence0     uint32
 	Allocated     int32

--- a/disk/disk_freebsd_arm64.go
+++ b/disk/disk_freebsd_arm64.go
@@ -31,34 +31,6 @@ type (
 	_C_long_double int64
 )
 
-type Statfs struct {
-	Version     uint32
-	Type        uint32
-	Flags       uint64
-	Bsize       uint64
-	Iosize      uint64
-	Blocks      uint64
-	Bfree       uint64
-	Bavail      int64
-	Files       uint64
-	Ffree       int64
-	Syncwrites  uint64
-	Asyncwrites uint64
-	Syncreads   uint64
-	Asyncreads  uint64
-	Spare       [10]uint64
-	Namemax     uint32
-	Owner       uint32
-	Fsid        Fsid
-	Charspare   [80]uint8
-	Fstypename  [16]int8
-	Mntfromname [1024]int8
-	Mntonname   [1024]int8
-}
-type Fsid struct {
-	Val [2]int32
-}
-
 type Devstat struct {
 	Sequence0     uint32
 	Allocated     int32

--- a/disk/types_freebsd.go
+++ b/disk/types_freebsd.go
@@ -58,8 +58,5 @@ type (
 	_C_long_double C.longlong
 )
 
-type Statfs C.struct_statfs
-type Fsid C.struct_fsid
-
 type Devstat C.struct_devstat
 type Bintime C.struct_bintime


### PR DESCRIPTION
Use unix.Getstatfs and its associated Statfs_t type instead of
implementing them locally in this package. This allows to use 64-bit
inode fields on FreeBSD 12 while still keeping backwards compatibility
for old FreeBSD versions, as unix.Getfsstat will use the correct syscall
number and data structure version and convert its result
correspondingly.

Also see https://golang.org/cl/136816 for details.