### PR TITLE
[net] add debug log to net_test.

### DIFF
--- a/net/net_test.go
+++ b/net/net_test.go
@@ -87,8 +87,9 @@ func TestNetIOCountersAll(t *testing.T) {
 	for _, p := range per {
 		pr += p.PacketsRecv
 	}
-	if math.Abs(float64(v[0].PacketsRecv-pr)) > 5 {
-		t.Errorf("invalid sum value: %v, %v", v[0].PacketsRecv, pr)
+	// small diff is ok
+	if int(math.Abs(float64(v[0].PacketsRecv-pr))) > 5 {
+		t.Errorf("invalid sum value: %v, %v, %v, %v, %v", v[0].PacketsRecv, pr, v[0].PacketsRecv-pr, math.Abs(float64(v[0].PacketsRecv-pr)), int(math.Abs(float64(v[0].PacketsRecv-pr))) > 5)
 	}
 }
 

--- a/v3/net/net_test.go
+++ b/v3/net/net_test.go
@@ -88,8 +88,8 @@ func TestNetIOCountersAll(t *testing.T) {
 		pr += p.PacketsRecv
 	}
 	// small diff is ok
-	if math.Abs(float64(v[0].PacketsRecv-pr)) > 5 {
-		t.Errorf("invalid sum value: %v, %v", v[0].PacketsRecv, pr)
+	if int(math.Abs(float64(v[0].PacketsRecv-pr))) > 5 {
+		t.Errorf("invalid sum value: %v, %v, %v, %v, %v", v[0].PacketsRecv, pr, v[0].PacketsRecv-pr, math.Abs(float64(v[0].PacketsRecv-pr)), int(math.Abs(float64(v[0].PacketsRecv-pr))) > 5)
 	}
 }
 


### PR DESCRIPTION
It seems CircleCI test fails many time in `TestNetIOCountersAll` in `net/net_test.go` . This PR add debug print to the test function.