### PR TITLE
Add arch buildconstraints on disk for openbsd (fixes #912)

### DIFF
--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -1,4 +1,5 @@
 // +build openbsd
+// +build amd64 386
 
 package disk
 


### PR DESCRIPTION
There's definitions for amd64 and 386, but nothing else on openbsd. In the version we used previously the build constraint was `openbsd,amd64`, now it's just `openbsd`. I now added build constraints for either `amd64` or `386`, thus "fixing" the build on arm (no functionality, but also no build failure).