### PR TITLE
Move C files to be included by `go mod`

### DIFF
--- a/host/host_darwin_cgo.go
+++ b/host/host_darwin_cgo.go
@@ -6,7 +6,7 @@ package host
 // #cgo LDFLAGS: -framework IOKit
 // #include <stdio.h>
 // #include <string.h>
-// #include "include/smc.c"
+// #include "smc_darwin.h"
 import "C"
 import "context"
 

--- a/host/smc_darwin.c
+++ b/host/smc_darwin.c
@@ -1,4 +1,4 @@
-#include "smc.h"
+#include "smc_darwin.h"
 
 #define IOSERVICE_SMC "AppleSMC"
 #define IOSERVICE_MODEL "IOPlatformExpertDevice"

--- a/host/smc_darwin.h
+++ b/host/smc_darwin.h
@@ -1,5 +1,5 @@
-#ifndef __SMC_H__
-#define __SMC_H__ 1
+#ifndef __SMC_DARWIN_H__
+#define __SMC_DARWIN_H__ 1
 
 #include <IOKit/IOKitLib.h>
 
@@ -29,4 +29,4 @@ kern_return_t open_smc(void);
 kern_return_t close_smc(void);
 double get_temperature(char *);
 
-#endif // __SMC_H__
+#endif // __SMC_DARWIN_H__


### PR DESCRIPTION
Fixes #832 by moving the C files into a go module directory, which means they should be included by `go mod vendor`.

Not sure how I should name them, let me know if you want it changed.