### PR TITLE
simplify mutex usage

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -27,7 +27,7 @@ type Process struct {
 	name           string
 	status         string
 	parent         int32
-	parentMutex    *sync.RWMutex // for windows ppid cache
+	parentMutex    sync.RWMutex // for windows ppid cache
 	numCtxSwitches *NumCtxSwitchesStat
 	uids           []int32
 	gids           []int32
@@ -170,8 +170,7 @@ func NewProcess(pid int32) (*Process, error) {
 
 func NewProcessWithContext(ctx context.Context, pid int32) (*Process, error) {
 	p := &Process{
-		Pid:         pid,
-		parentMutex: new(sync.RWMutex),
+		Pid: pid,
 	}
 
 	exists, err := PidExistsWithContext(ctx, pid)

--- a/v3/process/process.go
+++ b/v3/process/process.go
@@ -27,7 +27,7 @@ type Process struct {
 	name           string
 	status         string
 	parent         int32
-	parentMutex    *sync.RWMutex // for windows ppid cache
+	parentMutex    sync.RWMutex // for windows ppid cache
 	numCtxSwitches *NumCtxSwitchesStat
 	uids           []int32
 	gids           []int32
@@ -181,8 +181,7 @@ func NewProcess(pid int32) (*Process, error) {
 
 func NewProcessWithContext(ctx context.Context, pid int32) (*Process, error) {
 	p := &Process{
-		Pid:         pid,
-		parentMutex: new(sync.RWMutex),
+		Pid: pid,
 	}
 
 	exists, err := PidExistsWithContext(ctx, pid)


### PR DESCRIPTION
Mutexs don't have to be allocated so this was an unnecessary pointer. 