### PR TITLE
Added check for `CLK_TCK` for darwin

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -4,6 +4,7 @@ package cpu
 
 import (
 	"context"
+	"os/exec"
 	"strconv"
 	"strings"
 
@@ -22,6 +23,21 @@ const (
 
 // default value. from time.h
 var ClocksPerSec = float64(128)
+
+func init() {
+	getconf, err := exec.LookPath("getconf")
+	if err != nil {
+		return
+	}
+	out, err := invoke.Command(getconf, "CLK_TCK")
+	// ignore errors
+	if err == nil {
+		i, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+		if err == nil {
+			ClocksPerSec = float64(i)
+		}
+	}
+}
 
 func Times(percpu bool) ([]TimesStat, error) {
 	return TimesWithContext(context.Background(), percpu)


### PR DESCRIPTION
This PR adds a check for the clock tick of darwin OS as is done for freebsd, linux, and openbsd when calculating CPU stats instead of assuming a static `ClocksPerSec` of 128. 

