### PR TITLE
fix host.Info() panic if /etc/debian_version is empty

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -280,7 +280,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 				platform = "debian"
 			}
 			contents, err := common.ReadLines(common.HostEtc("debian_version"))
-			if err == nil {
+			if err == nil && len(contents) > 0 && contents[0] != "" {
 				version = contents[0]
 			}
 		}
@@ -315,7 +315,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	} else if common.PathExists(common.HostEtc("alpine-release")) {
 		platform = "alpine"
 		contents, err := common.ReadLines(common.HostEtc("alpine-release"))
-		if err == nil && len(contents) > 0 {
+		if err == nil && len(contents) > 0 && contents[0] != "" {
 			version = contents[0]
 		}
 	} else if common.PathExists(common.HostEtc("os-release")) {


### PR DESCRIPTION
The `ReadLines` helper function doesn't guarantee that the length of lines is non-zero or that the lines have contents. Most callers include a check for length but this was missing for version fingerprinting on Debian if `/etc/debian_version` was empty, leading to a panic.

This contributed to a panic for a user of Nomad in https://github.com/hashicorp/nomad/issues/6954. A minimal reproduction using a Debian Buster container is below.

To fix, I've reused the same length check done everywhere else in the `host_linux.go` file, and extended the zero-check for the Alpine version fingerprinting to match as well.

---

Reproduction:

`main.go`:

```go
package main

import (
	"fmt"
	"log"

	"github.com/shirou/gopsutil/host"
)

func main() {
	info, err := host.Info()
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(info)
}
```

Before fix:

```
$ sudo  mv /etc/debian_version /etc/debian_version.bak
$ sudo touch /etc/debian_version
$ go run main.go  | jq .
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/shirou/gopsutil/host.PlatformInformationWithContext(0x565600, 0xc00009e030, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0000b0000)
        /home/me/go/src/github.com/shirou/gopsutil/host/host_linux.go:284 +0x1b4e
github.com/shirou/gopsutil/host.PlatformInformation(0xc00009e040, 0xc, 0x0, 0x0, 0x30, 0x30, 0x5321c0, 0x612160)
        /home/me/go/src/github.com/shirou/gopsutil/host/host_linux.go:240 +0x3d
github.com/shirou/gopsutil/host.InfoWithContext(0x565600, 0xc00009e030, 0x438b87, 0x614ea0, 0xc00003e750)
        /home/me/go/src/github.com/shirou/gopsutil/host/host_linux.go:48 +0x8c
github.com/shirou/gopsutil/host.Info(...)
        /home/me/go/src/github.com/shirou/gopsutil/host/host_linux.go:35
main.main()
        /home/me/go/src/github.com/hashicorp/issues/6954_gopsutil/main.go:11 +0x3d
exit status 2
```

After fix:

```
$ sudo  mv /etc/debian_version /etc/debian_version.bak
$ sudo touch /etc/debian_version
$ go run main.go  | jq .
{
  "hostname": "cf4038b71167",
  "uptime": 143893,
  "bootTime": 1579144017,
  "procs": 4,
  "os": "linux",
  "platform": "debian",
  "platformFamily": "debian",
  "platformVersion": "",
  "kernelVersion": "4.9.184-linuxkit",
  "kernelArch": "x86_64",
  "virtualizationSystem": "docker",
  "virtualizationRole": "guest",
  "hostid": "0f454763-0000-0000-84ca-5540bf5161f8"
}
```