### PR TITLE
processor, v3/processor (Win): fix slow cpuinfo on multisocket config

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -5,6 +5,7 @@ package cpu
 import (
 	"context"
 	"fmt"
+	"strings"
 	"unsafe"
 
 	"github.com/StackExchange/wmi"
@@ -18,7 +19,14 @@ var (
 )
 
 type Win32_Processor struct {
-	LoadPercentage            *uint16
+	Win32_ProcessorWithoutLoadPct
+	LoadPercentage *uint16
+}
+
+// LoadPercentage takes a linearly more time as the number of sockets increases.
+// For vSphere by default corespersocket = 1, meaning for a 40 vCPU VM Get Processor Info
+// could take more than half a minute.
+type Win32_ProcessorWithoutLoadPct struct {
 	Family                    uint16
 	Manufacturer              string
 	Name                      string
@@ -104,8 +112,9 @@ func Info() ([]InfoStat, error) {
 
 func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	var ret []InfoStat
-	var dst []Win32_Processor
+	var dst []Win32_ProcessorWithoutLoadPct
 	q := wmi.CreateQuery(&dst, "")
+	q = strings.ReplaceAll(q, "Win32_ProcessorWithoutLoadPct", "Win32_Processor")
 	if err := common.WMIQueryWithContext(ctx, q, &dst); err != nil {
 		return ret, err
 	}
@@ -242,8 +251,9 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 	}
 	// physical cores https://github.com/giampaolo/psutil/blob/d01a9eaa35a8aadf6c519839e987a49d8be2d891/psutil/_psutil_windows.c#L499
 	// for the time being, try with unreliable and slow WMI call…
-	var dst []Win32_Processor
+	var dst []Win32_ProcessorWithoutLoadPct
 	q := wmi.CreateQuery(&dst, "")
+	q = strings.ReplaceAll(q, "Win32_ProcessorWithoutLoadPct", "Win32_Processor")
 	if err := common.WMIQueryWithContext(ctx, q, &dst); err != nil {
 		return 0, err
 	}

--- a/v3/cpu/cpu_windows.go
+++ b/v3/cpu/cpu_windows.go
@@ -18,7 +18,6 @@ var (
 )
 
 type win32_Processor struct {
-	LoadPercentage            *uint16
 	Family                    uint16
 	Manufacturer              string
 	Name                      string


### PR DESCRIPTION
updated win32_Processor struct to exclude (unused) LoadPercentage field.
The loadpercentage takes linearly more time as the # of sockets
increases. By default vSphere maps 1 vCPU to 1 socket, resulting in very
poor performance when getting CPU info against, saying, 40 vCPU VM
(basically 40 sockets as seen by the VM).

Here is the before and after time comparison:
![printcpu-diff](https://user-images.githubusercontent.com/21690857/121991295-9d9e1380-cd5c-11eb-9f8c-becc233f8b3e.png)


changes:

for cpu:
since `Win32_Processor` is a public struct, created a substruct named: `Win32_ProcessorWithoutLoadPct` for use in all queries without breaking any potential usage of the public api.

for v3/cpu:
since the struct now is private, simply removed `LoadPercentage`