### PR TITLE
process: unbreak build on OpenBSD

### DIFF
--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -176,7 +176,12 @@ func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
 		return nil, err
 	}
 
-	return k.Groups, nil
+	groups := make([]int32, k.Ngroups)
+	for i := int16(0); i < k.Ngroups; i++ {
+		groups[i] = int32(k.Groups[i])
+	}
+
+	return groups, nil
 }
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {


### PR DESCRIPTION
Match FreeBSD code to prevent:
process_openbsd.go:230:10: cannot use k.Groups (type [16]uint32) as type []int32 in return argument