### PR TITLE
Cache common/common_linux.Virtualization()

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -110,7 +110,14 @@ func Virtualization() (string, string, error) {
 	return VirtualizationWithContext(context.Background())
 }
 
+var virtualizationCache map[string]string = nil
+
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
+	// if cached already, return from cache
+	if virtualizationCache != nil {
+		return virtualizationCache["system"], virtualizationCache["role"], nil
+	}
+	
 	var system string
 	var role string
 
@@ -231,6 +238,13 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 			role = "host"
 		}
 	}
+	
+	// before returning for the first time, cache the system and role
+	virtualizationCache = map[string]string{
+		"system":	system,
+		"role": 	role,
+	}
+	
 	return system, role, nil
 }
 

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -110,7 +110,7 @@ func Virtualization() (string, string, error) {
 	return VirtualizationWithContext(context.Background())
 }
 
-var virtualizationCache map[string]string = nil
+var virtualizationCache map[string]string
 
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 	// if cached already, return from cache


### PR DESCRIPTION
By assuming virtualization environment won't change during a the program's runtime, we can cache common/common_linux.Virtualization() with a simple map to reduce amount of system calls. I first mentioned this issue at [890](https://github.com/shirou/gopsutil/pull/890#issuecomment-690211919)