### PR TITLE
net: move parseNetLine and parseNetAddr to net_unix.go

### DIFF
--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -4,7 +4,11 @@ package net
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -84,6 +88,95 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 	}
 
 	return ret, nil
+}
+
+var constMap = map[string]int{
+	"unix": syscall.AF_UNIX,
+	"TCP":  syscall.SOCK_STREAM,
+	"UDP":  syscall.SOCK_DGRAM,
+	"IPv4": syscall.AF_INET,
+	"IPv6": syscall.AF_INET6,
+}
+
+func parseNetLine(line string) (ConnectionStat, error) {
+	f := strings.Fields(line)
+	if len(f) < 8 {
+		return ConnectionStat{}, fmt.Errorf("wrong line,%s", line)
+	}
+
+	if len(f) == 8 {
+		f = append(f, f[7])
+		f[7] = "unix"
+	}
+
+	pid, err := strconv.Atoi(f[1])
+	if err != nil {
+		return ConnectionStat{}, err
+	}
+	fd, err := strconv.Atoi(strings.Trim(f[3], "u"))
+	if err != nil {
+		return ConnectionStat{}, fmt.Errorf("unknown fd, %s", f[3])
+	}
+	netFamily, ok := constMap[f[4]]
+	if !ok {
+		return ConnectionStat{}, fmt.Errorf("unknown family, %s", f[4])
+	}
+	netType, ok := constMap[f[7]]
+	if !ok {
+		return ConnectionStat{}, fmt.Errorf("unknown type, %s", f[7])
+	}
+
+	var laddr, raddr Addr
+	if f[7] == "unix" {
+		laddr.IP = f[8]
+	} else {
+		laddr, raddr, err = parseNetAddr(f[8])
+		if err != nil {
+			return ConnectionStat{}, fmt.Errorf("failed to parse netaddr, %s", f[8])
+		}
+	}
+
+	n := ConnectionStat{
+		Fd:     uint32(fd),
+		Family: uint32(netFamily),
+		Type:   uint32(netType),
+		Laddr:  laddr,
+		Raddr:  raddr,
+		Pid:    int32(pid),
+	}
+	if len(f) == 10 {
+		n.Status = strings.Trim(f[9], "()")
+	}
+
+	return n, nil
+}
+
+func parseNetAddr(line string) (laddr Addr, raddr Addr, err error) {
+	parse := func(l string) (Addr, error) {
+		host, port, err := net.SplitHostPort(l)
+		if err != nil {
+			return Addr{}, fmt.Errorf("wrong addr, %s", l)
+		}
+		lport, err := strconv.Atoi(port)
+		if err != nil {
+			return Addr{}, err
+		}
+		return Addr{IP: host, Port: uint32(lport)}, nil
+	}
+
+	addrs := strings.Split(line, "->")
+	if len(addrs) == 0 {
+		return laddr, raddr, fmt.Errorf("wrong netaddr, %s", line)
+	}
+	laddr, err = parse(addrs[0])
+	if len(addrs) == 2 { // remote addr exists
+		raddr, err = parse(addrs[1])
+		if err != nil {
+			return laddr, raddr, err
+		}
+	}
+
+	return laddr, raddr, err
 }
 
 // Return up to `max` network connections opened by a process.


### PR DESCRIPTION
These funcs are only used in net_unix.go which is only compiled for
darwin and freebsd.