### PR TITLE
Fix MemoryMaps on ARM

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -576,7 +576,8 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 			if len(field) < 2 {
 				continue
 			}
-			v := strings.Trim(field[1], " kB") // remove last "kB"
+			v := strings.Trim(field[1], "kB") // remove last "kB"
+			v = strings.TrimSpace(v)
 			t, err := strconv.ParseUint(v, 10, 64)
 			if err != nil {
 				return m, err
@@ -610,11 +611,11 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 
 	blocks := make([]string, 16)
 	for _, line := range lines {
-		field := strings.Split(line, " ")
-		if strings.HasSuffix(field[0], ":") == false {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && strings.HasSuffix(fields[0], ":") == false {
 			// new block section
 			if len(blocks) > 0 {
-				g, err := getBlock(field, blocks)
+				g, err := getBlock(fields, blocks)
 				if err != nil {
 					return &ret, err
 				}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -612,7 +612,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 	blocks := make([]string, 16)
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		if len(fields) > 0 && strings.HasSuffix(fields[0], ":") == false {
+		if len(fields) > 0 && !strings.HasSuffix(fields[0], ":") {
 			// new block section
 			if len(blocks) > 0 {
 				g, err := getBlock(fields, blocks)


### PR DESCRIPTION
ARM has some tab characters in smaps instead of spaces, hence switching to strings.Fields instead of strings.Split which handles splitting on all whitespace instead of just spaces.