### PR TITLE
Added support for reading hardware fan speeds in Linux.

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -38,6 +38,12 @@ type TemperatureStat struct {
 	Temperature float64 `json:"sensorTemperature"`
 }
 
+// FanStat describes a fan status.
+type FanStat struct {
+	SensorKey string  `json:"sensorKey"`   // Fan sensor key name
+	Speed     float64 `json:"sensorSpeed"` // Current fan speed in RPM (rounds per minute)
+}
+
 func (h InfoStat) String() string {
 	s, _ := json.Marshal(h)
 	return string(s)
@@ -50,5 +56,11 @@ func (u UserStat) String() string {
 
 func (t TemperatureStat) String() string {
 	s, _ := json.Marshal(t)
+	return string(s)
+}
+
+// String returns a JSON representation of fan.
+func (f FanStat) String() string {
+	s, _ := json.Marshal(f)
 	return string(s)
 }

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -249,3 +249,17 @@ func KernelVersionWithContext(ctx context.Context) (string, error) {
 	_, _, version, err := PlatformInformation()
 	return version, err
 }
+
+// SensorsFans returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFans() ([]FanStat, error) {
+	return SensorsFansWithContext(context.Background())
+}
+
+// SensorsFansWithContext returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFansWithContext(ctx context.Context) ([]FanStat, error) {
+	return []FanStat{}, common.ErrNotImplementedError
+}

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -201,3 +201,17 @@ func KernelVersionWithContext(ctx context.Context) (string, error) {
 	_, _, version, err := PlatformInformation()
 	return version, err
 }
+
+// SensorsFans returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFans() ([]FanStat, error) {
+	return SensorsFansWithContext(context.Background())
+}
+
+// SensorsFansWithContext returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFansWithContext(ctx context.Context) ([]FanStat, error) {
+	return []FanStat{}, common.ErrNotImplementedError
+}

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -251,3 +251,17 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 
 	return "solaris", "solaris", version, nil
 }
+
+// SensorsFans returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFans() ([]FanStat, error) {
+	return SensorsFansWithContext(context.Background())
+}
+
+// SensorsFansWithContext returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFansWithContext(ctx context.Context) ([]FanStat, error) {
+	return []FanStat{}, common.ErrNotImplementedError
+}

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -347,3 +347,17 @@ func kernelArch() (string, error) {
 	}
 	return "", nil
 }
+
+// SensorsFans returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFans() ([]FanStat, error) {
+	return SensorsFansWithContext(context.Background())
+}
+
+// SensorsFansWithContext returns hardware fans speed.
+// Each entry is representing a certain hardware sensor fan.
+// Fan speed is expressed in RPM (rounds per minute).
+func SensorsFansWithContext(ctx context.Context) ([]FanStat, error) {
+	return []FanStat{}, common.ErrNotImplementedError
+}


### PR DESCRIPTION
* Added the host.SensorsFans() function
* Added the host.SensorsFansWithContext() function
* Added the FanStat struct
* Added support for Linux and not implemented error in other OSs

Example output:

[{"sensorKey":"nct6776","sensorSpeed":2768} {"sensorKey":"nct6776","sensorSpeed":3161}]