### PR TITLE
fixed "cannot use stat.Mntfromname[:] (type []byte) as type []int8 in…

### DIFF
--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -64,9 +64,10 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			opts += ",nodev"
 		}
 		d := PartitionStat{
-			Device:     common.IntToString(stat.Mntfromname[:]),
-			Mountpoint: common.IntToString(stat.Mntonname[:]),
-			Fstype:     common.IntToString(stat.Fstypename[:]),
+			Device:     common.ByteToString(stat.Mntfromname[:]),
+			Mountpoint: common.ByteToString(stat.Mntonname[:]),
+			Fstype:     common.ByteToString(stat.Fstypename[:]),
+
 			Opts:       opts,
 		}
 		if all == false {
@@ -82,5 +83,5 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 }
 
 func getFsType(stat unix.Statfs_t) string {
-	return common.IntToString(stat.Fstypename[:])
+	return common.ByteToString(stat.Fstypename[:])
 }


### PR DESCRIPTION
… argument to common.IntToString" on darwin (osx)