### PR TITLE
fix an invalid shift in windows processes name UTF16 conversion

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -1002,7 +1002,7 @@ func convertUTF16ToString(src []byte) string {
 
 	srcIdx := 0
 	for i := 0; i < srcLen; i++ {
-		codePoints[i] = uint16(src[srcIdx]) | uint16(src[srcIdx+1]<<8)
+		codePoints[i] = uint16(src[srcIdx]) | uint16(src[srcIdx+1])<<8
 		srcIdx += 2
 	}
 	return syscall.UTF16ToString(codePoints)


### PR DESCRIPTION
Hello there,

this trivial PR should fix the conversion of UTF16 byte slices to strings, which was invalid in the presence of "high" UCS-2 or unicode codepoints.

Have a nice day !
