### PR TITLE
Fix lsof args for udp4 in unix

### DIFF
--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -63,7 +63,7 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 	case "udp":
 		args = append(args, "udp")
 	case "udp4":
-		args = append(args, "6udp")
+		args = append(args, "4udp")
 	case "udp6":
 		args = append(args, "6udp")
 	case "unix":

--- a/v3/net/net_unix.go
+++ b/v3/net/net_unix.go
@@ -63,7 +63,7 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 	case "udp":
 		args = append(args, "udp")
 	case "udp4":
-		args = append(args, "6udp")
+		args = append(args, "4udp")
 	case "udp6":
 		args = append(args, "6udp")
 	case "unix":


### PR DESCRIPTION
It's currently impossible to list UDP4 ports in Unix due to a typo