### PR TITLE
Fix for track disk stats when running in container

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -300,12 +300,18 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 				}
 			}
 
-			if strings.HasPrefix(d.Device, "/dev/mapper/") {
-				devpath, err := filepath.EvalSymlinks(d.Device)
-				if err == nil {
-					d.Device = devpath
-				}
-			}
+			//The block below has 2 problems, so should be disabled:
+			//1. Will not work, in case we track disk info on the host from container, as /dev will be mapped into other mount point
+			//2. Useful info about vg name removed if we follow symlink, here the example:
+			//	~# ls -la /dev/mapper/dm--01--vg-root
+			//	lrwxrwxrwx 1 root root 7 Oct  3 10:47 /dev/mapper/dm--01--vg-root -> ../dm-0
+
+			//if strings.HasPrefix(d.Device, "/dev/mapper/") {
+			//	devpath, err := filepath.EvalSymlinks(d.Device)
+			//	if err == nil {
+			//		d.Device = devpath
+			//	}
+			//}
 
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -300,18 +300,12 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 				}
 			}
 
-			//The block below has 2 problems, so should be disabled:
-			//1. Will not work, in case we track disk info on the host from container, as /dev will be mapped into other mount point
-			//2. Useful info about vg name removed if we follow symlink, here the example:
-			//	~# ls -la /dev/mapper/dm--01--vg-root
-			//	lrwxrwxrwx 1 root root 7 Oct  3 10:47 /dev/mapper/dm--01--vg-root -> ../dm-0
-
-			//if strings.HasPrefix(d.Device, "/dev/mapper/") {
-			//	devpath, err := filepath.EvalSymlinks(d.Device)
-			//	if err == nil {
-			//		d.Device = devpath
-			//	}
-			//}
+			if strings.HasPrefix(d.Device, "/dev/mapper/") {
+				devpath, err := filepath.EvalSymlinks(common.HostDev(strings.Replace(d.Device, "/dev", "", -1)))
+				if err == nil {
+					d.Device = devpath
+				}
+			}
 
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -338,6 +338,10 @@ func HostRun(combineWith ...string) string {
 	return GetEnv("HOST_RUN", "/run", combineWith...)
 }
 
+func HostDev(combineWith ...string) string {
+	return GetEnv("HOST_DEV", "/dev", combineWith...)
+}
+
 // getSysctrlEnv sets LC_ALL=C in a list of env vars for use when running
 // sysctl commands (see DoSysctrl).
 func getSysctrlEnv(env []string) []string {


### PR DESCRIPTION
The commented block has 2 problems, so should be disabled:
1. Will not work, in case we track disk info on the host from container, as /dev will be mapped into other mount point
2. Useful info about vg name removed if we follow symlink, here the example:
```
~# ls -la /dev/mapper/dm--01--vg-root
lrwxrwxrwx 1 root root 7 Oct  3 10:47 /dev/mapper/dm--01--vg-root -> ../dm-0
```
Issue is opened:
https://github.com/shirou/gopsutil/issues/817