### PR TITLE
Fix fillFromStatusWithContext() on systems with 128 bit signal masks.

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -935,30 +935,45 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 			}
 			p.memInfo.Locked = v * 1024
 		case "SigPnd":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.PendingThread = v
 		case "ShdPnd":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.PendingProcess = v
 		case "SigBlk":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.Blocked = v
 		case "SigIgn":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.Ignored = v
 		case "SigCgt":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err

--- a/v3/process/process_linux.go
+++ b/v3/process/process_linux.go
@@ -930,30 +930,45 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 			}
 			p.memInfo.Locked = v * 1024
 		case "SigPnd":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.PendingThread = v
 		case "ShdPnd":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.PendingProcess = v
 		case "SigBlk":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.Blocked = v
 		case "SigIgn":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err
 			}
 			p.sigInfo.Ignored = v
 		case "SigCgt":
+			if len(value) > 16 {
+				value = value[len(value)-16:]
+			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
 				return err


### PR DESCRIPTION
It seems, that on some Linux systems, the signal counters and bit masks in /proc/\<pid\>/status are 128 bit values. 

On a MIPS64 system the fields in the /proc/\<pid\>/status file look like this:
```
SigPnd:	00000000000000000000000000000000
ShdPnd:	00000000000000000000000000000000
SigBlk:	00000000000000000000000000000000
SigIgn:	ffffffffffffffffffffffffffffffff
SigCgt:	00000000000000000000000000000000
```

The strconv.ParseUint() function can only handle values up to 64 bit and will fail on parsing the SigIgn value. This causes fillFromStatusWithContext() to fail too and procress.Status() will not return any value.

The first octets were 0000000000000000 or ffffffffffffffff in all cases. This patch removes the first characters of the string before passing it to strconv.ParseUint() if it is longer than 16 octets.