### PR TITLE
add go.mod and add "v2" to import path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/shirou/gopsutil/v2
+
+go 1.14
+
+require (
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
+	github.com/davecgh/go-spew v1.1.1
+	github.com/go-ole/go-ole v1.2.4
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.6.0
+	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6
+	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
+)
+
+replace github.com/shirou/gopsutil/v2 => github.com/shirou/gopsutil v2.20.7


### PR DESCRIPTION
add `gomod` and `v2` to import paths.

This PR should be merged 
- after golang 1.15 release and
- before releasing v2.20.7.

Because go module becomes default enable after 1.13, and 1.12 will be EoL at 1.15 release. So we should add go.mod after that.
and adding go.mod is not enough. To add latest go mod supported version to https://proxy.golang.org, new git-tag version is required. so we should merge this PR at certain timing.

If releasing 1.15 becomes delayed, merge will be postponed to next monthly release.

