### PR TITLE
Refactor "process" package

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"runtime"
 	"sort"
+	"syscall"
 	"time"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/net"
 )
 
 var (
@@ -150,21 +152,31 @@ func PidsWithContext(ctx context.Context) ([]int32, error) {
 	return pids, err
 }
 
+// Processes returns a slice of pointers to Process structs for all
+// currently running processes.
+func Processes() ([]*Process, error) {
+	return ProcessesWithContext(context.Background())
+}
+
 // NewProcess creates a new Process instance, it only stores the pid and
 // checks that the process exists. Other method on Process can be used
 // to get more information about the process. An error will be returned
 // if the process does not exist.
 func NewProcess(pid int32) (*Process, error) {
+	return NewProcessWithContext(context.Background(), pid)
+}
+
+func NewProcessWithContext(ctx context.Context, pid int32) (*Process, error) {
 	p := &Process{Pid: pid}
 
-	exists, err := PidExists(pid)
+	exists, err := PidExistsWithContext(ctx, pid)
 	if err != nil {
 		return p, err
 	}
 	if !exists {
 		return p, ErrorProcessNotRunning
 	}
-	p.CreateTime()
+	p.CreateTimeWithContext(ctx)
 	return p, nil
 }
 
@@ -192,7 +204,7 @@ func (p *Process) Percent(interval time.Duration) (float64, error) {
 }
 
 func (p *Process) PercentWithContext(ctx context.Context, interval time.Duration) (float64, error) {
-	cpuTimes, err := p.Times()
+	cpuTimes, err := p.TimesWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -204,7 +216,7 @@ func (p *Process) PercentWithContext(ctx context.Context, interval time.Duration
 		if err := common.Sleep(ctx, interval); err != nil {
 			return 0, err
 		}
-		cpuTimes, err = p.Times()
+		cpuTimes, err = p.TimesWithContext(ctx)
 		now = time.Now()
 		if err != nil {
 			return 0, err
@@ -236,7 +248,7 @@ func (p *Process) IsRunningWithContext(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	p2, err := NewProcess(p.Pid)
+	p2, err := NewProcessWithContext(ctx, p.Pid)
 	if err == ErrorProcessNotRunning {
 		return false, nil
 	}
@@ -276,13 +288,13 @@ func (p *Process) MemoryPercent() (float32, error) {
 }
 
 func (p *Process) MemoryPercentWithContext(ctx context.Context) (float32, error) {
-	machineMemory, err := mem.VirtualMemory()
+	machineMemory, err := mem.VirtualMemoryWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
 	total := machineMemory.Total
 
-	processMemory, err := p.MemoryInfo()
+	processMemory, err := p.MemoryInfoWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -297,12 +309,12 @@ func (p *Process) CPUPercent() (float64, error) {
 }
 
 func (p *Process) CPUPercentWithContext(ctx context.Context) (float64, error) {
-	crt_time, err := p.CreateTime()
+	crt_time, err := p.createTimeWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	cput, err := p.Times()
+	cput, err := p.TimesWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -319,4 +331,209 @@ func (p *Process) CPUPercentWithContext(ctx context.Context) (float64, error) {
 // Groups returns all group IDs(include supplementary groups) of the process as a slice of the int
 func (p *Process) Groups() ([]int32, error) {
 	return p.GroupsWithContext(context.Background())
+}
+
+// Ppid returns Parent Process ID of the process.
+func (p *Process) Ppid() (int32, error) {
+	return p.PpidWithContext(context.Background())
+}
+
+// Name returns name of the process.
+func (p *Process) Name() (string, error) {
+	return p.NameWithContext(context.Background())
+}
+
+// Exe returns executable path of the process.
+func (p *Process) Exe() (string, error) {
+	return p.ExeWithContext(context.Background())
+}
+
+// Cmdline returns the command line arguments of the process as a string with
+// each argument separated by 0x20 ascii character.
+func (p *Process) Cmdline() (string, error) {
+	return p.CmdlineWithContext(context.Background())
+}
+
+// CmdlineSlice returns the command line arguments of the process as a slice with each
+// element being an argument.
+func (p *Process) CmdlineSlice() ([]string, error) {
+	return p.CmdlineSliceWithContext(context.Background())
+}
+
+// Cwd returns current working directory of the process.
+func (p *Process) Cwd() (string, error) {
+	return p.CwdWithContext(context.Background())
+}
+
+// Parent returns parent Process of the process.
+func (p *Process) Parent() (*Process, error) {
+	return p.ParentWithContext(context.Background())
+}
+
+// Status returns the process status.
+// Return value could be one of these.
+// R: Running S: Sleep T: Stop I: Idle
+// Z: Zombie W: Wait L: Lock
+// The character is same within all supported platforms.
+func (p *Process) Status() (string, error) {
+	return p.StatusWithContext(context.Background())
+}
+
+// Foreground returns true if the process is in foreground, false otherwise.
+func (p *Process) Foreground() (bool, error) {
+	return p.ForegroundWithContext(context.Background())
+}
+
+// Uids returns user ids of the process as a slice of the int
+func (p *Process) Uids() ([]int32, error) {
+	return p.UidsWithContext(context.Background())
+}
+
+// Gids returns group ids of the process as a slice of the int
+func (p *Process) Gids() ([]int32, error) {
+	return p.GidsWithContext(context.Background())
+}
+
+// Terminal returns a terminal which is associated with the process.
+func (p *Process) Terminal() (string, error) {
+	return p.TerminalWithContext(context.Background())
+}
+
+// Nice returns a nice value (priority).
+func (p *Process) Nice() (int32, error) {
+	return p.NiceWithContext(context.Background())
+}
+
+// IOnice returns process I/O nice value (priority).
+func (p *Process) IOnice() (int32, error) {
+	return p.IOniceWithContext(context.Background())
+}
+
+// Rlimit returns Resource Limits.
+func (p *Process) Rlimit() ([]RlimitStat, error) {
+	return p.RlimitWithContext(context.Background())
+}
+
+// RlimitUsage returns Resource Limits.
+// If gatherUsed is true, the currently used value will be gathered and added
+// to the resulting RlimitStat.
+func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
+	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
+}
+
+// IOCounters returns IO Counters.
+func (p *Process) IOCounters() (*IOCountersStat, error) {
+	return p.IOCountersWithContext(context.Background())
+}
+
+// NumCtxSwitches returns the number of the context switches of the process.
+func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
+	return p.NumCtxSwitchesWithContext(context.Background())
+}
+
+// NumFDs returns the number of File Descriptors used by the process.
+func (p *Process) NumFDs() (int32, error) {
+	return p.NumFDsWithContext(context.Background())
+}
+
+// NumThreads returns the number of threads used by the process.
+func (p *Process) NumThreads() (int32, error) {
+	return p.NumThreadsWithContext(context.Background())
+}
+
+func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
+	return p.ThreadsWithContext(context.Background())
+}
+
+// Times returns CPU times of the process.
+func (p *Process) Times() (*cpu.TimesStat, error) {
+	return p.TimesWithContext(context.Background())
+}
+
+// CPUAffinity returns CPU affinity of the process.
+func (p *Process) CPUAffinity() ([]int32, error) {
+	return p.CPUAffinityWithContext(context.Background())
+}
+
+// MemoryInfo returns generic process memory information,
+// such as RSS, VMS and Swap
+func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
+	return p.MemoryInfoWithContext(context.Background())
+}
+
+// MemoryInfoEx returns platform-specific process memory information.
+func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
+	return p.MemoryInfoExWithContext(context.Background())
+}
+
+// PageFaultsInfo returns the process's page fault counters.
+func (p *Process) PageFaults() (*PageFaultsStat, error) {
+	return p.PageFaultsWithContext(context.Background())
+}
+
+// Children returns a slice of Process of the process.
+func (p *Process) Children() ([]*Process, error) {
+	return p.ChildrenWithContext(context.Background())
+}
+
+// OpenFiles returns a slice of OpenFilesStat opend by the process.
+// OpenFilesStat includes a file path and file descriptor.
+func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
+	return p.OpenFilesWithContext(context.Background())
+}
+
+// Connections returns a slice of net.ConnectionStat used by the process.
+// This returns all kind of the connection. This means TCP, UDP or UNIX.
+func (p *Process) Connections() ([]net.ConnectionStat, error) {
+	return p.ConnectionsWithContext(context.Background())
+}
+
+// Connections returns a slice of net.ConnectionStat used by the process at most `max`.
+func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
+	return p.ConnectionsMaxWithContext(context.Background(), max)
+}
+
+// NetIOCounters returns NetIOCounters of the process.
+func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
+	return p.NetIOCountersWithContext(context.Background(), pernic)
+}
+
+// MemoryMaps get memory maps from /proc/(pid)/smaps
+func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
+	return p.MemoryMapsWithContext(context.Background(), grouped)
+}
+
+// Tgid returns thread group id of the process.
+func (p *Process) Tgid() (int32, error) {
+	return p.TgidWithContext(context.Background())
+}
+
+// SendSignal sends a unix.Signal to the process.
+func (p *Process) SendSignal(sig syscall.Signal) error {
+	return p.SendSignalWithContext(context.Background(), sig)
+}
+
+// Suspend sends SIGSTOP to the process.
+func (p *Process) Suspend() error {
+	return p.SuspendWithContext(context.Background())
+}
+
+// Resume sends SIGCONT to the process.
+func (p *Process) Resume() error {
+	return p.ResumeWithContext(context.Background())
+}
+
+// Terminate sends SIGTERM to the process.
+func (p *Process) Terminate() error {
+	return p.TerminateWithContext(context.Background())
+}
+
+// Kill sends SIGKILL to the process.
+func (p *Process) Kill() error {
+	return p.KillWithContext(context.Background())
+}
+
+// Username returns a username of the process.
+func (p *Process) Username() (string, error) {
+	return p.UsernameWithContext(context.Background())
 }

--- a/process/process_bsd.go
+++ b/process/process_bsd.go
@@ -1,0 +1,80 @@
+// +build darwin freebsd openbsd
+
+package process
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/internal/common"
+	"github.com/shirou/gopsutil/net"
+)
+
+type MemoryInfoExStat struct{}
+
+type MemoryMapsStat struct{}
+
+func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+
+func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
+	return "", common.ErrNotImplementedError
+}
+
+func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+
+func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
+	return 0, common.ErrNotImplementedError
+}
+
+func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func parseKinfoProc(buf []byte) (KinfoProc, error) {
+	var k KinfoProc
+	br := bytes.NewReader(buf)
+	err := common.Read(br, binary.LittleEndian, &k)
+	return k, err
+}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -3,9 +3,7 @@
 package process
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -37,13 +35,6 @@ type _Ctype_struct___0 struct {
 	Pad uint64
 }
 
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-}
-
-type MemoryMapsStat struct {
-}
-
 func pidsWithContext(ctx context.Context) ([]int32, error) {
 	var ret []int32
 
@@ -63,10 +54,6 @@ func pidsWithContext(ctx context.Context) ([]int32, error) {
 	return ret, nil
 }
 
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
-}
-
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	r, err := callPsWithContext(ctx, "ppid", p.Pid, false)
 	if err != nil {
@@ -79,9 +66,6 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	}
 
 	return int32(v), err
-}
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
@@ -108,18 +92,6 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 
 	return name, nil
 }
-func (p *Process) Tgid() (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
-}
-
-// Cmdline returns the command line arguments of the process as a string with
-// each argument separated by 0x20 ascii character.
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
-}
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 	r, err := callPsWithContext(ctx, "command", p.Pid, false)
@@ -129,15 +101,11 @@ func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 	return strings.Join(r[0], " "), err
 }
 
-// CmdlineSlice returns the command line arguments of the process as a slice with each
+// CmdlineSliceWithContext returns the command line arguments of the process as a slice with each
 // element being an argument. Because of current deficiencies in the way that the command
 // line arguments are found, single arguments that have spaces in the will actually be
 // reported as two separate items. In order to do something better CGO would be needed
 // to use the native darwin functions.
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
-}
-
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
 	r, err := callPsWithContext(ctx, "command", p.Pid, false)
 	if err != nil {
@@ -176,16 +144,6 @@ func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	start := time.Now().Add(-elapsed)
 	return start.Unix() * 1000, nil
 }
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
-
-func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
-	return "", common.ErrNotImplementedError
-}
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
-}
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
 	rr, err := common.CallLsofWithContext(ctx, invoke, p.Pid, "-FR")
@@ -201,12 +159,9 @@ func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
 		if err != nil {
 			return nil, err
 		}
-		return NewProcess(int32(v))
+		return NewProcessWithContext(ctx, int32(v))
 	}
 	return nil, fmt.Errorf("could not find parent line")
-}
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
@@ -216,10 +171,6 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	}
 
 	return r[0][0][0:1], err
-}
-
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
@@ -236,10 +187,6 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	return strings.IndexByte(string(out), '+') != -1, nil
 }
 
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
-
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	k, err := p.getKProc()
 	if err != nil {
@@ -250,9 +197,6 @@ func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	userEffectiveUID := int32(k.Eproc.Ucred.UID)
 
 	return []int32{userEffectiveUID}, nil
-}
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
@@ -280,9 +224,6 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 
 	return groups, nil
 }
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
-}
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
@@ -301,9 +242,6 @@ func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 		return termmap[ttyNr], nil
 	*/
 }
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
 
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
@@ -312,52 +250,9 @@ func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	}
 	return int32(k.Proc.P_nice), nil
 }
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
-}
-
-func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
-
-func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
-}
-
-func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
-}
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
-}
-
-func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
-
-func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
@@ -366,14 +261,6 @@ func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 	return int32(len(r)), nil
-}
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
-}
-
-func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
-	ret := make(map[int32]*cpu.TimesStat)
-	return ret, common.ErrNotImplementedError
 }
 
 func convertCPUTimes(s string) (ret float64, err error) {
@@ -421,9 +308,6 @@ func convertCPUTimes(s string) (ret float64, err error) {
 	t += h
 	return float64(t) / ClockTicks, nil
 }
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
-}
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
 	r, err := callPsWithContext(ctx, "utime,stime", p.Pid, false)
@@ -447,16 +331,6 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 		System: stime,
 	}
 	return ret, nil
-}
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
-
-func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
@@ -485,25 +359,6 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 
 	return ret, nil
 }
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
-
-func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
-}
-
-func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
-}
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
@@ -512,7 +367,7 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	}
 	ret := make([]*Process, 0, len(pids))
 	for _, pid := range pids {
-		np, err := NewProcess(pid)
+		np, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			return nil, err
 		}
@@ -521,50 +376,12 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	return ret, nil
 }
 
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
-}
-
-func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
-}
-
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
-	return net.ConnectionsPid("all", p.Pid)
-}
-
-// Connections returns a slice of net.ConnectionStat used by the process at most `max`
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
+	return net.ConnectionsPidWithContext(ctx, "all", p.Pid)
 }
 
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return net.ConnectionsPidMax("all", p.Pid, max)
-}
-
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
-}
-
-func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
-}
-
-func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
-	var ret []MemoryMapsStat
-	return &ret, common.ErrNotImplementedError
-}
-
-func Processes() ([]*Process, error) {
-	return ProcessesWithContext(context.Background())
+	return net.ConnectionsPidMaxWithContext(ctx, "all", p.Pid, max)
 }
 
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
@@ -576,7 +393,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	}
 
 	for _, pid := range pids {
-		p, err := NewProcess(pid)
+		p, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			continue
 		}
@@ -584,18 +401,6 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	}
 
 	return out, nil
-}
-
-func parseKinfoProc(buf []byte) (KinfoProc, error) {
-	var k KinfoProc
-	br := bytes.NewReader(buf)
-
-	err := common.Read(br, binary.LittleEndian, &k)
-	if err != nil {
-		return k, err
-	}
-
-	return k, nil
 }
 
 // Returns a proc as defined here:

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -29,10 +29,6 @@ type MemoryInfoExStat struct {
 }
 
 func pidsWithContext(ctx context.Context) ([]int32, error) {
-	return []int32{}, common.ErrNotImplementedError
-}
-
-func Processes() ([]*Process, error) {
 	return nil, common.ErrNotImplementedError
 }
 
@@ -41,294 +37,167 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 }
 
 func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
-	pids, err := PidsWithContext(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	for _, i := range pids {
-		if i == pid {
-			return true, err
-		}
-	}
-
-	return false, err
-}
-
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
+	return false, common.ErrNotImplementedError
 }
 
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
-}
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
-func (p *Process) Tgid() (int32, error) {
+
+func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
-}
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
-}
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
-	return []string{}, common.ErrNotImplementedError
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
 
 func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
-}
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
 }
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
-}
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
-}
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	return false, common.ErrNotImplementedError
 }
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
 
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
-	return []int32{}, common.ErrNotImplementedError
-}
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
-	return []int32{}, common.ErrNotImplementedError
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
-	return []int32{}, common.ErrNotImplementedError
-}
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
 
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
-}
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
 }
 
 func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
 
 func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
 }
 
 func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
-}
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
 }
 
 func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
 
 func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
-}
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
-}
 
 func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
 }
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
 
 func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
 
 func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
-}
+
 func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
-}
 
 func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
-	return []OpenFilesStat{}, common.ErrNotImplementedError
-}
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
-	return []net.ConnectionStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return []net.ConnectionStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
-	return []net.IOCountersStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) SendSignal(sig syscall.Signal) error {
-	return p.SendSignalWithContext(context.Background(), sig)
-}
 
 func (p *Process) SendSignalWithContext(ctx context.Context, sig syscall.Signal) error {
 	return common.ErrNotImplementedError
-}
-func (p *Process) Suspend() error {
-	return p.SuspendWithContext(context.Background())
 }
 
 func (p *Process) SuspendWithContext(ctx context.Context) error {
 	return common.ErrNotImplementedError
 }
-func (p *Process) Resume() error {
-	return p.ResumeWithContext(context.Background())
-}
 
 func (p *Process) ResumeWithContext(ctx context.Context) error {
 	return common.ErrNotImplementedError
-}
-func (p *Process) Terminate() error {
-	return p.TerminateWithContext(context.Background())
 }
 
 func (p *Process) TerminateWithContext(ctx context.Context) error {
 	return common.ErrNotImplementedError
 }
-func (p *Process) Kill() error {
-	return p.KillWithContext(context.Background())
-}
 
 func (p *Process) KillWithContext(ctx context.Context) error {
 	return common.ErrNotImplementedError
-}
-func (p *Process) Username() (string, error) {
-	return p.UsernameWithContext(context.Background())
 }
 
 func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -5,7 +5,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -17,16 +16,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-}
-
-type MemoryMapsStat struct {
-}
-
 func pidsWithContext(ctx context.Context) ([]int32, error) {
 	var ret []int32
-	procs, err := Processes()
+	procs, err := ProcessesWithContext(ctx)
 	if err != nil {
 		return ret, nil
 	}
@@ -38,10 +30,6 @@ func pidsWithContext(ctx context.Context) ([]int32, error) {
 	return ret, nil
 }
 
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
-}
-
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
 	if err != nil {
@@ -49,9 +37,6 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	}
 
 	return k.Ppid, nil
-}
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
@@ -78,19 +63,9 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 
 	return name, nil
 }
-func (p *Process) Tgid() (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
-}
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
-}
-
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
 }
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
@@ -107,10 +82,6 @@ func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 	})
 
 	return strings.Join(ret, " "), nil
-}
-
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
@@ -137,22 +108,9 @@ func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error)
 func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
-
-func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
-	return "", common.ErrNotImplementedError
-}
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
-}
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
-	return p, common.ErrNotImplementedError
-}
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
@@ -181,10 +139,6 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return s, nil
 }
 
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
-}
-
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
@@ -199,10 +153,6 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	return strings.IndexByte(string(out), '+') != -1, nil
 }
 
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
-
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	k, err := p.getKProc()
 	if err != nil {
@@ -214,9 +164,6 @@ func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	uids = append(uids, int32(k.Ruid), int32(k.Uid), int32(k.Svuid))
 
 	return uids, nil
-}
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
@@ -244,9 +191,6 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 
 	return groups, nil
 }
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
-}
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	k, err := p.getKProc()
@@ -263,9 +207,6 @@ func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 
 	return termmap[ttyNr], nil
 }
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
 
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
@@ -273,32 +214,6 @@ func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 	return int32(k.Nice), nil
-}
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
-}
-
-func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
-
-func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
-}
-
-func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
 }
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
@@ -311,23 +226,6 @@ func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, e
 		WriteCount: uint64(k.Rusage.Oublock),
 	}, nil
 }
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
-}
-
-func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
-
-func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
-}
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
@@ -336,17 +234,6 @@ func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	}
 
 	return k.Numthreads, nil
-}
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
-}
-
-func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
-	ret := make(map[int32]*cpu.TimesStat)
-	return ret, common.ErrNotImplementedError
-}
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
 }
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
@@ -359,16 +246,6 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 		User:   float64(k.Rusage.Utime.Sec) + float64(k.Rusage.Utime.Usec)/1000000,
 		System: float64(k.Rusage.Stime.Sec) + float64(k.Rusage.Stime.Usec)/1000000,
 	}, nil
-}
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
-
-func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
@@ -387,25 +264,6 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 		VMS: uint64(k.Size),
 	}, nil
 }
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
-
-func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
-}
-
-func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
-}
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
@@ -414,7 +272,7 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	}
 	ret := make([]*Process, 0, len(pids))
 	for _, pid := range pids {
-		np, err := NewProcess(pid)
+		np, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			return nil, err
 		}
@@ -423,50 +281,12 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	return ret, nil
 }
 
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
-}
-
-func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
-}
-
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-// Connections returns a slice of net.ConnectionStat used by the process at most `max`
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
-}
-
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return []net.ConnectionStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
-}
-
-func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
-}
-
-func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
-	var ret []MemoryMapsStat
-	return &ret, common.ErrNotImplementedError
-}
-
-func Processes() ([]*Process, error) {
-	return ProcessesWithContext(context.Background())
 }
 
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
@@ -488,7 +308,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 		if err != nil {
 			continue
 		}
-		p, err := NewProcess(int32(k.Pid))
+		p, err := NewProcessWithContext(ctx, int32(k.Pid))
 		if err != nil {
 			continue
 		}
@@ -499,18 +319,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	return results, nil
 }
 
-func parseKinfoProc(buf []byte) (KinfoProc, error) {
-	var k KinfoProc
-	br := bytes.NewReader(buf)
-	err := common.Read(br, binary.LittleEndian, &k)
-	return k, err
-}
-
 func (p *Process) getKProc() (*KinfoProc, error) {
-	return p.getKProcWithContext(context.Background())
-}
-
-func (p *Process) getKProcWithContext(ctx context.Context) (*KinfoProc, error) {
 	mib := []int32{CTLKern, KernProc, KernProcPID, p.Pid}
 
 	buf, length, err := common.CallSyscall(mib)

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -64,22 +64,12 @@ func (m MemoryMapsStat) String() string {
 	return string(s)
 }
 
-// Ppid returns Parent Process ID of the process.
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
-}
-
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	_, ppid, _, _, _, _, _, err := p.fillFromStatWithContext(ctx)
 	if err != nil {
 		return -1, err
 	}
 	return ppid, nil
-}
-
-// Name returns name of the process.
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
@@ -91,39 +81,21 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	return p.name, nil
 }
 
-// Tgid returns tgid, a Linux-synonym for user-space Pid
-func (p *Process) Tgid() (int32, error) {
+func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
 	if p.tgid == 0 {
-		if err := p.fillFromStatusWithContext(context.Background()); err != nil {
+		if err := p.fillFromStatusWithContext(ctx); err != nil {
 			return 0, err
 		}
 	}
 	return p.tgid, nil
 }
 
-// Exe returns executable path of the process.
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
-}
-
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	return p.fillFromExeWithContext(ctx)
 }
 
-// Cmdline returns the command line arguments of the process as a string with
-// each argument separated by 0x20 ascii character.
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
-}
-
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 	return p.fillFromCmdlineWithContext(ctx)
-}
-
-// CmdlineSlice returns the command line arguments of the process as a slice with each
-// element being an argument.
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
@@ -138,18 +110,8 @@ func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	return createTime, nil
 }
 
-// Cwd returns current working directory of the process.
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
-
 func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 	return p.fillFromCwdWithContext(ctx)
-}
-
-// Parent returns parent Process of the process.
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
 }
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
@@ -160,16 +122,7 @@ func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
 	if p.parent == 0 {
 		return nil, fmt.Errorf("wrong number of parents")
 	}
-	return NewProcess(p.parent)
-}
-
-// Status returns the process status.
-// Return value could be one of these.
-// R: Running S: Sleep T: Stop I: Idle
-// Z: Zombie W: Wait L: Lock
-// The character is same within all supported platforms.
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
+	return NewProcessWithContext(ctx, p.parent)
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
@@ -178,11 +131,6 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return p.status, nil
-}
-
-// Foreground returns true if the process is in foreground, false otherwise.
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
@@ -202,22 +150,12 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	return pgid == tpgid, nil
 }
 
-// Uids returns user ids of the process as a slice of the int
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
-
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	err := p.fillFromStatusWithContext(ctx)
 	if err != nil {
 		return []int32{}, err
 	}
 	return p.uids, nil
-}
-
-// Gids returns group ids of the process as a slice of the int
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
@@ -236,11 +174,6 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 	return p.groups, nil
 }
 
-// Terminal returns a terminal which is associated with the process.
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
-}
-
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	t, _, _, _, _, _, _, err := p.fillFromStatWithContext(ctx)
 	if err != nil {
@@ -254,12 +187,6 @@ func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	return terminal, nil
 }
 
-// Nice returns a nice value (priority).
-// Notice: gopsutil can not set nice value.
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
-
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	_, _, _, _, _, nice, _, err := p.fillFromStatWithContext(ctx)
 	if err != nil {
@@ -268,29 +195,12 @@ func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	return nice, nil
 }
 
-// IOnice returns process I/O nice value (priority).
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
-}
-
 func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
 }
 
-// Rlimit returns Resource Limits.
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
-
 func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
-	return p.RlimitUsage(false)
-}
-
-// RlimitUsage returns Resource Limits.
-// If gatherUsed is true, the currently used value will be gathered and added
-// to the resulting RlimitStat.
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
+	return p.RlimitUsageWithContext(ctx, false)
 }
 
 func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
@@ -311,7 +221,7 @@ func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) (
 		rs := &rlimits[i]
 		switch rs.Resource {
 		case RLIMIT_CPU:
-			times, err := p.Times()
+			times, err := p.TimesWithContext(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -323,7 +233,7 @@ func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) (
 		case RLIMIT_RSS:
 			rs.Used = uint64(p.memInfo.RSS)
 		case RLIMIT_NOFILE:
-			n, err := p.NumFDs()
+			n, err := p.NumFDsWithContext(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -348,18 +258,8 @@ func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) (
 	return rlimits, err
 }
 
-// IOCounters returns IO Counters.
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
-}
-
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
 	return p.fillFromIOWithContext(ctx)
-}
-
-// NumCtxSwitches returns the number of the context switches of the process.
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
 }
 
 func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
@@ -370,19 +270,9 @@ func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitche
 	return p.numCtxSwitches, nil
 }
 
-// NumFDs returns the number of File Descriptors used by the process.
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
-
 func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
 	_, fnames, err := p.fillFromfdListWithContext(ctx)
 	return int32(len(fnames)), err
-}
-
-// NumThreads returns the number of threads used by the process.
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
@@ -391,10 +281,6 @@ func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 	return p.numThreads, nil
-}
-
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
 }
 
 func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
@@ -417,11 +303,6 @@ func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesS
 	return ret, nil
 }
 
-// Times returns CPU times of the process.
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
-}
-
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
 	_, _, cpuTimes, _, _, _, _, err := p.fillFromStatWithContext(ctx)
 	if err != nil {
@@ -430,20 +311,8 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 	return cpuTimes, nil
 }
 
-// CPUAffinity returns CPU affinity of the process.
-//
-// Notice: Not implemented yet.
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
-
 func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
-}
-
-// MemoryInfo returns platform in-dependend memory information, such as RSS, VMS and Swap
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
@@ -454,22 +323,12 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 	return meminfo, nil
 }
 
-// MemoryInfoEx returns platform dependend memory information.
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
-
 func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
 	_, memInfoEx, err := p.fillFromStatmWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return memInfoEx, nil
-}
-
-// PageFaultsInfo returns the process's page fault counters
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
 }
 
 func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
@@ -479,11 +338,6 @@ func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, e
 	}
 	return pageFaults, nil
 
-}
-
-// Children returns a slice of Process of the process.
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
@@ -496,19 +350,13 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	}
 	ret := make([]*Process, 0, len(pids))
 	for _, pid := range pids {
-		np, err := NewProcess(pid)
+		np, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			return nil, err
 		}
 		ret = append(ret, np)
 	}
 	return ret, nil
-}
-
-// OpenFiles returns a slice of OpenFilesStat opend by the process.
-// OpenFilesStat includes a file path and file descriptor.
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
 }
 
 func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
@@ -524,38 +372,17 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 	return ret, nil
 }
 
-// Connections returns a slice of net.ConnectionStat used by the process.
-// This returns all kind of the connection. This measn TCP, UDP or UNIX.
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
-}
-
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
-	return net.ConnectionsPid("all", p.Pid)
-}
-
-// Connections returns a slice of net.ConnectionStat used by the process at most `max`
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
+	return net.ConnectionsPidWithContext(ctx, "all", p.Pid)
 }
 
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return net.ConnectionsPidMax("all", p.Pid, max)
-}
-
-// NetIOCounters returns NetIOCounters of the process.
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
+	return net.ConnectionsPidMaxWithContext(ctx, "all", p.Pid, max)
 }
 
 func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
 	filename := common.HostProc(strconv.Itoa(int(p.Pid)), "net/dev")
-	return net.IOCountersByFile(pernic, filename)
-}
-
-// MemoryMaps get memory maps from /proc/(pid)/smaps
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
+	return net.IOCountersByFileWithContext(ctx, pernic, filename)
 }
 
 func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
@@ -1181,7 +1008,7 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 	// docs).  Note: I am assuming at least Linux 2.6.18
 	iotime, err := strconv.ParseFloat(fields[i+40], 64)
 	if err != nil {
-		iotime = 0  // Ancient linux version, most likely
+		iotime = 0 // Ancient linux version, most likely
 	}
 
 	cpuTimes := &cpu.TimesStat{
@@ -1249,12 +1076,6 @@ func pidsWithContext(ctx context.Context) ([]int32, error) {
 	return readPidsFromDir(common.HostProc())
 }
 
-// Process returns a slice of pointers to Process structs for all
-// currently running processes.
-func Processes() ([]*Process, error) {
-	return ProcessesWithContext(context.Background())
-}
-
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	out := []*Process{}
 
@@ -1264,7 +1085,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	}
 
 	for _, pid := range pids {
-		p, err := NewProcess(pid)
+		p, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			continue
 		}

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -4,9 +4,7 @@ package process
 
 import (
 	"C"
-	"bytes"
 	"context"
-	"encoding/binary"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -20,16 +18,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-}
-
-type MemoryMapsStat struct {
-}
-
 func pidsWithContext(ctx context.Context) ([]int32, error) {
 	var ret []int32
-	procs, err := Processes()
+	procs, err := ProcessesWithContext(ctx)
 	if err != nil {
 		return ret, nil
 	}
@@ -41,10 +32,6 @@ func pidsWithContext(ctx context.Context) ([]int32, error) {
 	return ret, nil
 }
 
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
-}
-
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
 	if err != nil {
@@ -52,9 +39,6 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	}
 
 	return k.Ppid, nil
-}
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
@@ -81,19 +65,9 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 
 	return name, nil
 }
-func (p *Process) Tgid() (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
-}
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
-}
-
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
@@ -119,12 +93,8 @@ func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error)
 	return strParts, nil
 }
 
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
-}
-
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
-	argv, err := p.CmdlineSlice()
+	argv, err := p.CmdlineSliceWithContext(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -134,22 +104,9 @@ func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
-
-func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
-	return "", common.ErrNotImplementedError
-}
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
-}
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
-	return p, common.ErrNotImplementedError
-}
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
@@ -173,9 +130,6 @@ func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 
 	return s, nil
 }
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
-}
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
@@ -190,9 +144,6 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	}
 	return strings.IndexByte(string(out), '+') != -1, nil
 }
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
 
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 	k, err := p.getKProc()
@@ -206,9 +157,6 @@ func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
 
 	return uids, nil
 }
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
-}
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	k, err := p.getKProc()
@@ -221,6 +169,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 
 	return gids, nil
 }
+
 func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 	k, err := p.getKProc()
 	if err != nil {
@@ -228,9 +177,6 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 	}
 
 	return k.Groups, nil
-}
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
 }
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
@@ -248,9 +194,6 @@ func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 
 	return termmap[ttyNr], nil
 }
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
 
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	k, err := p.getKProc()
@@ -258,32 +201,6 @@ func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 	return int32(k.Nice), nil
-}
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
-}
-
-func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
-
-func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
-}
-
-func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
 }
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
@@ -296,38 +213,10 @@ func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, e
 		WriteCount: uint64(k.Uru_oublock),
 	}, nil
 }
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
-}
-
-func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
-
-func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
-	return 0, common.ErrNotImplementedError
-}
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
-}
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	/* not supported, just return 1 */
 	return 1, nil
-}
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
-}
-
-func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
-	ret := make(map[int32]*cpu.TimesStat)
-	return ret, common.ErrNotImplementedError
-}
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
 }
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
@@ -341,23 +230,13 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 		System: float64(k.Ustime_sec) + float64(k.Ustime_usec)/1000000,
 	}, nil
 }
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
-
-func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
-	return nil, common.ErrNotImplementedError
-}
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
-}
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
 	k, err := p.getKProc()
 	if err != nil {
 		return nil, err
 	}
-	pageSize, err := mem.GetPageSize()
+	pageSize, err := mem.GetPageSizeWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -368,25 +247,6 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 			uint64(k.Vm_ssize),
 	}, nil
 }
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
-
-func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
-}
-
-func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
-}
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
@@ -395,7 +255,7 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	}
 	ret := make([]*Process, 0, len(pids))
 	for _, pid := range pids {
-		np, err := NewProcess(pid)
+		np, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			return nil, err
 		}
@@ -404,55 +264,18 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	return ret, nil
 }
 
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
-}
-
-func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
-	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
-}
-
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
-}
-
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return []net.ConnectionStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
-}
-
-func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
-}
-
-func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
-	var ret []MemoryMapsStat
-	return &ret, common.ErrNotImplementedError
-}
-
-func Processes() ([]*Process, error) {
-	return ProcessesWithContext(context.Background())
 }
 
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	results := []*Process{}
 
-	buf, length, err := CallKernProcSyscall(KernProcAll, 0)
+	buf, length, err := callKernProcSyscall(KernProcAll, 0)
 
 	if err != nil {
 		return results, err
@@ -468,7 +291,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 		if err != nil {
 			continue
 		}
-		p, err := NewProcess(int32(k.Pid))
+		p, err := NewProcessWithContext(ctx, int32(k.Pid))
 		if err != nil {
 			continue
 		}
@@ -479,19 +302,8 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	return results, nil
 }
 
-func parseKinfoProc(buf []byte) (KinfoProc, error) {
-	var k KinfoProc
-	br := bytes.NewReader(buf)
-	err := common.Read(br, binary.LittleEndian, &k)
-	return k, err
-}
-
 func (p *Process) getKProc() (*KinfoProc, error) {
-	return p.getKProcWithContext(context.Background())
-}
-
-func (p *Process) getKProcWithContext(ctx context.Context) (*KinfoProc, error) {
-	buf, length, err := CallKernProcSyscall(KernProcPID, p.Pid)
+	buf, length, err := callKernProcSyscall(KernProcPID, p.Pid)
 	if err != nil {
 		return nil, err
 	}
@@ -506,11 +318,7 @@ func (p *Process) getKProcWithContext(ctx context.Context) (*KinfoProc, error) {
 	return &k, nil
 }
 
-func CallKernProcSyscall(op int32, arg int32) ([]byte, uint64, error) {
-	return CallKernProcSyscallWithContext(context.Background(), op, arg)
-}
-
-func CallKernProcSyscallWithContext(ctx context.Context, op int32, arg int32) ([]byte, uint64, error) {
+func callKernProcSyscall(op int32, arg int32) ([]byte, uint64, error) {
 	mib := []int32{CTLKern, KernProc, op, arg, sizeOfKinfoProc, 0}
 	mibptr := unsafe.Pointer(&mib[0])
 	miblen := uint64(len(mib))

--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -114,12 +114,6 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 	return false, err
 }
 
-// SendSignal sends a unix.Signal to the process.
-// Currently, SIGSTOP, SIGCONT, SIGTERM and SIGKILL are supported.
-func (p *Process) SendSignal(sig syscall.Signal) error {
-	return p.SendSignalWithContext(context.Background(), sig)
-}
-
 func (p *Process) SendSignalWithContext(ctx context.Context, sig syscall.Signal) error {
 	process, err := os.FindProcess(int(p.Pid))
 	if err != nil {
@@ -134,49 +128,24 @@ func (p *Process) SendSignalWithContext(ctx context.Context, sig syscall.Signal)
 	return nil
 }
 
-// Suspend sends SIGSTOP to the process.
-func (p *Process) Suspend() error {
-	return p.SuspendWithContext(context.Background())
-}
-
 func (p *Process) SuspendWithContext(ctx context.Context) error {
-	return p.SendSignal(unix.SIGSTOP)
-}
-
-// Resume sends SIGCONT to the process.
-func (p *Process) Resume() error {
-	return p.ResumeWithContext(context.Background())
+	return p.SendSignalWithContext(ctx, unix.SIGSTOP)
 }
 
 func (p *Process) ResumeWithContext(ctx context.Context) error {
-	return p.SendSignal(unix.SIGCONT)
-}
-
-// Terminate sends SIGTERM to the process.
-func (p *Process) Terminate() error {
-	return p.TerminateWithContext(context.Background())
+	return p.SendSignalWithContext(ctx, unix.SIGCONT)
 }
 
 func (p *Process) TerminateWithContext(ctx context.Context) error {
-	return p.SendSignal(unix.SIGTERM)
-}
-
-// Kill sends SIGKILL to the process.
-func (p *Process) Kill() error {
-	return p.KillWithContext(context.Background())
+	return p.SendSignalWithContext(ctx, unix.SIGTERM)
 }
 
 func (p *Process) KillWithContext(ctx context.Context) error {
-	return p.SendSignal(unix.SIGKILL)
-}
-
-// Username returns a username of the process.
-func (p *Process) Username() (string, error) {
-	return p.UsernameWithContext(context.Background())
+	return p.SendSignalWithContext(ctx, unix.SIGKILL)
 }
 
 func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {
-	uids, err := p.Uids()
+	uids, err := p.UidsWithContext(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -235,10 +235,6 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 	return exitCode == STILL_ACTIVE, err
 }
 
-func (p *Process) Ppid() (int32, error) {
-	return p.PpidWithContext(context.Background())
-}
-
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	// if cached already, return from cache
 	if p.parent != 0 {
@@ -256,10 +252,6 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	return ppid, nil
 }
 
-func (p *Process) Name() (string, error) {
-	return p.NameWithContext(context.Background())
-}
-
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	ppid, _, name, err := getFromSnapProcess(p.Pid)
 	if err != nil {
@@ -272,12 +264,8 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	return name, nil
 }
 
-func (p *Process) Tgid() (int32, error) {
+func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
-}
-
-func (p *Process) Exe() (string, error) {
-	return p.ExeWithContext(context.Background())
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
@@ -307,23 +295,12 @@ func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	return common.ConvertDOSPath(windows.UTF16ToString(buf[:])), nil
 }
 
-func (p *Process) Cmdline() (string, error) {
-	return p.CmdlineWithContext(context.Background())
-}
-
 func (p *Process) CmdlineWithContext(_ context.Context) (string, error) {
 	cmdline, err := getProcessCommandLine(p.Pid)
 	if err != nil {
 		return "", fmt.Errorf("could not get CommandLine: %s", err)
 	}
 	return cmdline, nil
-}
-
-// CmdlineSlice returns the command line arguments of the process as a slice with each
-// element being an argument. This merely returns the CommandLine informations passed
-// to the process split on the 0x20 ASCII character.
-func (p *Process) CmdlineSlice() ([]string, error) {
-	return p.CmdlineSliceWithContext(context.Background())
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
@@ -343,15 +320,8 @@ func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	return ru.CreationTime.Nanoseconds() / 1000000, nil
 }
 
-func (p *Process) Cwd() (string, error) {
-	return p.CwdWithContext(context.Background())
-}
-
 func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
-}
-func (p *Process) Parent() (*Process, error) {
-	return p.ParentWithContext(context.Background())
 }
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
@@ -360,26 +330,15 @@ func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
 		return nil, fmt.Errorf("could not get ParentProcessID: %s", err)
 	}
 
-	return NewProcess(ppid)
-}
-func (p *Process) Status() (string, error) {
-	return p.StatusWithContext(context.Background())
+	return NewProcessWithContext(ctx, ppid)
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
 
-func (p *Process) Foreground() (bool, error) {
-	return p.ForegroundWithContext(context.Background())
-}
-
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	return false, common.ErrNotImplementedError
-}
-
-func (p *Process) Username() (string, error) {
-	return p.UsernameWithContext(context.Background())
 }
 
 func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {
@@ -405,30 +364,16 @@ func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {
 	return domain + "\\" + user, err
 }
 
-func (p *Process) Uids() ([]int32, error) {
-	return p.UidsWithContext(context.Background())
-}
-
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
-	var uids []int32
-
-	return uids, common.ErrNotImplementedError
-}
-func (p *Process) Gids() ([]int32, error) {
-	return p.GidsWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
-	var gids []int32
-	return gids, common.ErrNotImplementedError
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
-	var groups []int32
-	return groups, common.ErrNotImplementedError
-}
-func (p *Process) Terminal() (string, error) {
-	return p.TerminalWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
@@ -447,11 +392,6 @@ var priorityClasses = map[int]int32{
 	0x00000100: 24, // REALTIME_PRIORITY_CLASS
 }
 
-// Nice returns priority in Windows
-func (p *Process) Nice() (int32, error) {
-	return p.NiceWithContext(context.Background())
-}
-
 func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	c, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(p.Pid))
 	if err != nil {
@@ -468,34 +408,17 @@ func (p *Process) NiceWithContext(ctx context.Context) (int32, error) {
 	}
 	return priority, nil
 }
-func (p *Process) IOnice() (int32, error) {
-	return p.IOniceWithContext(context.Background())
-}
 
 func (p *Process) IOniceWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
 }
-func (p *Process) Rlimit() ([]RlimitStat, error) {
-	return p.RlimitWithContext(context.Background())
-}
 
 func (p *Process) RlimitWithContext(ctx context.Context) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-
-	return rlimit, common.ErrNotImplementedError
-}
-func (p *Process) RlimitUsage(gatherUsed bool) ([]RlimitStat, error) {
-	return p.RlimitUsageWithContext(context.Background(), gatherUsed)
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) ([]RlimitStat, error) {
-	var rlimit []RlimitStat
-
-	return rlimit, common.ErrNotImplementedError
-}
-
-func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.IOCountersWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, error) {
@@ -518,22 +441,13 @@ func (p *Process) IOCountersWithContext(ctx context.Context) (*IOCountersStat, e
 
 	return stats, nil
 }
-func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
-	return p.NumCtxSwitchesWithContext(context.Background())
-}
 
 func (p *Process) NumCtxSwitchesWithContext(ctx context.Context) (*NumCtxSwitchesStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-func (p *Process) NumFDs() (int32, error) {
-	return p.NumFDsWithContext(context.Background())
-}
 
 func (p *Process) NumFDsWithContext(ctx context.Context) (int32, error) {
 	return 0, common.ErrNotImplementedError
-}
-func (p *Process) NumThreads() (int32, error) {
-	return p.NumThreadsWithContext(context.Background())
 }
 
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
@@ -547,16 +461,9 @@ func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 
 	return ret, nil
 }
-func (p *Process) Threads() (map[int32]*cpu.TimesStat, error) {
-	return p.ThreadsWithContext(context.Background())
-}
 
 func (p *Process) ThreadsWithContext(ctx context.Context) (map[int32]*cpu.TimesStat, error) {
-	ret := make(map[int32]*cpu.TimesStat)
-	return ret, common.ErrNotImplementedError
-}
-func (p *Process) Times() (*cpu.TimesStat, error) {
-	return p.TimesWithContext(context.Background())
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
@@ -582,15 +489,9 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 		System: kernel,
 	}, nil
 }
-func (p *Process) CPUAffinity() ([]int32, error) {
-	return p.CPUAffinityWithContext(context.Background())
-}
 
 func (p *Process) CPUAffinityWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
-}
-func (p *Process) MemoryInfo() (*MemoryInfoStat, error) {
-	return p.MemoryInfoWithContext(context.Background())
 }
 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
@@ -606,24 +507,13 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 
 	return ret, nil
 }
-func (p *Process) MemoryInfoEx() (*MemoryInfoExStat, error) {
-	return p.MemoryInfoExWithContext(context.Background())
-}
 
 func (p *Process) MemoryInfoExWithContext(ctx context.Context) (*MemoryInfoExStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) PageFaults() (*PageFaultsStat, error) {
-	return p.PageFaultsWithContext(context.Background())
-}
-
 func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Children() ([]*Process, error) {
-	return p.ChildrenWithContext(context.Background())
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
@@ -640,7 +530,7 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	}
 	for {
 		if pe32.ParentProcessID == uint32(p.Pid) {
-			p, err := NewProcess(int32(pe32.ProcessID))
+			p, err := NewProcessWithContext(ctx, int32(pe32.ProcessID))
 			if err == nil {
 				out = append(out, p)
 			}
@@ -652,57 +542,28 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	return out, nil
 }
 
-func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	return p.OpenFilesWithContext(context.Background())
-}
-
 func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, error) {
 	return nil, common.ErrNotImplementedError
-}
-
-func (p *Process) Connections() ([]net.ConnectionStat, error) {
-	return p.ConnectionsWithContext(context.Background())
 }
 
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
 	return net.ConnectionsPidWithContext(ctx, "all", p.Pid)
 }
 
-func (p *Process) ConnectionsMax(max int) ([]net.ConnectionStat, error) {
-	return p.ConnectionsMaxWithContext(context.Background(), max)
-}
-
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return []net.ConnectionStat{}, common.ErrNotImplementedError
-}
-
-func (p *Process) NetIOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return p.NetIOCountersWithContext(context.Background(), pernic)
+	return nil, common.ErrNotImplementedError
 }
 
 func (p *Process) NetIOCountersWithContext(ctx context.Context, pernic bool) ([]net.IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
-	return p.MemoryMapsWithContext(context.Background(), grouped)
-}
-
 func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]MemoryMapsStat, error) {
-	var ret []MemoryMapsStat
-	return &ret, common.ErrNotImplementedError
+	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) SendSignal(sig windows.Signal) error {
-	return p.SendSignalWithContext(context.Background(), sig)
-}
-
-func (p *Process) SendSignalWithContext(ctx context.Context, sig windows.Signal) error {
+func (p *Process) SendSignalWithContext(ctx context.Context, sig syscall.Signal) error {
 	return common.ErrNotImplementedError
-}
-
-func (p *Process) Suspend() error {
-	return p.SuspendWithContext(context.Background())
 }
 
 func (p *Process) SuspendWithContext(ctx context.Context) error {
@@ -721,10 +582,6 @@ func (p *Process) SuspendWithContext(ctx context.Context) error {
 	return nil
 }
 
-func (p *Process) Resume() error {
-	return p.ResumeWithContext(context.Background())
-}
-
 func (p *Process) ResumeWithContext(ctx context.Context) error {
 	c, err := windows.OpenProcess(windows.PROCESS_SUSPEND_RESUME, false, uint32(p.Pid))
 	if err != nil {
@@ -741,10 +598,6 @@ func (p *Process) ResumeWithContext(ctx context.Context) error {
 	return nil
 }
 
-func (p *Process) Terminate() error {
-	return p.TerminateWithContext(context.Background())
-}
-
 func (p *Process) TerminateWithContext(ctx context.Context) error {
 	proc, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(p.Pid))
 	if err != nil {
@@ -753,10 +606,6 @@ func (p *Process) TerminateWithContext(ctx context.Context) error {
 	err = windows.TerminateProcess(proc, 0)
 	windows.CloseHandle(proc)
 	return err
-}
-
-func (p *Process) Kill() error {
-	return p.KillWithContext(context.Background())
 }
 
 func (p *Process) KillWithContext(ctx context.Context) error {
@@ -787,11 +636,6 @@ func getFromSnapProcess(pid int32) (int32, int32, string, error) {
 	return 0, 0, "", fmt.Errorf("couldn't find pid: %d", pid)
 }
 
-// Get processes
-func Processes() ([]*Process, error) {
-	return ProcessesWithContext(context.Background())
-}
-
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	out := []*Process{}
 
@@ -801,7 +645,7 @@ func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
 	}
 
 	for _, pid := range pids {
-		p, err := NewProcess(pid)
+		p, err := NewProcessWithContext(ctx, pid)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
* All context-less wrapping functions (the ones without WithContext
suffix) were moved into process.go since they all are the same.
* Call context is now passed to all underlying functions in
*WithContext() functions.
* All common *BSD bits were moved to process_bsd.go.
* Process.Tgid() method lacked a WithContext counterpart, so
Process.TgidWithContext() was added for uniformity.
* NewProcessWithContext() function was added since NewProcess() is
used a lot throughout the module, and there is no way to pass a
context to it.

This is a part of #761 effort.