### PR TITLE
[v3][cpu][windows] Remove exported windows-specific dead code

### DIFF
--- a/_tools/v3migration/v3Changes.md
+++ b/_tools/v3migration/v3Changes.md
@@ -15,3 +15,4 @@
 - [disk] `GetDiskSerialNumber()` is now `SerialNumber()` and spread to all platform
 - [disk] `GetLabel ()` is now `Label()` and spread to all platform
 - [net] Change net.InterfaceStat.Addrs to InterfaceAddrList (#226)
+- [cpu] Removed windows-specific `ProcInfo()`

--- a/_tools/v3migration/v3Changes.md
+++ b/_tools/v3migration/v3Changes.md
@@ -2,17 +2,17 @@
 
 - v3 is in the `v3` directory
 
-- [process] RLimit is now uint64 (#364)
-- [process] Remove process.NetIOCounters (#429)
-- [docker] fix typo of memoryLimitInBbytes  (#464)
-- [mem] VirtualMemoryStat JSON fields capitalization (#545)
+- [process] RLimit is now uint64 ([#364](https://github.com/shirou/gopsutil/issues/364))
+- [process] Remove process.NetIOCounters ([#429](https://github.com/shirou/gopsutil/issues/429))
+- [docker] fix typo of memoryLimitInBbytes  ([#464](https://github.com/shirou/gopsutil/issues/464))
+- [mem] VirtualMemoryStat JSON fields capitalization ([#545](https://github.com/shirou/gopsutil/issues/545))
   - various JSON field name and some of Variable name have been changed. see v3migration.sh
 - [all] various kind of platform dependent values/constants such as process.GetWin32Proc is now private. see v3migration.sh
-- [process] process.Status() now returns []string. and status string is "Running", not just "R". defined in process.go. (#596)
-- [docker] `CgroupCPU()` now returns `*CgroupCPUStat` with Usage  (#590 and #581)
-- [disk] `disk.Opts` is now string[], not string. (related to #955)
-- [host] Fixed temperature sensors detection in Linux (#905)
-- [disk] `GetDiskSerialNumber()` is now `SerialNumber()` and spread to all platform
+- [process] process.Status() now returns []string. and status string is "Running", not just "R". defined in process.go. ([#596](https://github.com/shirou/gopsutil/issues/596))
+- [docker] `CgroupCPU()` now returns `*CgroupCPUStat` with Usage  ([#590](https://github.com/shirou/gopsutil/issues/590) and [#581](https://github.com/shirou/gopsutil/issues/581))
+- [disk] `disk.Opts` is now string[], not string. (related to [#955](https://github.com/shirou/gopsutil/issues/955))
+- [host] Fixed temperature sensors detection in Linux ([#905](https://github.com/shirou/gopsutil/issues/905))
+- [disk] `GetDiskSerialNumber()` is now `SerialNumber()` and spread to all platforms
 - [disk] `GetLabel ()` is now `Label()` and spread to all platform
-- [net] Change net.InterfaceStat.Addrs to InterfaceAddrList (#226)
+- [net] Change net.InterfaceStat.Addrs to InterfaceAddrList ([#226](https://github.com/shirou/gopsutil/issues/226))
 - [cpu] Removed windows-specific `ProcInfo()`

--- a/v3/cpu/cpu_windows.go
+++ b/v3/cpu/cpu_windows.go
@@ -43,12 +43,6 @@ type win32_SystemProcessorPerformanceInformation struct {
 	InterruptCount uint32
 }
 
-// Win32_PerfFormattedData_PerfOS_System struct to have count of processes and processor queue length
-type Win32_PerfFormattedData_PerfOS_System struct {
-	Processes            uint32
-	ProcessorQueueLength uint32
-}
-
 const (
 	ClocksPerSec = 10000000.0
 
@@ -131,22 +125,6 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	}
 
 	return ret, nil
-}
-
-// ProcInfo returns processes count and processor queue length in the system.
-// There is a single queue for processor even on multiprocessors systems.
-func ProcInfo() ([]Win32_PerfFormattedData_PerfOS_System, error) {
-	return ProcInfoWithContext(context.Background())
-}
-
-func ProcInfoWithContext(ctx context.Context) ([]Win32_PerfFormattedData_PerfOS_System, error) {
-	var ret []Win32_PerfFormattedData_PerfOS_System
-	q := wmi.CreateQuery(&ret, "")
-	err := common.WMIQueryWithContext(ctx, q, &ret)
-	if err != nil {
-		return []Win32_PerfFormattedData_PerfOS_System{}, err
-	}
-	return ret, err
 }
 
 // perCPUTimes returns times stat per cpu, per core and overall for all CPUs


### PR DESCRIPTION
Users wanting to use this Windows-specific feature can still use github.com/StackExchange/wmi by themselves.