### PR TITLE
[cpu][linux] Get logical cores in Counts() with non-deprecated kernel API first

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -313,19 +313,25 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 		return ret, nil
 	}
 	// physical cores
-	// https://github.com/giampaolo/psutil/blob/122174a10b75c9beebe15f6c07dcf3afbe3b120d/psutil/_pslinux.py#L621-L629
+	// https://github.com/giampaolo/psutil/blob/8415355c8badc9c94418b19bdf26e622f06f0cce/psutil/_pslinux.py#L615-L628
 	var threadSiblingsLists = make(map[string]bool)
-	if files, err := filepath.Glob(common.HostSys("devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list")); err == nil {
-		for _, file := range files {
-			lines, err := common.ReadLines(file)
-			if err != nil || len(lines) != 1 {
-				continue
+	// These 2 files are the same but */core_cpus_list is newer while */thread_siblings_list is deprecated and may disappear in the future.
+	// https://www.kernel.org/doc/Documentation/admin-guide/cputopology.rst
+	// https://github.com/giampaolo/psutil/pull/1727#issuecomment-707624964
+	// https://lkml.org/lkml/2019/2/26/41
+	for _, glob := range []string{"devices/system/cpu/cpu[0-9]*/topology/core_cpus_list", "devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list"} {
+		if files, err := filepath.Glob(common.HostSys(glob)); err == nil {
+			for _, file := range files {
+				lines, err := common.ReadLines(file)
+				if err != nil || len(lines) != 1 {
+					continue
+				}
+				threadSiblingsLists[lines[0]] = true
 			}
-			threadSiblingsLists[lines[0]] = true
-		}
-		ret := len(threadSiblingsLists)
-		if ret != 0 {
-			return ret, nil
+			ret := len(threadSiblingsLists)
+			if ret != 0 {
+				return ret, nil
+			}
 		}
 	}
 	// https://github.com/giampaolo/psutil/blob/122174a10b75c9beebe15f6c07dcf3afbe3b120d/psutil/_pslinux.py#L631-L652

--- a/v3/cpu/cpu_linux.go
+++ b/v3/cpu/cpu_linux.go
@@ -313,19 +313,25 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 		return ret, nil
 	}
 	// physical cores
-	// https://github.com/giampaolo/psutil/blob/122174a10b75c9beebe15f6c07dcf3afbe3b120d/psutil/_pslinux.py#L621-L629
+	// https://github.com/giampaolo/psutil/blob/8415355c8badc9c94418b19bdf26e622f06f0cce/psutil/_pslinux.py#L615-L628
 	var threadSiblingsLists = make(map[string]bool)
-	if files, err := filepath.Glob(common.HostSys("devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list")); err == nil {
-		for _, file := range files {
-			lines, err := common.ReadLines(file)
-			if err != nil || len(lines) != 1 {
-				continue
+	// These 2 files are the same but */core_cpus_list is newer while */thread_siblings_list is deprecated and may disappear in the future.
+	// https://www.kernel.org/doc/Documentation/admin-guide/cputopology.rst
+	// https://github.com/giampaolo/psutil/pull/1727#issuecomment-707624964
+	// https://lkml.org/lkml/2019/2/26/41
+	for _, glob := range []string{"devices/system/cpu/cpu[0-9]*/topology/core_cpus_list", "devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list"} {
+		if files, err := filepath.Glob(common.HostSys(glob)); err == nil {
+			for _, file := range files {
+				lines, err := common.ReadLines(file)
+				if err != nil || len(lines) != 1 {
+					continue
+				}
+				threadSiblingsLists[lines[0]] = true
 			}
-			threadSiblingsLists[lines[0]] = true
-		}
-		ret := len(threadSiblingsLists)
-		if ret != 0 {
-			return ret, nil
+			ret := len(threadSiblingsLists)
+			if ret != 0 {
+				return ret, nil
+			}
 		}
 	}
 	// https://github.com/giampaolo/psutil/blob/122174a10b75c9beebe15f6c07dcf3afbe3b120d/psutil/_pslinux.py#L631-L652


### PR DESCRIPTION
Implementing https://github.com/giampaolo/psutil/pull/1727#issuecomment-707624964 and https://github.com/giampaolo/psutil/commit/bfae1fc4a371c9e08f2c3f5053a80542e43d18f7