### PR TITLE
[disk][darwin] fix build with latest x/sys

### DIFF
--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -64,9 +64,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			opts += ",nodev"
 		}
 		d := PartitionStat{
-			Device:     common.IntToString(stat.Mntfromname[:]),
-			Mountpoint: common.IntToString(stat.Mntonname[:]),
-			Fstype:     common.IntToString(stat.Fstypename[:]),
+			Device:     common.ByteToString(stat.Mntfromname[:]),
+			Mountpoint: common.ByteToString(stat.Mntonname[:]),
+			Fstype:     common.ByteToString(stat.Fstypename[:]),
 			Opts:       opts,
 		}
 		if all == false {
@@ -82,5 +82,5 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 }
 
 func getFsType(stat unix.Statfs_t) string {
-	return common.IntToString(stat.Fstypename[:])
+	return common.ByteToString(stat.Fstypename[:])
 }


### PR DESCRIPTION
fixes build on darwin with `golang.org/x/sys v0.0.0-20201007165808-a893ed343c85`

```
# github.com/shirou/gopsutil/disk
../../go/pkg/mod/github.com/fancybits/gopsutil@v2.16.11-0.20201007180101-23d63601d124+incompatible/disk/disk_darwin.go:67:51: cannot use stat.Mntfromname[:] (type []byte) as type []int8 in argument to common.IntToString
../../go/pkg/mod/github.com/fancybits/gopsutil@v2.16.11-0.20201007180101-23d63601d124+incompatible/disk/disk_darwin.go:68:49: cannot use stat.Mntonname[:] (type []byte) as type []int8 in argument to common.IntToString
../../go/pkg/mod/github.com/fancybits/gopsutil@v2.16.11-0.20201007180101-23d63601d124+incompatible/disk/disk_darwin.go:69:50: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
../../go/pkg/mod/github.com/fancybits/gopsutil@v2.16.11-0.20201007180101-23d63601d124+incompatible/disk/disk_darwin.go:85:43: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
```