### PR TITLE
LXC Guest Detection from Environ Procfile

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -94,6 +94,17 @@ func (i FakeInvoke) CommandWithContext(ctx context.Context, name string, arg ...
 
 var ErrNotImplementedError = errors.New("not implemented yet")
 
+// ReadFile reads contents from a file
+func ReadFile(filename string) (string, error) {
+	content, err := ioutil.ReadFile(filename)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
 // ReadLines reads contents from a file and splits them by new lines.
 // A convenience wrapper to ReadLinesOffsetN(filename, 0, -1).
 func ReadLines(filename string) ([]string, error) {

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -194,6 +194,17 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 		}
 	}
 
+	if PathExists(filepath.Join(filename, "1", "environ")) {
+		contents, err := ReadFile(filepath.Join(filename, "1", "environ"))
+
+		if err == nil {
+			if strings.Contains(contents, "container=lxc") {
+				system = "lxc"
+				role = "guest"
+			}
+		}
+	}
+
 	if PathExists(filepath.Join(filename, "self", "cgroup")) {
 		contents, err := ReadLines(filepath.Join(filename, "self", "cgroup"))
 		if err == nil {


### PR DESCRIPTION
This PR adds an additional check for LXC guests using `/proc/1/environ` and resolves 
- https://github.com/shirou/gopsutil/issues/679
- https://github.com/influxdata/telegraf/issues/2968

Implementation notes:
- `ReadFile` was added because `/proc/1/environ` doesn't appear to contain any newlines and `ReadLines` was returning an empty slice
- I left the existing test for LXC guests in place in case it remains valid on some systems, I'd be comfortable removing that if that would be preferred

Tested on a Centos 7 LXC guest.

```sh
[root@centos7-test ~]# ./linux-master 
Virt - system:kvm role:host
Uptime - 327h10m35s
[root@centos7-test ~]# ./linux-branch 
Virt - system:lxc role:guest
Uptime - 45m6s
```