### PR TITLE
Fix wrong OpenBSD user count

### DIFF
--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -78,7 +78,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 		var u Utmp
 		br := bytes.NewReader(b)
 		err := binary.Read(br, binary.LittleEndian, &u)
-		if err != nil || u.Time == 0 {
+		if err != nil || u.Time == 0 || u.Name[0] == 0 {
 			continue
 		}
 		user := UserStat{


### PR DESCRIPTION
There are empty entries in OpenBSD's utmp that have a line and time entry but no user logged in (the entry is "cleared" after user logs out but not totally as expected in the code here). Current checks are insufficient so check if Name field is empty and skip in that case.