### PR TITLE
Detect wsl virtualization same way as detect-virt

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -178,6 +178,18 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 		}
 	}
 
+	filename = HostProc("sys/kernel/osrelease")
+	if PathExists(filename) {
+		contents, err := ReadLines(filename)
+		if err == nil {
+			if StringsContains(contents, "Microsoft") ||
+				StringsContains(contents, "WSL") {
+				system = "wsl"
+				role = "guest"
+			}
+		}
+	}
+
 	filename = HostProc("bus/pci/devices")
 	if PathExists(filename) {
 		contents, err := ReadLines(filename)


### PR DESCRIPTION
It is the Windows Subsystem for Linux, version 2

Adopted from https://github.com/microsoft/WSL/issues/423 and systemd