### PR TITLE
Feature/remove disk partition args on bsds

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,23 +23,32 @@ os:linux:
   - ./**/*_linux_test.go
   - ./**/*_linux_s390x.go
   - ./**/*_linux_amd64.go
+  - ./**/*_posix.go
 os:freebsd:
   - ./**/*_freebsd.go
   - ./**/*_freebsd_386.go
   - ./**/*_freebsd_test.go
   - ./**/*_freebsd_amd64.go
+  - ./**/*_bsd.go
+  - ./**/*_posix.go
 os:darwin:
   - ./**/*_darwin.go
   - ./**/*_darwin_386.go
   - ./**/*_darwin_test.go
   - ./**/*_darwin_amd64.go
+  - ./**/*_posix.go
 os:openbsd:
   - ./**/*_openbsd.go
   - ./**/*_openbsd_386.go
   - ./**/*_openbsd_test.go
   - ./**/*_openbsd_amd64.go
+  - ./**/*_bsd.go
+  - ./**/*_posix.go
 os:windows:
   - ./**/*_windows.go
   - ./**/*_windows_386.go
   - ./**/*_windows_test.go
   - ./**/*_windows_amd64.go
+os:solaris:
+  - ./**/*_solaris.go
+  - ./**/*_posix.go

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,45 @@
+package:cpu:
+  - cpu/*
+package:disk:
+  - disk/*
+package:docker:
+  - docker/*
+package:host:
+  - host/*
+package:load:
+  - load/*
+package:mem:
+  - mem/*
+package:net:
+  - net/*
+package:process:
+  - process/*
+package:winservices:
+  - winservices/*
+os:linux:
+  - ./**/*_linux.go
+  - ./**/*_linux_mips64.go
+  - ./**/*_linux_386.go
+  - ./**/*_linux_test.go
+  - ./**/*_linux_s390x.go
+  - ./**/*_linux_amd64.go
+os:freebsd:
+  - ./**/*_freebsd.go
+  - ./**/*_freebsd_386.go
+  - ./**/*_freebsd_test.go
+  - ./**/*_freebsd_amd64.go
+os:darwin:
+  - ./**/*_darwin.go
+  - ./**/*_darwin_386.go
+  - ./**/*_darwin_test.go
+  - ./**/*_darwin_amd64.go
+os:openbsd:
+  - ./**/*_openbsd.go
+  - ./**/*_openbsd_386.go
+  - ./**/*_openbsd_test.go
+  - ./**/*_openbsd_amd64.go
+os:windows:
+  - ./**/*_windows.go
+  - ./**/*_windows_386.go
+  - ./**/*_windows_test.go
+  - ./**/*_windows_amd64.go

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -4,7 +4,6 @@ package disk
 
 import (
 	"context"
-	"path"
 
 	"github.com/shirou/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
@@ -14,6 +13,8 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return PartitionsWithContext(context.Background(), all)
 }
 
+// PartitionsWithContext returns disk partition.
+// 'all' argument is ignored, see: https://github.com/giampaolo/psutil/issues/906
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
@@ -68,11 +69,6 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			Mountpoint: common.ByteToString(stat.Mntonname[:]),
 			Fstype:     common.ByteToString(stat.Fstypename[:]),
 			Opts:       opts,
-		}
-		if all == false {
-			if !path.IsAbs(d.Device) || !common.PathExists(d.Device) {
-				continue
-			}
 		}
 
 		ret = append(ret, d)

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"path"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -18,6 +17,8 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return PartitionsWithContext(context.Background(), all)
 }
 
+// PartitionsWithContext returns disk partition.
+// 'all' argument is ignored, see: https://github.com/giampaolo/psutil/issues/906
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
@@ -88,11 +89,6 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			Mountpoint: common.ByteToString(stat.Mntonname[:]),
 			Fstype:     common.ByteToString(stat.Fstypename[:]),
 			Opts:       opts,
-		}
-		if all == false {
-			if !path.IsAbs(d.Device) || !common.PathExists(d.Device) {
-				continue
-			}
 		}
 
 		ret = append(ret, d)

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"path"
 
 	"github.com/shirou/gopsutil/internal/common"
 	"golang.org/x/sys/unix"
@@ -16,6 +15,8 @@ func Partitions(all bool) ([]PartitionStat, error) {
 	return PartitionsWithContext(context.Background(), all)
 }
 
+// PartitionsWithContext returns disk partition.
+// 'all' argument is ignored, see: https://github.com/giampaolo/psutil/issues/906
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
@@ -65,11 +66,6 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			Mountpoint: common.IntToString(stat.F_mntonname[:]),
 			Fstype:     common.IntToString(stat.F_fstypename[:]),
 			Opts:       opts,
-		}
-		if all == false {
-			if !path.IsAbs(d.Device) || !common.PathExists(d.Device) {
-				continue
-			}
 		}
 
 		ret = append(ret, d)


### PR DESCRIPTION
I found [psutil ignore argument](https://github.com/giampaolo/psutil/blob/master/psutil/_psbsd.py#L323) on BSD systems according to [the issue](https://github.com/giampaolo/psutil/issues/906).

This PR changes to return all partition information. 

(These code is written in 2016 and I can not remember why add path evaluation)