### PR TITLE
Clarify the godoc of the Children function.

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -476,7 +476,8 @@ func (p *Process) PageFaults() (*PageFaultsStat, error) {
 	return p.PageFaultsWithContext(context.Background())
 }
 
-// Children returns a slice of Process of the process.
+// Children returns the children of the process represented as a slice
+// of pointers to Process type.
 func (p *Process) Children() ([]*Process, error) {
 	return p.ChildrenWithContext(context.Background())
 }

--- a/v3/process/process.go
+++ b/v3/process/process.go
@@ -487,7 +487,8 @@ func (p *Process) PageFaults() (*PageFaultsStat, error) {
 	return p.PageFaultsWithContext(context.Background())
 }
 
-// Children returns a slice of Process of the process.
+// Children returns the children of the process represented as a slice
+// of pointers to Process type.
 func (p *Process) Children() ([]*Process, error) {
 	return p.ChildrenWithContext(context.Background())
 }


### PR DESCRIPTION
The previous godoc string was slightly confusing and only described information that can be deduced from the function signature.