### PR TITLE
Avoid returning slice into buffer from Readfile

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -821,8 +821,12 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					}
 				}
 			}
+			// Ensure we have a copy and not reference into slice
+			p.name = string([]byte(p.name))
 		case "State":
 			p.status = value[0:1]
+			// Ensure we have a copy and not reference into slice
+			p.status = string([]byte(p.status))
 		case "PPid", "Ppid":
 			pval, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {


### PR DESCRIPTION
The memory usage is quite ineffecient without this fix since the whole Readfile buffer can not be garbage collected due to the name and status short strings being slices with the underlying array being the Readfile buffer.