### PR TITLE
[process][darwin] Fix #925 remove references to removed const unix.SYS___SYSCTL from x/sys/unix

### DIFF
--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -36,7 +36,7 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	// get required buffer size
 	length := uint64(0)
 	_, _, err := unix.Syscall6(
-		unix.SYS___SYSCTL,
+		202, // unix.SYS___SYSCTL https://github.com/golang/sys/blob/76b94024e4b621e672466e8db3d7f084e7ddcad2/unix/zsysnum_darwin_amd64.go#L146
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		0,
@@ -54,7 +54,7 @@ func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	// get proc info itself
 	buf := make([]byte, length)
 	_, _, err = unix.Syscall6(
-		unix.SYS___SYSCTL,
+		202, // unix.SYS___SYSCTL https://github.com/golang/sys/blob/76b94024e4b621e672466e8db3d7f084e7ddcad2/unix/zsysnum_darwin_amd64.go#L146
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(miblen),
 		uintptr(unsafe.Pointer(&buf[0])),

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -611,7 +611,7 @@ func (p *Process) getKProcWithContext(ctx context.Context) (*KinfoProc, error) {
 	length := uint64(unsafe.Sizeof(procK))
 	buf := make([]byte, length)
 	_, _, syserr := unix.Syscall6(
-		unix.SYS___SYSCTL,
+		202, // unix.SYS___SYSCTL https://github.com/golang/sys/blob/76b94024e4b621e672466e8db3d7f084e7ddcad2/unix/zsysnum_darwin_amd64.go#L146
 		uintptr(unsafe.Pointer(&mib[0])),
 		uintptr(len(mib)),
 		uintptr(unsafe.Pointer(&buf[0])),


### PR DESCRIPTION
More like a workaround, wanted to port process.getKProcWithContext() to use unix.SysctlRaw() to get rid of exec calls to ps
in the same time but didn't have time.