### PR TITLE
Update docs for TimesStat with correct time unit

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -14,8 +14,7 @@ import (
 )
 
 // TimesStat contains the amounts of time the CPU has spent performing different
-// kinds of work. Time units are in USER_HZ or Jiffies (typically hundredths of
-// a second). It is based on linux /proc/stat file.
+// kinds of work. Time units are in seconds. It is based on linux /proc/stat file.
 type TimesStat struct {
 	CPU       string  `json:"cpu"`
 	User      float64 `json:"user"`


### PR DESCRIPTION
This PR updates the documentation for `TimesStat`. Time units are returned as seconds rather than USER_HZ/ jiffies as indicated by the documentation.