### PR TITLE
Added missing distributions to the suse platform family

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -281,7 +281,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "fedora"
 	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm":
 		family = "rhel"
-	case "suse", "opensuse", "sles":
+	case "suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sles", "sled", "caasp":
 		family = "suse"
 	case "gentoo":
 		family = "gentoo"


### PR DESCRIPTION
We've found using `gopsutil` quite useful in open-source [rport](https://github.com/cloudradar-monitoring/rport) project. But we've encountered a problem of detecting a platform family for Linux `opensuse-leap` distribution. Here is an example of `os-release` file:
```
    NAME="openSUSE Leap"
    VERSION="15.2"
    ID="opensuse-leap"
    ID_LIKE="suse opensuse"
    VERSION_ID="15.2"
    PRETTY_NAME="openSUSE Leap 15.2"
    ANSI_COLOR="0;32"
    CPE_NAME="cpe:/o:opensuse:leap:15.2"
    BUG_REPORT_URL="https://bugs.opensuse.org"
    HOME_URL="https://www.opensuse.org/"
```
`PlatformInformationWithContext` detects platform family by `ID` attribute. Since `"opensuse-leap"` is missing in the switch statement, it returns an empty string for `family`. This PR fixes this issue.

Also, according to https://en.opensuse.org/SDB:SUSE_and_openSUSE_Products_Version_Outputs there are other distributions: `"opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sled", "caasp"`. This PR fixes the issue for all missing distributions.

BTW, if you like our project https://github.com/cloudradar-monitoring/rport - please give us a star🙂