### PR TITLE
Various fixes for OpenBSD

### DIFF
--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -59,9 +59,15 @@ func TestCpu_times(t *testing.T) {
 		perCPUIdleTimeSum += pc.Idle
 	}
 	margin := 2.0
-	assert.InEpsilon(t, cpuTotal[0].User, perCPUUserTimeSum, margin)
-	assert.InEpsilon(t, cpuTotal[0].System, perCPUSystemTimeSum, margin)
-	assert.InEpsilon(t, cpuTotal[0].Idle, perCPUIdleTimeSum, margin)
+	if cpuTotal[0].User != 0 {
+		assert.InEpsilon(t, cpuTotal[0].User, perCPUUserTimeSum, margin)
+	}
+	if cpuTotal[0].System != 0 {
+		assert.InEpsilon(t, cpuTotal[0].System, perCPUSystemTimeSum, margin)
+	}
+	if cpuTotal[0].Idle != 0 {
+		assert.InEpsilon(t, cpuTotal[0].Idle, perCPUIdleTimeSum, margin)
+	}
 }
 
 func TestCpu_counts(t *testing.T) {

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -121,15 +121,15 @@ func TestUserStat_String(t *testing.T) {
 }
 
 func TestHostGuid(t *testing.T) {
-	hi, err := Info()
+	id, err := HostID()
 	skipIfNotImplementedErr(t, err)
 	if err != nil {
 		t.Error(err)
 	}
-	if hi.HostID == "" {
+	if id == "" {
 		t.Error("Host id is empty")
 	} else {
-		t.Logf("Host id value: %v", hi.HostID)
+		t.Logf("Host id value: %v", id)
 	}
 }
 

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -4,7 +4,6 @@ package net
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -153,7 +152,7 @@ func FilterCounters() ([]FilterStat, error) {
 }
 
 func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
-	return nil, errors.New("NetFilterCounters not implemented for openbsd")
+	return nil, common.ErrNotImplementedError
 }
 
 func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
@@ -173,7 +172,7 @@ func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
 }
 
 func ProtoCountersWithContext(ctx context.Context, protocols []string) ([]ProtoCountersStat, error) {
-	return nil, errors.New("NetProtoCounters not implemented for openbsd")
+	return nil, common.ErrNotImplementedError
 }
 
 func parseNetstatLine(line string) (ConnectionStat, error) {

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -227,7 +227,12 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 		return nil, err
 	}
 
-	return k.Groups, nil
+	groups := make([]int32, k.Ngroups)
+	for i := int16(0); i < k.Ngroups; i++ {
+		groups[i] = int32(k.Groups[i])
+	}
+
+	return groups, nil
 }
 func (p *Process) Terminal() (string, error) {
 	return p.TerminalWithContext(context.Background())


### PR DESCRIPTION
* Use Host.HostID() in TestHostGuid
* Use common.ErrNotImplementedError in net/net_openbsd.go
* Check if CPU metrics are not null before assertion in CPU.Times test
* Fix return type in Process.GroupsWithContext()