### PR TITLE
use new syscall on darwin

### DIFF
--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -36,7 +36,7 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	// get required buffer size
 	length := uint64(0)
 	_, _, err := unix.Syscall6(
-		unix.SYS___SYSCTL,
+		unix.SYS_SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		0,
@@ -54,7 +54,7 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	// get proc info itself
 	buf := make([]byte, length)
 	_, _, err = unix.Syscall6(
-		unix.SYS___SYSCTL,
+		unix.SYS_SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -611,7 +611,7 @@ func (p *Process) getKProcWithContext(ctx context.Context) (*KinfoProc, error) {
 	length := uint64(unsafe.Sizeof(procK))
 	buf := make([]byte, length)
 	_, _, syserr := unix.Syscall6(
-		unix.SYS___SYSCTL,
+		unix.SYS_SYSCTL,
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(len(mib)),
 		uintptr(unsafe.Pointer(&buf[0])),


### PR DESCRIPTION
Go has officially removed support for the old style of syscalls.
See https://github.com/golang/sys/commit/6fcdbc0bbc04dcd9e7dc145879ceaf9bf1c6ff03

fixes #925 