### PR TITLE
Do not cache boot time for linux. Fix #837

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 )
 
@@ -54,14 +53,7 @@ func NumProcs() (uint64, error) {
 	return cnt, nil
 }
 
-// cachedBootTime must be accessed via atomic.Load/StoreUint64
-var cachedBootTime uint64
-
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
-	t := atomic.LoadUint64(&cachedBootTime)
-	if t != 0 {
-		return t, nil
-	}
 
 	system, role, err := Virtualization()
 	if err != nil {
@@ -94,8 +86,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 				if err != nil {
 					return 0, err
 				}
-				t = uint64(b)
-				atomic.StoreUint64(&cachedBootTime, t)
+				t := uint64(b)
 				return t, nil
 			}
 		}
@@ -108,8 +99,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		t = uint64(time.Now().Unix()) - uint64(b)
-		atomic.StoreUint64(&cachedBootTime, t)
+		t := uint64(time.Now().Unix()) - uint64(b)
 		return t, nil
 	}
 


### PR DESCRIPTION
This should fix the issue #837: we now query the value of /proc/stat or /proc/uptime at each invocation.

Not doing so will not return the correct boot time when NTP adjusts the time of the system in linux.