### PR TITLE
Add pgmajfault to data returned by vmstat on Linux

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -88,6 +88,9 @@ type SwapMemoryStat struct {
 	PgIn        uint64  `json:"pgin"`
 	PgOut       uint64  `json:"pgout"`
 	PgFault     uint64  `json:"pgfault"`
+
+	// Linux specific numbers
+	// https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 	PgMajFault  uint64  `json:"pgmajfault"`
 }
 

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -88,6 +88,7 @@ type SwapMemoryStat struct {
 	PgIn        uint64  `json:"pgin"`
 	PgOut       uint64  `json:"pgout"`
 	PgFault     uint64  `json:"pgfault"`
+	PgMajFault  uint64  `json:"pgmajfault"`
 }
 
 func (m VirtualMemoryStat) String() string {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -232,6 +232,12 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 				continue
 			}
 			ret.PgFault = value * 4 * 1024
+		case "pgmajfault":
+			value, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			ret.PgMajFault = value * 4 * 1024
 		}
 	}
 	return ret, nil

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -94,8 +94,9 @@ func TestSwapMemoryStat_String(t *testing.T) {
 		PgIn:        3,
 		PgOut:       4,
 		PgFault:     5,
+		PgMajFault:  6,
 	}
-	e := `{"total":10,"used":30,"free":40,"usedPercent":30.1,"sin":1,"sout":2,"pgin":3,"pgout":4,"pgfault":5}`
+	e := `{"total":10,"used":30,"free":40,"usedPercent":30.1,"sin":1,"sout":2,"pgin":3,"pgout":4,"pgfault":5,"pgmajfault":6}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("SwapMemoryStat string is invalid: %v", v)
 	}


### PR DESCRIPTION
Minor change to add `pgmajfault` to swap data returned by `vmstat` on Linux