### PR TITLE
[load][windows] Implement load.Avg() for Windows

### DIFF
--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -94,7 +94,7 @@ func BytePtrToString(p *uint8) string {
 	return string(a[:i])
 }
 
-// CounterInfo XXX
+// CounterInfo struct is used to track a windows performance counter
 // copied from https://github.com/mackerelio/mackerel-agent/
 type CounterInfo struct {
 	PostName    string
@@ -102,7 +102,7 @@ type CounterInfo struct {
 	Counter     windows.Handle
 }
 
-// CreateQuery XXX
+// CreateQuery with a PdhOpenQuery call
 // copied from https://github.com/mackerelio/mackerel-agent/
 func CreateQuery() (windows.Handle, error) {
 	var query windows.Handle
@@ -113,7 +113,7 @@ func CreateQuery() (windows.Handle, error) {
 	return query, nil
 }
 
-// CreateCounter XXX
+// CreateCounter with a PdhAddCounter call
 func CreateCounter(query windows.Handle, pname, cname string) (*CounterInfo, error) {
 	var counter windows.Handle
 	r, _, err := PdhAddCounter.Call(

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/shirou/gopsutil/internal/common"
 )
 
-func skipIfNotImplementedErr(t *testing.T, err error) {
+func skipIfNotImplementedErr(t testing.TB, err error) {
 	if err == common.ErrNotImplementedError {
 		t.Skip("not implemented")
 	}
@@ -26,23 +26,6 @@ func TestLoad(t *testing.T) {
 	}
 	t.Log(v)
 }
-
-// Commented out to not to slow down CI
-// Do conduct heavy cpu load on he computer to observe change
-// func TestLoadWithInterval(t *testing.T) {
-// 	interval := 5
-// 	iteration := 110 / interval
-
-// 	for i := 0; i < iteration; i++ {
-// 		v, err := Avg()
-// 		skipIfNotImplementedErr(t, err)
-// 		if err != nil {
-// 			t.Errorf("error %v", err)
-// 		}
-// 		t.Log(v)
-// 		time.Sleep(time.Duration(interval) * time.Second)
-// 	}
-// }
 
 func TestLoadAvgStat_String(t *testing.T) {
 	v := AvgStat{
@@ -83,4 +66,29 @@ func TestMiscStatString(t *testing.T) {
 		t.Errorf("TestMiscString string is invalid: %v", v)
 	}
 	t.Log(e)
+}
+
+func BenchmarkLoad(b *testing.B) {
+
+	loadAvg := func(t testing.TB) {
+		v, err := Avg()
+		skipIfNotImplementedErr(t, err)
+		if err != nil {
+			t.Errorf("error %v", err)
+		}
+		empty := &AvgStat{}
+		if v == empty {
+			t.Errorf("error load: %v", v)
+		}
+	}
+
+	b.Run("FirstCall", func(b *testing.B) {
+		loadAvg(b)
+	})
+
+	b.Run("SubsequentCalls", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			loadAvg(b)
+		}
+	})
 }

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -27,6 +27,23 @@ func TestLoad(t *testing.T) {
 	t.Log(v)
 }
 
+// Commented out to not to slow down CI
+// Do conduct heavy cpu load on he computer to observe change
+// func TestLoadWithInterval(t *testing.T) {
+// 	interval := 5
+// 	iteration := 110 / interval
+
+// 	for i := 0; i < iteration; i++ {
+// 		v, err := Avg()
+// 		skipIfNotImplementedErr(t, err)
+// 		if err != nil {
+// 			t.Errorf("error %v", err)
+// 		}
+// 		t.Log(v)
+// 		time.Sleep(time.Duration(interval) * time.Second)
+// 	}
+// }
+
 func TestLoadAvgStat_String(t *testing.T) {
 	v := AvgStat{
 		Load1:  10.1,

--- a/load/load_windows.go
+++ b/load/load_windows.go
@@ -22,9 +22,9 @@ var (
 )
 
 // loadAvgGoroutine updates avg data by fetching current load by interval
-// TODO register callback rather than this
+// TODO instead of this goroutine, we can register a Win32 counter just as psutil does
 // see https://psutil.readthedocs.io/en/latest/#psutil.getloadavg
-// code https://github.com/giampaolo/psutil/blob/master/psutil/arch/windows/wmi.c
+// code https://github.com/giampaolo/psutil/blob/8415355c8badc9c94418b19bdf26e622f06f0cce/psutil/arch/windows/wmi.c
 func loadAvgGoroutine() {
 	const (
 		loadAvgFactor1F  = 0.9200444146293232478931553241

--- a/load/load_windows.go
+++ b/load/load_windows.go
@@ -4,18 +4,75 @@ package load
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/shirou/gopsutil/internal/common"
 )
+
+var (
+	loadErr              error
+	loadAvg1M            float64 = 0.0
+	loadAvg5M            float64 = 0.0
+	loadAvg15M           float64 = 0.0
+	loadAvgMutex         sync.RWMutex
+	loadAvgGoroutineOnce sync.Once
+)
+
+// loadAvgGoroutine updates avg data by fetching current load by interval
+// TODO register callback rather than this
+// see https://psutil.readthedocs.io/en/latest/#psutil.getloadavg
+// code https://github.com/giampaolo/psutil/blob/master/psutil/arch/windows/wmi.c
+func loadAvgGoroutine() {
+	const (
+		loadAvgFactor1F  = 0.9200444146293232478931553241
+		loadAvgFactor5F  = 0.9834714538216174894737477501
+		loadAvgFactor15F = 0.9944598480048967508795473394
+	)
+
+	var (
+		interval = 5 * time.Second
+	)
+
+	generator, err := common.NewProcessorQueueLengthGenerator()
+	if err != nil {
+		loadAvgMutex.Lock()
+		loadErr = err
+		loadAvgMutex.Unlock()
+		return
+	}
+	for {
+		time.Sleep(interval)
+		if generator == nil {
+			return
+		}
+		currentLoad, err := generator.Generate()
+		loadAvgMutex.Lock()
+		loadErr = err
+		if err == nil {
+			loadAvg1M = loadAvg1M*loadAvgFactor1F + currentLoad*(1.0-loadAvgFactor1F)
+			loadAvg5M = loadAvg5M*loadAvgFactor5F + currentLoad*(1.0-loadAvgFactor5F)
+			loadAvg15M = loadAvg15M*loadAvgFactor15F + currentLoad*(1.0-loadAvgFactor15F)
+		}
+		loadAvgMutex.Unlock()
+	}
+}
 
 func Avg() (*AvgStat, error) {
 	return AvgWithContext(context.Background())
 }
 
 func AvgWithContext(ctx context.Context) (*AvgStat, error) {
-	ret := AvgStat{}
+	loadAvgGoroutineOnce.Do(func() { go loadAvgGoroutine() })
+	loadAvgMutex.RLock()
+	defer loadAvgMutex.RUnlock()
+	ret := AvgStat{
+		Load1:  loadAvg1M,
+		Load5:  loadAvg5M,
+		Load15: loadAvg15M,
+	}
 
-	return &ret, common.ErrNotImplementedError
+	return &ret, loadErr
 }
 
 func Misc() (*MiscStat, error) {


### PR DESCRIPTION
[psutil doc](https://psutil.readthedocs.io/en/latest/#psutil.getloadavg) specifies that there is a Win32 API callback, which can be observed in [source code](https://github.com/giampaolo/psutil/blob/master/psutil/arch/windows/wmi.c) as reading from a counter. Even though original psutil registers a callback function, I don't really have enough experience or time to implement it the exact way. So I kind of combined it with the source code in [mackarel agent](https://github.com/mackerelio/mackerel-agent/blob/master/metrics/windows/processor_queue_length.go). Please do test as I tend to do many typos and bugs...

Hopefully will close #973 