### PR TITLE
Make mktypes.sh generate code for v3 and make scripts shellcheck-compliant

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+name: Shellcheck
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get shellCheck
+      run: |
+        curl -Lf https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz | tar xJfv - --strip-components=1 shellcheck-stable/shellcheck -C /bin
+    - name: Run shellcheck
+      run: |
+        git ls-files --exclude='*.sh' --ignored | xargs shellcheck

--- a/_tools/v3migration/v3migration.sh
+++ b/_tools/v3migration/v3migration.sh
@@ -7,12 +7,12 @@ set -eu
 
 
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT=$(cd ${DIR}/../.. && pwd)
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+ROOT=$(cd "${DIR}"/../.. && pwd)
 
 
 ## 1. refresh
-cd ${ROOT}
+cd "${ROOT}"
 
 /bin/rm -rf v3
 
@@ -23,22 +23,22 @@ cp -rp cpu disk docker host internal load mem net process winservices v3
 cp Makefile v3
 
 # build migartion tool
-go build -o v3/v3migration ${DIR}/v3migration.go
+go build -o v3/v3migration "${DIR}"/v3migration.go
 
 
-V3DIR=$(cd ${ROOT}/v3 && pwd)
-cd ${V3DIR}
+V3DIR=$(cd "${ROOT}"/v3 && pwd)
+cd "${V3DIR}"
 
 ## 3. mod
 go mod init
 
 ###  change import path
-find . -name "*.go" | xargs -I@ sed -i 's|"github.com/shirou/gopsutil/|"github.com/shirou/gopsutil/v3/|g' @
+find . -name "*.go" -print0 | xargs -0 -I@ sed -i 's|"github.com/shirou/gopsutil/|"github.com/shirou/gopsutil/v3/|g' @
 
 ############ Issues
 
 # #429 process.NetIOCounters is pointless on Linux
-./v3migration `pwd` 429
+./v3migration "$(pwd)" 429
 sed -i '/NetIOCounters/d' process/process.go
 sed -i "/github.com\/shirou\/gopsutil\/v3\/net/d" process/process_bsd.go
 
@@ -165,10 +165,7 @@ sed -i 's|PrioProcess|prioProcess|g' process/process_*.go
 sed -i 's|ClockTicks|clockTicks|g' process/process_*.go
 
 
-./v3migration `pwd` issueRemoveUnusedValue
+./v3migration "$(pwd)" issueRemoveUnusedValue
 
 
 ############ SHOULD BE FIXED BY HAND
-
-
-

--- a/coverall.sh
+++ b/coverall.sh
@@ -1,12 +1,12 @@
-#/bin/sh
+#!/bin/sh
 
 # see http://www.songmu.jp/riji/entry/2015-01-15-goveralls-multi-package.html
 
 set -e
 # cleanup
 cleanup() {
-  if [ $tmpprof != "" ] && [ -f $tmpprof ]; then
-    rm -f $tmpprof
+  if [ "$tmpprof" != "" ] && [ -f "$tmpprof" ]; then
+    rm -f "$tmpprof"
   fi
   exit
 }
@@ -14,13 +14,13 @@ trap cleanup INT QUIT TERM EXIT
 
 # メインの処理
 prof=${1:-".profile.cov"}
-echo "mode: count" > $prof
-gopath1=$(echo $GOPATH | cut -d: -f1)
+echo "mode: count" > "$prof"
+gopath1=$(echo "$GOPATH" | cut -d: -f1)
 for pkg in $(go list ./...); do
-  tmpprof=$gopath1/src/$pkg/profile.tmp
-  go test -covermode=count -coverprofile=$tmpprof $pkg
-  if [ -f $tmpprof ]; then
-    cat $tmpprof | tail -n +2 >> $prof
-    rm $tmpprof
+  tmpprof="$gopath1/src/$pkg/profile.tmp"
+  go test -covermode=count -coverprofile="$tmpprof" "$pkg"
+  if [ -f "$tmpprof" ]; then
+    tail -n +2 "$tmpprof" >> "$prof"
+    rm "$tmpprof"
   fi
 done

--- a/mktypes.sh
+++ b/mktypes.sh
@@ -6,11 +6,15 @@ GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
 GOARCH=$(go env GOARCH)
 
-for PKG in $PKGS
+for DIR in . v3
 do
-        if [ -e "${PKG}/types_${GOOS}.go" ]; then
-                (echo "// +build $GOOS"
-                echo "// +build $GOARCH"
-                go tool cgo -godefs "${PKG}/types_${GOOS}.go") | gofmt > "${PKG}/${PKG}_${GOOS}_${GOARCH}.go"
-        fi
+        (cd "$DIR" || exit
+        for PKG in $PKGS
+        do
+                if [ -e "${PKG}/types_${GOOS}.go" ]; then
+                        (echo "// +build $GOOS"
+                        echo "// +build $GOARCH"
+                        go tool cgo -godefs "${PKG}/types_${GOOS}.go") | gofmt > "${PKG}/${PKG}_${GOOS}_${GOARCH}.go"
+                fi
+        done)
 done

--- a/v2migration.sh
+++ b/v2migration.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 # This script is a helper of migration to gopsutil v2 using gorename
-# 
+#
 # go get golang.org/x/tools/cmd/gorename
 
 IFS=$'\n'
@@ -12,7 +13,7 @@ IFS=$'\n'
 #   This scripts replace process.NetIOCounters() to IOCounters().
 #   So you need hand-fixing process.
 
-TARGETS=`cat <<EOF
+TARGETS=$(cat <<EOF
 CPUTimesStat -> TimesStat
 CPUInfoStat -> InfoStat
 CPUTimes -> Times
@@ -48,11 +49,12 @@ NetConnectionsPid -> ConnectionsPid
 Uid -> UID
 Id -> ID
 convertCpuTimes -> convertCPUTimes
-EOF`
+EOF
+)
 
 for T in $TARGETS
 do
-  echo $T
+  echo "$T"
   gofmt -w -r "$T" ./*.go
 done
 


### PR DESCRIPTION
As seen in #993, `mktypes.sh` doesn't generate types for v3.

Also implement automatic [shellcheck](https://github.com/koalaman/shellcheck) test on GH Actions and fix scripts so they are compliant.