### PR TITLE
Add linux/riscv64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build_test:  ## test only buildable
 	GOOS=linux GOARCH=386 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=linux GOARCH=arm go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=linux GOARCH=arm64 go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=riscv64 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd GOARCH=arm go test ./... | $(BUILD_FAIL_PATTERN)
 	CGO_ENABLED=0 GOOS=darwin go test ./... | $(BUILD_FAIL_PATTERN)

--- a/host/host_linux_riscv64.go
+++ b/host/host_linux_riscv64.go
@@ -1,0 +1,47 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_linux.go
+
+package host
+
+const (
+	sizeofPtr      = 0x8
+	sizeofShort    = 0x2
+	sizeofInt      = 0x4
+	sizeofLong     = 0x8
+	sizeofLongLong = 0x8
+	sizeOfUtmp     = 0x180
+)
+
+type (
+	_C_short     int16
+	_C_int       int32
+	_C_long      int64
+	_C_long_long int64
+)
+
+type utmp struct {
+	Type              int16
+	Pid               int32
+	Line              [32]int8
+	Id                [4]int8
+	User              [32]int8
+	Host              [256]int8
+	Exit              exit_status
+	Session           int32
+	Tv                _Ctype_struct___0
+	Addr_v6           [4]int32
+	X__glibc_reserved [20]uint8
+}
+type exit_status struct {
+	Termination int16
+	Exit        int16
+}
+type timeval struct {
+	Sec  int64
+	Usec int64
+}
+
+type _Ctype_struct___0 struct {
+	Sec  int32
+	Usec int32
+}


### PR DESCRIPTION
The first commit adds the necessary const and type definitions to be able to build on linux/riscv64.

The second commit adds a build test for linux/riscv64