### PR TITLE
Fix VirtualizationWithContext() race in linux

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -3,6 +3,7 @@ package host
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/shirou/gopsutil/internal/common"
@@ -144,13 +145,24 @@ func TestTemperatureStat_String(t *testing.T) {
 }
 
 func TestVirtualization(t *testing.T) {
-	system, role, err := Virtualization()
-	skipIfNotImplementedErr(t, err)
-	if err != nil {
-		t.Errorf("Virtualization() failed, %v", err)
-	}
+	wg := sync.WaitGroup{}
+	testCount := 10
+	wg.Add(testCount)
+	for i := 0; i < testCount; i++ {
+		go func(j int) {
+			system, role, err := Virtualization()
+			wg.Done()
+			skipIfNotImplementedErr(t, err)
+			if err != nil {
+				t.Errorf("Virtualization() failed, %v", err)
+			}
 
-	t.Logf("Virtualization(): %s, %s", system, role)
+			if j == 9 {
+				t.Logf("Virtualization(): %s, %s", system, role)
+			}
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestKernelVersion(t *testing.T) {


### PR DESCRIPTION
The current common linux `VirtualizationWithContext()` function* isn't thread safe.  These changes introduce a cache singleton to prevent data races:

With only test update:
```
root@1a49945dd9fa:/go/src/github.com/shirou/gopsutil/host# go test -race -run=TestVirtualization
==================
WARNING: DATA RACE
Write at 0x0000007d8548 by goroutine 8:
  github.com/shirou/gopsutil/internal/common.VirtualizationWithContext()
      /go/src/github.com/shirou/gopsutil/internal/common/common_linux.go:243 +0x933
  github.com/shirou/gopsutil/host.VirtualizationWithContext()
      /go/src/github.com/shirou/gopsutil/host/host_linux.go:365 +0x5a
  github.com/shirou/gopsutil/host.Virtualization()
      /go/src/github.com/shirou/gopsutil/host/host.go:141 +0x97
  github.com/shirou/gopsutil/host.TestVirtualization.func1()
      /go/src/github.com/shirou/gopsutil/host/host_test.go:153 +0x44

Previous read at 0x0000007d8548 by goroutine 14:
  github.com/shirou/gopsutil/internal/common.VirtualizationWithContext()
      /go/src/github.com/shirou/gopsutil/internal/common/common_linux.go:117 +0x52
  github.com/shirou/gopsutil/host.VirtualizationWithContext()
      /go/src/github.com/shirou/gopsutil/host/host_linux.go:365 +0x5a
  github.com/shirou/gopsutil/host.Virtualization()
      /go/src/github.com/shirou/gopsutil/host/host.go:141 +0x97
  github.com/shirou/gopsutil/host.TestVirtualization.func1()
      /go/src/github.com/shirou/gopsutil/host/host_test.go:153 +0x44

Goroutine 8 (running) created at:
  github.com/shirou/gopsutil/host.TestVirtualization()
      /go/src/github.com/shirou/gopsutil/host/host_test.go:152 +0xbe
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1054 +0x1eb

Goroutine 14 (running) created at:
  github.com/shirou/gopsutil/host.TestVirtualization()
      /go/src/github.com/shirou/gopsutil/host/host_test.go:152 +0xbe
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1054 +0x1eb
==================
```

With complete diff:
```
root@1a49945dd9fa:/go/src/github.com/shirou/gopsutil/host# go test -race -run=TestVirtualization
PASS
ok  	github.com/shirou/gopsutil/host	0.044s
```