### PR TITLE
Set the 'free' memory value to the 'available' memory on windows

### DIFF
--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -42,6 +42,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	ret := &VirtualMemoryStat{
 		Total:       memInfo.ullTotalPhys,
 		Available:   memInfo.ullAvailPhys,
+		Free:        memInfo.ullAvailPhys,
 		UsedPercent: float64(memInfo.dwMemoryLoad),
 	}
 


### PR DESCRIPTION
Hello,

in the spirit of https://github.com/shirou/gopsutil/issues/841#issuecomment-637820470, this PR matches psutil behavior when it comes to memory on Windows.