### PR TITLE
host: fix TestHostInfoStat_String

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -86,9 +86,9 @@ func TestHostInfoStat_String(t *testing.T) {
 		BootTime: 1447040000,
 		HostID:   "edfd25ff-3c9c-b1a4-e660-bd826495ad35",
 	}
-	e := `{"hostname":"test","uptime":3000,"bootTime":1447040000,"procs":100,"os":"linux","platform":"ubuntu","platformFamily":"","platformVersion":"","kernelVersion":"","virtualizationSystem":"","virtualizationRole":"","hostid":"edfd25ff-3c9c-b1a4-e660-bd826495ad35"}`
+	e := `{"hostname":"test","uptime":3000,"bootTime":1447040000,"procs":100,"os":"linux","platform":"ubuntu","platformFamily":"","platformVersion":"","kernelVersion":"","kernelArch":"","virtualizationSystem":"","virtualizationRole":"","hostid":"edfd25ff-3c9c-b1a4-e660-bd826495ad35"}`
 	if e != fmt.Sprintf("%v", v) {
-		t.Errorf("HostInfoStat string is invalid: %v", v)
+		t.Errorf("HostInfoStat string is invalid:\ngot  %v\nwant %v", v, e)
 	}
 }
 


### PR DESCRIPTION
TestHostInfoStat_String has been broken since kernelArch has been
introduced. Fix it.

Also adjust the error message to show the wanted string, aligned with
the gotten string so it's easier to spot differences.