### PR TITLE
Don't ignore context for io counters

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -50,7 +50,7 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 
 func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, error) {
 	filename := common.HostProc("net/dev")
-	return IOCountersByFile(pernic, filename)
+	return IOCountersByFileWithContext(ctx, pernic, filename)
 }
 
 func IOCountersByFile(pernic bool, filename string) ([]IOCountersStat, error) {


### PR DESCRIPTION
`IOCountersWithContext` would drop the given `ctx` and call `IOCountersByFile` which would create a background context then call `IOCountersByFileWithContext`.