### PR TITLE
Renamed variables storing `CLK_TCK` value for consistency across OSs

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-var CPUTick = float64(100)
+var ClocksPerSec = float64(100)
 
 func init() {
 	getconf, err := exec.LookPath("getconf")
@@ -25,7 +25,7 @@ func init() {
 	if err == nil {
 		i, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
 		if err == nil {
-			CPUTick = i
+			ClocksPerSec = i
 		}
 	}
 }
@@ -250,34 +250,34 @@ func parseStatLine(line string) (*TimesStat, error) {
 
 	ct := &TimesStat{
 		CPU:     cpu,
-		User:    user / CPUTick,
-		Nice:    nice / CPUTick,
-		System:  system / CPUTick,
-		Idle:    idle / CPUTick,
-		Iowait:  iowait / CPUTick,
-		Irq:     irq / CPUTick,
-		Softirq: softirq / CPUTick,
+		User:    user / ClocksPerSec,
+		Nice:    nice / ClocksPerSec,
+		System:  system / ClocksPerSec,
+		Idle:    idle / ClocksPerSec,
+		Iowait:  iowait / ClocksPerSec,
+		Irq:     irq / ClocksPerSec,
+		Softirq: softirq / ClocksPerSec,
 	}
 	if len(fields) > 8 { // Linux >= 2.6.11
 		steal, err := strconv.ParseFloat(fields[8], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.Steal = steal / CPUTick
+		ct.Steal = steal / ClocksPerSec
 	}
 	if len(fields) > 9 { // Linux >= 2.6.24
 		guest, err := strconv.ParseFloat(fields[9], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.Guest = guest / CPUTick
+		ct.Guest = guest / ClocksPerSec
 	}
 	if len(fields) > 10 { // Linux >= 3.2.0
 		guestNice, err := strconv.ParseFloat(fields[10], 64)
 		if err != nil {
 			return nil, err
 		}
-		ct.GuestNice = guestNice / CPUTick
+		ct.GuestNice = guestNice / ClocksPerSec
 	}
 
 	return ct, nil

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -50,7 +50,7 @@ type Win32_PerfFormattedData_PerfOS_System struct {
 }
 
 const (
-	win32_TicksPerSecond = 10000000.0
+	ClocksPerSec = 10000000.0
 
 	// systemProcessorPerformanceInformationClass information class to query with NTQuerySystemInformation
 	// https://processhacker.sourceforge.io/doc/ntexapi_8h.html#ad5d815b48e8f4da1ef2eb7a2f18a54e0
@@ -159,10 +159,10 @@ func perCPUTimes() ([]TimesStat, error) {
 	for core, v := range stats {
 		c := TimesStat{
 			CPU:    fmt.Sprintf("cpu%d", core),
-			User:   float64(v.UserTime) / win32_TicksPerSecond,
-			System: float64(v.KernelTime-v.IdleTime) / win32_TicksPerSecond,
-			Idle:   float64(v.IdleTime) / win32_TicksPerSecond,
-			Irq:    float64(v.InterruptTime) / win32_TicksPerSecond,
+			User:   float64(v.UserTime) / ClocksPerSec,
+			System: float64(v.KernelTime-v.IdleTime) / ClocksPerSec,
+			Idle:   float64(v.IdleTime) / ClocksPerSec,
+			Irq:    float64(v.InterruptTime) / ClocksPerSec,
 		}
 		ret = append(ret, c)
 	}

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -117,13 +117,13 @@ func CgroupCPUWithContext(ctx context.Context, containerID string, base string) 
 		if fields[0] == "user" {
 			user, err := strconv.ParseFloat(fields[1], 64)
 			if err == nil {
-				ret.User = user / cpu.CPUTick
+				ret.User = user / cpu.ClocksPerSec
 			}
 		}
 		if fields[0] == "system" {
 			system, err := strconv.ParseFloat(fields[1], 64)
 			if err == nil {
-				ret.System = system / cpu.CPUTick
+				ret.System = system / cpu.ClocksPerSec
 			}
 		}
 	}


### PR DESCRIPTION
This PR renames the variables holding the value of `CLK_TCK` across all OSs for consistency. `ClocksPerSec` is used for darwin, openbsd, freebsd and solaris, but other names are used for linux and windows. It would be helpful to rename the variable so that it is consistent across all supported platforms.