### PR TITLE
Fix labeler CI "HttpError: Resource not accessible by integration" error

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
See https://github.com/actions/labeler/issues/12#issuecomment-670967607