### PR TITLE
[disk][linux] Add `Source` field to PartitionStat for original symbolic link path

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -23,6 +23,7 @@ type UsageStat struct {
 
 type PartitionStat struct {
 	Device     string `json:"device"`
+	Source     string `json:"source,omitempty"`
 	Mountpoint string `json:"mountpoint"`
 	Fstype     string `json:"fstype"`
 	Opts       string `json:"opts"`

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -303,6 +303,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			if strings.HasPrefix(d.Device, "/dev/mapper/") {
 				devpath, err := filepath.EvalSymlinks(common.HostDev(strings.Replace(d.Device, "/dev", "", -1)))
 				if err == nil {
+					d.Source = d.Device
 					d.Device = devpath
 				}
 			}

--- a/disk/disk_test.go
+++ b/disk/disk_test.go
@@ -114,6 +114,18 @@ func TestDiskPartitionStat_String(t *testing.T) {
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("DiskUsageStat string is invalid: %v", v)
 	}
+
+	v = PartitionStat{
+		Device:     "dm-1",
+		Source:     "vg0--lv0",
+		Mountpoint: "/",
+		Fstype:     "ext4",
+		Opts:       "ro",
+	}
+	e = `{"device":"dm-1","source":"vg0--lv0","mountpoint":"/","fstype":"ext4","opts":"ro"}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("DiskUsageStat string is invalid: %v", v)
+	}
 }
 
 func TestDiskIOCountersStat_String(t *testing.T) {


### PR DESCRIPTION
Currently in order to find the correct device name, anything mounted
from symbolic link under `/dev/mapper` will be evaluated to the real
device it points to. See [#686](https://github.com/shirou/gopsutil/pull/686)

However, the label under `/dev/mapper` is often much more infomative,
and is a very useful piece of informtion to keep. Though this info could
be mapped back, but it is much easier to just record it here.

In this change, I've add a new field named source and would only be
populated when the symlink evaluation had been carried out.

The json tag of the new source field is created with "omitempty" option,
so it won't create any behavior difference for code that does not make
use of it.