### PR TITLE
Refactor "host" package

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -1,7 +1,11 @@
 package host
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"runtime"
+	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
@@ -51,4 +55,100 @@ func (u UserStat) String() string {
 func (t TemperatureStat) String() string {
 	s, _ := json.Marshal(t)
 	return string(s)
+}
+
+func Info() (*InfoStat, error) {
+	return InfoWithContext(context.Background())
+}
+
+func InfoWithContext(ctx context.Context) (*InfoStat, error) {
+	var err error
+	ret := &InfoStat{
+		OS: runtime.GOOS,
+	}
+
+	ret.Hostname, err = os.Hostname()
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.Platform, ret.PlatformFamily, ret.PlatformVersion, err = PlatformInformationWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.KernelVersion, err = KernelVersionWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.KernelArch, err = KernelArch()
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.VirtualizationSystem, ret.VirtualizationRole, err = VirtualizationWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.BootTime, err = BootTimeWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.Uptime, err = UptimeWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.Procs, err = numProcs(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	ret.HostID, err = HostIDWithContext(ctx)
+	if err != nil && err != common.ErrNotImplementedError {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// BootTime returns the system boot time expressed in seconds since the epoch.
+func BootTime() (uint64, error) {
+	return BootTimeWithContext(context.Background())
+}
+
+func Uptime() (uint64, error) {
+	return UptimeWithContext(context.Background())
+}
+
+func Users() ([]UserStat, error) {
+	return UsersWithContext(context.Background())
+}
+
+func PlatformInformation() (string, string, string, error) {
+	return PlatformInformationWithContext(context.Background())
+}
+
+// HostID returns the unique host ID provided by the OS.
+func HostID() (string, error) {
+	return HostIDWithContext(context.Background())
+}
+
+func Virtualization() (string, string, error) {
+	return VirtualizationWithContext(context.Background())
+}
+
+func KernelVersion() (string, error) {
+	return KernelVersionWithContext(context.Background())
+}
+
+func SensorsTemperatures() ([]TemperatureStat, error) {
+	return SensorsTemperaturesWithContext(context.Background())
+}
+
+func timeSince(ts uint64) uint64 {
+	return uint64(time.Now().Unix()) - ts
 }

--- a/host/host_bsd.go
+++ b/host/host_bsd.go
@@ -5,17 +5,12 @@ package host
 import (
 	"context"
 	"sync/atomic"
-	"time"
 
 	"golang.org/x/sys/unix"
 )
 
 // cachedBootTime must be accessed via atomic.Load/StoreUint64
 var cachedBootTime uint64
-
-func BootTime() (uint64, error) {
-	return BootTimeWithContext(context.Background())
-}
 
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	t := atomic.LoadUint64(&cachedBootTime)
@@ -32,18 +27,10 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	return uint64(tv.Sec), nil
 }
 
-func uptime(boot uint64) uint64 {
-	return uint64(time.Now().Unix()) - boot
-}
-
-func Uptime() (uint64, error) {
-	return UptimeWithContext(context.Background())
-}
-
 func UptimeWithContext(ctx context.Context) (uint64, error) {
 	boot, err := BootTimeWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return uptime(boot), nil
+	return timeSince(boot), nil
 }

--- a/host/host_darwin_cgo.go
+++ b/host/host_darwin_cgo.go
@@ -8,10 +8,6 @@ package host
 import "C"
 import "context"
 
-func SensorsTemperatures() ([]TemperatureStat, error) {
-	return SensorsTemperaturesWithContext(context.Background())
-}
-
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	temperatureKeys := []string{
 		C.AMBIENT_AIR_0,

--- a/host/host_darwin_nocgo.go
+++ b/host/host_darwin_nocgo.go
@@ -9,10 +9,6 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-func SensorsTemperatures() ([]TemperatureStat, error) {
-	return SensorsTemperaturesWithContext(context.Background())
-}
-
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	return []TemperatureStat{}, common.ErrNotImplementedError
 }

--- a/host/host_fallback.go
+++ b/host/host_fallback.go
@@ -8,58 +8,42 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-func Info() (*InfoStat, error) {
-	return InfoWithContext(context.Background())
+func HostIDWithContext(ctx context.Context) (string, error) {
+	return "", common.ErrNotImplementedError
 }
 
-func InfoWithContext(ctx context.Context) (*InfoStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func BootTime() (uint64, error) {
-	return BootTimeWithContext(context.Background())
+func numProcs(ctx context.Context) (uint64, error) {
+	return 0, common.ErrNotImplementedError
 }
 
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	return 0, common.ErrNotImplementedError
 }
 
-func Uptime() (uint64, error) {
-	return UptimeWithContext(context.Background())
-}
-
 func UptimeWithContext(ctx context.Context) (uint64, error) {
 	return 0, common.ErrNotImplementedError
-}
-
-func Users() ([]UserStat, error) {
-	return UsersWithContext(context.Background())
 }
 
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	return []UserStat{}, common.ErrNotImplementedError
 }
 
-func Virtualization() (string, string, error) {
-	return VirtualizationWithContext(context.Background())
-}
-
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 	return "", "", common.ErrNotImplementedError
-}
-
-func KernelVersion() (string, error) {
-	return KernelVersionWithContext(context.Background())
 }
 
 func KernelVersionWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
 
-func PlatformInformation() (string, string, string, error) {
-	return PlatformInformationWithContext(context.Background())
-}
-
 func PlatformInformationWithContext(ctx context.Context) (string, string, string, error) {
 	return "", "", "", common.ErrNotImplementedError
+}
+
+func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
+	return []TemperatureStat{}, common.ErrNotImplementedError
+}
+
+func KernelArch() (string, error) {
+	return "", common.ErrNotImplementedError
 }

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -12,10 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
@@ -31,52 +29,7 @@ type LSB struct {
 // from utmp.h
 const USER_PROCESS = 7
 
-func Info() (*InfoStat, error) {
-	return InfoWithContext(context.Background())
-}
-
-func InfoWithContext(ctx context.Context) (*InfoStat, error) {
-	ret := &InfoStat{
-		OS: runtime.GOOS,
-	}
-
-	hostname, err := os.Hostname()
-	if err == nil {
-		ret.Hostname = hostname
-	}
-
-	platform, family, version, err := PlatformInformation()
-	if err == nil {
-		ret.Platform = platform
-		ret.PlatformFamily = family
-		ret.PlatformVersion = version
-	}
-	kernelVersion, err := KernelVersion()
-	if err == nil {
-		ret.KernelVersion = kernelVersion
-	}
-
-	kernelArch, err := kernelArch()
-	if err == nil {
-		ret.KernelArch = kernelArch
-	}
-
-	system, role, err := Virtualization()
-	if err == nil {
-		ret.VirtualizationSystem = system
-		ret.VirtualizationRole = role
-	}
-
-	boot, err := BootTime()
-	if err == nil {
-		ret.BootTime = boot
-		ret.Uptime = uptime(boot)
-	}
-
-	if numProcs, err := common.NumProcs(); err == nil {
-		ret.Procs = numProcs
-	}
-
+func HostIDWithContext(ctx context.Context) (string, error) {
 	sysProductUUID := common.HostSys("class/dmi/id/product_uuid")
 	machineID := common.HostEtc("machine-id")
 	procSysKernelRandomBootID := common.HostProc("sys/kernel/random/boot_id")
@@ -86,8 +39,7 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 	case common.PathExists(sysProductUUID):
 		lines, err := common.ReadLines(sysProductUUID)
 		if err == nil && len(lines) > 0 && lines[0] != "" {
-			ret.HostID = strings.ToLower(lines[0])
-			break
+			return strings.ToLower(lines[0]), nil
 		}
 		fallthrough
 	// Fallback on GNU Linux systems with systemd, readable by everyone
@@ -95,36 +47,26 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 		lines, err := common.ReadLines(machineID)
 		if err == nil && len(lines) > 0 && len(lines[0]) == 32 {
 			st := lines[0]
-			ret.HostID = fmt.Sprintf("%s-%s-%s-%s-%s", st[0:8], st[8:12], st[12:16], st[16:20], st[20:32])
-			break
+			return fmt.Sprintf("%s-%s-%s-%s-%s", st[0:8], st[8:12], st[12:16], st[16:20], st[20:32]), nil
 		}
 		fallthrough
 	// Not stable between reboot, but better than nothing
 	default:
 		lines, err := common.ReadLines(procSysKernelRandomBootID)
 		if err == nil && len(lines) > 0 && lines[0] != "" {
-			ret.HostID = strings.ToLower(lines[0])
+			return strings.ToLower(lines[0]), nil
 		}
 	}
 
-	return ret, nil
+	return "", nil
 }
 
-// BootTime returns the system boot time expressed in seconds since the epoch.
-func BootTime() (uint64, error) {
-	return BootTimeWithContext(context.Background())
+func numProcs(ctx context.Context) (uint64, error) {
+	return common.NumProcs()
 }
 
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	return common.BootTimeWithContext(ctx)
-}
-
-func uptime(boot uint64) uint64 {
-	return uint64(time.Now().Unix()) - boot
-}
-
-func Uptime() (uint64, error) {
-	return UptimeWithContext(context.Background())
 }
 
 func UptimeWithContext(ctx context.Context) (uint64, error) {
@@ -132,11 +74,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uptime(boot), nil
-}
-
-func Users() ([]UserStat, error) {
-	return UsersWithContext(context.Background())
+	return timeSince(boot), nil
 }
 
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
@@ -236,12 +174,7 @@ func getLSB() (*LSB, error) {
 	return ret, nil
 }
 
-func PlatformInformation() (platform string, family string, version string, err error) {
-	return PlatformInformationWithContext(context.Background())
-}
-
 func PlatformInformationWithContext(ctx context.Context) (platform string, family string, version string, err error) {
-
 	lsb, err := getLSB()
 	if err != nil {
 		lsb = &LSB{}
@@ -370,10 +303,6 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 
 }
 
-func KernelVersion() (version string, err error) {
-	return KernelVersionWithContext(context.Background())
-}
-
 func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 	var utsname unix.Utsname
 	err = unix.Uname(&utsname)
@@ -432,16 +361,8 @@ func getSusePlatform(contents []string) string {
 	return "suse"
 }
 
-func Virtualization() (string, string, error) {
-	return VirtualizationWithContext(context.Background())
-}
-
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 	return common.VirtualizationWithContext(ctx)
-}
-
-func SensorsTemperatures() ([]TemperatureStat, error) {
-	return SensorsTemperaturesWithContext(context.Background())
 }
 
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"strings"
 	"unsafe"
 
@@ -23,54 +22,16 @@ const (
 	UTHostSize = 16
 )
 
-func Info() (*InfoStat, error) {
-	return InfoWithContext(context.Background())
+func HostIDWithContext(ctx context.Context) (string, error) {
+	return "", common.ErrNotImplementedError
 }
 
-func InfoWithContext(ctx context.Context) (*InfoStat, error) {
-	ret := &InfoStat{
-		OS:             runtime.GOOS,
-		PlatformFamily: "openbsd",
+func numProcs(ctx context.Context) (uint64, error) {
+	procs, err := process.PidsWithContext(ctx)
+	if err != nil {
+		return 0, err
 	}
-
-	hostname, err := os.Hostname()
-	if err == nil {
-		ret.Hostname = hostname
-	}
-
-	kernelArch, err := kernelArch()
-	if err == nil {
-		ret.KernelArch = kernelArch
-	}
-
-	platform, family, version, err := PlatformInformation()
-	if err == nil {
-		ret.Platform = platform
-		ret.PlatformFamily = family
-		ret.PlatformVersion = version
-	}
-	system, role, err := Virtualization()
-	if err == nil {
-		ret.VirtualizationSystem = system
-		ret.VirtualizationRole = role
-	}
-
-	procs, err := process.Pids()
-	if err == nil {
-		ret.Procs = uint64(len(procs))
-	}
-
-	boot, err := BootTime()
-	if err == nil {
-		ret.BootTime = boot
-		ret.Uptime = uptime(boot)
-	}
-
-	return ret, nil
-}
-
-func PlatformInformation() (string, string, string, error) {
-	return PlatformInformationWithContext(context.Background())
+	return uint64(len(procs)), nil
 }
 
 func PlatformInformationWithContext(ctx context.Context) (string, string, string, error) {
@@ -90,16 +51,8 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 	return platform, family, version, nil
 }
 
-func Virtualization() (string, string, error) {
-	return VirtualizationWithContext(context.Background())
-}
-
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 	return "", "", common.ErrNotImplementedError
-}
-
-func Users() ([]UserStat, error) {
-	return UsersWithContext(context.Background())
 }
 
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
@@ -141,19 +94,11 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	return ret, nil
 }
 
-func SensorsTemperatures() ([]TemperatureStat, error) {
-	return SensorsTemperaturesWithContext(context.Background())
-}
-
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	return []TemperatureStat{}, common.ErrNotImplementedError
 }
 
-func KernelVersion() (string, error) {
-	return KernelVersionWithContext(context.Background())
-}
-
 func KernelVersionWithContext(ctx context.Context) (string, error) {
-	_, _, version, err := PlatformInformation()
+	_, _, version, err := PlatformInformationWithContext(ctx)
 	return version, err
 }

--- a/host/host_posix.go
+++ b/host/host_posix.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func kernelArch() (string, error) {
+func KernelArch() (string, error) {
 	var utsname unix.Utsname
 	err := unix.Uname(&utsname)
 	return string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]), err

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -16,7 +14,7 @@ import (
 
 	"github.com/StackExchange/wmi"
 	"github.com/shirou/gopsutil/internal/common"
-	process "github.com/shirou/gopsutil/process"
+	"github.com/shirou/gopsutil/process"
 	"golang.org/x/sys/windows"
 )
 
@@ -64,66 +62,7 @@ type msAcpi_ThermalZoneTemperature struct {
 	InstanceName       string
 }
 
-func Info() (*InfoStat, error) {
-	return InfoWithContext(context.Background())
-}
-
-func InfoWithContext(ctx context.Context) (*InfoStat, error) {
-	ret := &InfoStat{
-		OS: runtime.GOOS,
-	}
-
-	{
-		hostname, err := os.Hostname()
-		if err == nil {
-			ret.Hostname = hostname
-		}
-	}
-
-	{
-		platform, family, version, err := PlatformInformationWithContext(ctx)
-		if err == nil {
-			ret.Platform = platform
-			ret.PlatformFamily = family
-			ret.PlatformVersion = version
-		} else {
-			return ret, err
-		}
-	}
-
-	{
-		kernelArch, err := kernelArch()
-		if err == nil {
-			ret.KernelArch = kernelArch
-		}
-	}
-
-	{
-		boot, err := BootTimeWithContext(ctx)
-		if err == nil {
-			ret.BootTime = boot
-			ret.Uptime, _ = Uptime()
-		}
-	}
-
-	{
-		hostID, err := getMachineGuid()
-		if err == nil {
-			ret.HostID = hostID
-		}
-	}
-
-	{
-		procs, err := process.PidsWithContext(ctx)
-		if err == nil {
-			ret.Procs = uint64(len(procs))
-		}
-	}
-
-	return ret, nil
-}
-
-func getMachineGuid() (string, error) {
+func HostIDWithContext(ctx context.Context) (string, error) {
 	// there has been reports of issues on 32bit using golang.org/x/sys/windows/registry, see https://github.com/shirou/gopsutil/pull/312#issuecomment-277422612
 	// for rationale of using windows.RegOpenKeyEx/RegQueryValueEx instead of registry.OpenKey/GetStringValue
 	var h windows.Handle
@@ -153,8 +92,12 @@ func getMachineGuid() (string, error) {
 	return strings.ToLower(hostID), nil
 }
 
-func Uptime() (uint64, error) {
-	return UptimeWithContext(context.Background())
+func numProcs(ctx context.Context) (uint64, error) {
+	procs, err := process.PidsWithContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(procs)), nil
 }
 
 func UptimeWithContext(ctx context.Context) (uint64, error) {
@@ -170,16 +113,8 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	return uint64((time.Duration(r1) * time.Millisecond).Seconds()), nil
 }
 
-func bootTimeFromUptime(up uint64) uint64 {
-	return uint64(time.Now().Unix()) - up
-}
-
 // cachedBootTime must be accessed via atomic.Load/StoreUint64
 var cachedBootTime uint64
-
-func BootTime() (uint64, error) {
-	return BootTimeWithContext(context.Background())
-}
 
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	t := atomic.LoadUint64(&cachedBootTime)
@@ -190,13 +125,9 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	t = bootTimeFromUptime(up)
+	t = timeSince(up)
 	atomic.StoreUint64(&cachedBootTime, t)
 	return t, nil
-}
-
-func PlatformInformation() (platform string, family string, version string, err error) {
-	return PlatformInformationWithContext(context.Background())
 }
 
 func PlatformInformationWithContext(ctx context.Context) (platform string, family string, version string, err error) {
@@ -212,7 +143,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	}
 
 	// Platform
-	var h windows.Handle // like getMachineGuid(), we query the registry using the raw windows.RegOpenKeyEx/RegQueryValueEx
+	var h windows.Handle // like HostIDWithContext(), we query the registry using the raw windows.RegOpenKeyEx/RegQueryValueEx
 	err = windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, windows.StringToUTF16Ptr(`SOFTWARE\Microsoft\Windows NT\CurrentVersion`), 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &h)
 	if err != nil {
 		return
@@ -258,18 +189,10 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	return platform, family, version, nil
 }
 
-func Users() ([]UserStat, error) {
-	return UsersWithContext(context.Background())
-}
-
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	var ret []UserStat
 
 	return ret, common.ErrNotImplementedError
-}
-
-func SensorsTemperatures() ([]TemperatureStat, error) {
-	return SensorsTemperaturesWithContext(context.Background())
 }
 
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
@@ -299,24 +222,16 @@ func kelvinToCelsius(temp uint32, n int) float64 {
 	return math.Trunc((t+0.5/n10)*n10) / n10
 }
 
-func Virtualization() (string, string, error) {
-	return VirtualizationWithContext(context.Background())
-}
-
 func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 	return "", "", common.ErrNotImplementedError
 }
 
-func KernelVersion() (string, error) {
-	return KernelVersionWithContext(context.Background())
-}
-
 func KernelVersionWithContext(ctx context.Context) (string, error) {
-	_, _, version, err := PlatformInformation()
+	_, _, version, err := PlatformInformationWithContext(ctx)
 	return version, err
 }
 
-func kernelArch() (string, error) {
+func KernelArch() (string, error) {
 	var systemInfo systemInfo
 	procGetNativeSystemInfo.Call(uintptr(unsafe.Pointer(&systemInfo)))
 


### PR DESCRIPTION
This has stared as an attempt to export a `HostID` exporter, but the resulting patch is mostly refactoring. Here are the main changes:

- `InfoWithContext()` function was unified across all platforms, and now relies on platform-specific function implementations.
- `InfoWithContext()` function now has the same behavior across all platforms (for example, some platfors ignored underlying errors, and some returned them).
- Call context is now passed to all underlying functions in `InfoWithContext()`.
- All context-less wrapping functions (the ones without `WithContext` suffix) were moved into `host.go` since they all are the same.
- `KernelArch()` function is now exported since there was no way to get its value without calling the `InfoWithContext()`, which is clearly an overkill.
- Platform-specific `HostID()` function was added for the same reasons as above.
- Missing function placeholders were added to the `host_fallback.go`.
- Some parts of `host_solaris.go` were rewritten. `PlatformInformationWithContext()` now returns sane values.