### PR TITLE
[host][linux] Change to use unix.SysInfo_t to get Uptime in Linux

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -70,11 +70,11 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 }
 
 func UptimeWithContext(ctx context.Context) (uint64, error) {
-	boot, err := BootTime()
-	if err != nil {
+	sysinfo := &unix.Sysinfo_t{}
+	if err := unix.Sysinfo(sysinfo); err != nil {
 		return 0, err
 	}
-	return timeSince(boot), nil
+	return uint64(sysinfo.Uptime), nil
 }
 
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {


### PR DESCRIPTION
According to [this](https://github.com/shirou/gopsutil/pull/857#issuecomment-629858607) and [this](https://github.com/shirou/gopsutil/pull/942#issuecomment-691185427) comments, change to use `unix.Sysinfo_t` in Linux.

Unfortunately, other platform such as FreeBSD do not include "Uptime" in Sysinfo. So this only for Linux.