### PR TITLE
[process][linux] Fixing smaps parser

### DIFF
--- a/v3/process/process_linux.go
+++ b/v3/process/process_linux.go
@@ -394,9 +394,9 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 	lines := strings.Split(string(contents), "\n")
 
 	// function of parsing a block
-	getBlock := func(first_line []string, block []string) (MemoryMapsStat, error) {
+	getBlock := func(firstLine []string, block []string) (MemoryMapsStat, error) {
 		m := MemoryMapsStat{}
-		m.Path = first_line[len(first_line)-1]
+		m.Path = firstLine[len(firstLine)-1]
 
 		for _, line := range block {
 			if strings.Contains(line, "VmFlags") {
@@ -439,13 +439,15 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 		return m, nil
 	}
 
-	blocks := make([]string, 16)
-	for _, line := range lines {
+	var firstLine []string
+	blocks := make([]string, 0, 16)
+
+	for i, line := range lines {
 		fields := strings.Fields(line)
-		if len(fields) > 0 && !strings.HasSuffix(fields[0], ":") {
+		if (len(fields) > 0 && !strings.HasSuffix(fields[0], ":")) || i == len(lines)-1 {
 			// new block section
-			if len(blocks) > 0 {
-				g, err := getBlock(fields, blocks)
+			if len(firstLine) > 0 && len(blocks) > 0 {
+				g, err := getBlock(firstLine, blocks)
 				if err != nil {
 					return &ret, err
 				}
@@ -465,7 +467,8 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 				}
 			}
 			// starts new block
-			blocks = make([]string, 16)
+			blocks = make([]string, 0, 16)
+			firstLine = fields
 		} else {
 			blocks = append(blocks, line)
 		}


### PR DESCRIPTION
There seems to be a bug in the `SMAPS` parsing, what I am observing is that the values in the last block of `/proc/pid/smaps` are not being included in the final output. If you see the [sample input](https://gist.github.com/rishabh-arya95/1d98ce3a4053d2989ca0320e06b42643), the value of Size should be `20` but it comes out `16`.

Also, the blocks are not getting the correct pathname, they are getting the name of the next block that is because in the first iteration the first `if`  condition becomes true, and the first line always gets skipped.

One minor issue is that we are creating a slice `blocks` of length 16 and then we are appending to it, so this will lead to increasing the length of the slice which is inefficient.

This PR fixes the above issues