### PR TITLE
Add processes created to misc stats

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -21,6 +21,7 @@ func (l AvgStat) String() string {
 
 type MiscStat struct {
 	ProcsTotal   int `json:"procsTotal"`
+	ProcsCreated int `json:"procsCreated"`
 	ProcsRunning int `json:"procsRunning"`
 	ProcsBlocked int `json:"procsBlocked"`
 	Ctxt         int `json:"ctxt"`

--- a/load/load_bsd.go
+++ b/load/load_bsd.go
@@ -37,6 +37,12 @@ func AvgWithContext(ctx context.Context) (*AvgStat, error) {
 	return ret, nil
 }
 
+type forkstat struct {
+	forks    int
+	vforks   int
+	__tforks int
+}
+
 // Misc returns miscellaneous host-wide statistics.
 // darwin use ps command to get process running/blocked count.
 // Almost same as Darwin implementation, but state is different.
@@ -63,6 +69,12 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 			ret.ProcsBlocked++
 		}
 	}
+
+	f, err := getForkStat()
+	if err != nil {
+		return nil, err
+	}
+	ret.ProcsCreated = f.forks
 
 	return &ret, nil
 }

--- a/load/load_freebsd.go
+++ b/load/load_freebsd.go
@@ -1,0 +1,7 @@
+// +build freebsd
+
+package load
+
+func getForkStat() (forkstat, error) {
+	return forkstat{}, nil
+}

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -92,6 +92,8 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 			continue
 		}
 		switch fields[0] {
+		case "processes":
+			ret.ProcsCreated = int(v)
 		case "procs_running":
 			ret.ProcsRunning = int(v)
 		case "procs_blocked":

--- a/load/load_openbsd.go
+++ b/load/load_openbsd.go
@@ -1,0 +1,17 @@
+// +build openbsd
+
+package load
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func getForkStat() (forkstat, error) {
+	b, err := unix.SysctlRaw("kern.forkstat")
+	if err != nil {
+		return forkstat{}, err
+	}
+	return *(*forkstat)(unsafe.Pointer((&b[0]))), nil
+}

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -47,11 +47,12 @@ func TestMisc(t *testing.T) {
 func TestMiscStatString(t *testing.T) {
 	v := MiscStat{
 		ProcsTotal:   4,
+		ProcsCreated: 5,
 		ProcsRunning: 1,
 		ProcsBlocked: 2,
 		Ctxt:         3,
 	}
-	e := `{"procsTotal":4,"procsRunning":1,"procsBlocked":2,"ctxt":3}`
+	e := `{"procsTotal":4,"procsCreated":5,"procsRunning":1,"procsBlocked":2,"ctxt":3}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("TestMiscString string is invalid: %v", v)
 	}


### PR DESCRIPTION
This PR adds the "processes" result from `proc/stat`. Not 100% sure if "ProcsCreated is the best name for this.

https://man7.org/linux/man-pages/man5/proc.5.html lists this as "Number of forks since boot" which I believe is equivalent to the number of processes created since boot. A similar concept should exist for other OSs, though may not be able to be easily retrieved.