### PR TITLE
Make limitToUint parse to uint instead of int

### DIFF
--- a/v3/process/process_linux.go
+++ b/v3/process/process_linux.go
@@ -485,11 +485,11 @@ func limitToUint(val string) (uint64, error) {
 	if val == "unlimited" {
 		return math.MaxUint64, nil
 	} else {
-		res, err := strconv.ParseInt(val, 10, 32)
+		res, err := strconv.ParseUint(val, 10, 64)
 		if err != nil {
 			return 0, err
 		}
-		return uint64(res), nil
+		return res, nil
 	}
 }
 


### PR DESCRIPTION
Attempting to parse a soft/hard limit greater than int32 fails and returns 0 instead.
I believe soft/hard limits are always unsigned, hence no need to attempt to parse as int.