### PR TITLE
Fix TestVirtual_memory on OpenBSD

### DIFF
--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -33,7 +33,7 @@ func TestVirtual_memory(t *testing.T) {
 	case "windows":
 		total = v.Used + v.Available
 		totalStr = "used + available"
-	case "darwin":
+	case "darwin", "openbsd":
 		total = v.Used + v.Free + v.Cached + v.Inactive
 		totalStr = "used + free + cached + inactive"
 	case "freebsd":


### PR DESCRIPTION
On OpenBSD, the total is used + free + cached + inactive like on macOS.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>