### PR TITLE
[linux] Fix #900, skip or fix failing tests in docker

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -67,7 +67,7 @@ func TestUsers(t *testing.T) {
 	}
 	empty := UserStat{}
 	if len(v) == 0 {
-		t.Fatal("Users is empty")
+		t.Skip("Users is empty")
 	}
 	for _, u := range v {
 		if u == empty {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -253,7 +253,10 @@ func Test_Process_Groups(t *testing.T) {
 	if err != nil {
 		t.Errorf("getting groups error %v", err)
 	}
-	if len(v) <= 0 || v[0] < 0 {
+	if len(v) == 0 {
+		t.Skip("Groups is empty")
+	}
+	if v[0] < 0 {
 		t.Errorf("invalid Groups: %v", v)
 	}
 }


### PR DESCRIPTION
TestGetProcInodesAll: create a server so there are some opened inodes
TestUsers: skip if Users is empty, because of an empty /var/run/utmp
Test_Process_Groups: skip if Groups is empty
TestConnectionsMax: skip on CI, not only CircleCI