### PR TITLE
cpufreq for apple silicon macs

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -93,13 +93,33 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
-	cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency")
+	cpuFrequency, err := getFrequency()
 	if err != nil {
 		return ret, err
 	}
 	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
+}
+
+func getFrequency() (uint64, error) {
+	// This works for Intel macs.
+	if cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency"); err == nil {
+		return cpuFrequency, nil
+	}
+
+	// On Apple Silicon fallback to hw.tbfrequency and kern.clockrate[hz]
+	tbFreq, err := unix.SysctlUint64("hw.tbfrequency")
+	if err != nil {
+		return 0, err
+	}
+
+	kernClockrate, err := unix.SysctlClockinfo("kern.clockrate")
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(kernClockrate.Hz) * tbFreq, nil
 }
 
 func CountsWithContext(ctx context.Context, logical bool) (int, error) {

--- a/v3/cpu/cpu_darwin.go
+++ b/v3/cpu/cpu_darwin.go
@@ -93,13 +93,33 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
-	cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency")
+	cpuFrequency, err := getFrequency()
 	if err != nil {
 		return ret, err
 	}
 	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
+}
+
+func getFrequency() (uint64, error) {
+	// This works for Intel macs.
+	if cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency"); err == nil {
+		return cpuFrequency, nil
+	}
+
+	// On Apple Silicon fallback to hw.tbfrequency and kern.clockrate[hz]
+	tbFreq, err := unix.SysctlUint64("hw.tbfrequency")
+	if err != nil {
+		return 0, err
+	}
+
+	kernClockrate, err := unix.SysctlClockinfo("kern.clockrate")
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(kernClockrate.Hz) * tbFreq, nil
 }
 
 func CountsWithContext(ctx context.Context, logical bool) (int, error) {


### PR DESCRIPTION
Previously on darwin, it was safe to assume that `hw.cpufrequency`
would be defined in sysctl. On the new M1 macs instead use the base
frequency `hw.tbfrequency` and `kern.clockrate[hz]`. The computed
value appears to be 2.4 GHz, which is I believe is the correct base
clock.

Before:
```
 m1  cpu  master % go test
--- FAIL: TestCpuInfo (0.00s)
    cpu_test.go:117: error no such file or directory
    cpu_test.go:120: could not get CPU Info
FAIL
exit status 1
FAIL	github.com/shirou/gopsutil/v3/cpu	0.371s
```

After:
```
 m1  cpu  m1freq % go test
PASS
ok  	github.com/shirou/gopsutil/v3/cpu	0.248s
```