### PR TITLE
Fix FreeBSD build with latest x/sys/unix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,16 +48,18 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:63d8236278940f9c63816950fb4ed7fa389307c0b6367484b748f5b08dee9299"
+  branch = "master"
+  digest = "1:c33af8636b2c5128b62b5bacd6fbdf6bf65a76e95b5b0111bfa134cb8ad5676d"
   name = "golang.org/x/sys"
   packages = [
+    "internal/unsafeheader",
     "unix",
     "windows",
     "windows/svc",
     "windows/svc/mgr",
   ]
   pruneopts = "UT"
-  revision = "a7d97aace0b03bedead413ec782269d62e032341"
+  revision = "ed371f2e16b4b305ee99df548828de367527b76b"
 
 [[projects]]
   branch = "v3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,8 +34,8 @@
   version = "1.2.2"
 
 [[constraint]]
+  branch = "master"
   name = "golang.org/x/sys"
-  revision = "a7d97aace0b03bedead413ec782269d62e032341"
 
 [prune]
   go-tests = true

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -84,9 +84,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		}
 
 		d := PartitionStat{
-			Device:     common.IntToString(stat.Mntfromname[:]),
-			Mountpoint: common.IntToString(stat.Mntonname[:]),
-			Fstype:     common.IntToString(stat.Fstypename[:]),
+			Device:     common.ByteToString(stat.Mntfromname[:]),
+			Mountpoint: common.ByteToString(stat.Mntonname[:]),
+			Fstype:     common.ByteToString(stat.Fstypename[:]),
 			Opts:       opts,
 		}
 		if all == false {
@@ -170,5 +170,5 @@ func parseDevstat(buf []byte) (Devstat, error) {
 }
 
 func getFsType(stat unix.Statfs_t) string {
-	return common.IntToString(stat.Fstypename[:])
+	return common.ByteToString(stat.Fstypename[:])
 }


### PR DESCRIPTION
There was a breaking change in upstream golang.org/x/sys/unix which
changed the type of some Statfs_t members, see #853. As it looks like
this change won't be reverted, adjust gopsutil to work with it and allow
to build against the latest version of x/sys/unix.