### PR TITLE
net_linux.go: decode port as uint16 instead if int64

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -696,7 +696,7 @@ func decodeAddress(family uint32, src string) (Addr, error) {
 		return Addr{}, fmt.Errorf("does not contain port, %s", src)
 	}
 	addr := t[0]
-	port, err := strconv.ParseInt("0x"+t[1], 0, 64)
+	port, err := strconv.ParseUint(t[1], 16, 16)
 	if err != nil {
 		return Addr{}, fmt.Errorf("invalid port, %s", src)
 	}


### PR DESCRIPTION
Changes the port parsing from `/proc/net/*` files records from parsing them as 64-bit integers to parse them as 16-bit unsigned integers.

While this is mostly a cosmetic change, it will also make so that the code fails faster in case the entry is malformed (for whatever reason).

Note that the returned value is still casted to uint32 when an  `Addr` object is created. 
It seems to me that the `Addr.port` field should be changed to `uint16` but maybe some other APIs/systems wants it to be `uint32` and also changing it there may require changes in users code if they update. This being said I am not changing that field's type.

EDIT: Additionally, I am also changing the `base` used for parsing to 16 and removing the addition of `"0x"` string prefix. The `base=16` is the appropriate base here and the `"0x"` prefix is redundant after we explicitly specify the base.