### PR TITLE
change to use ludeeus/action-shellcheck for shellcheck.

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,9 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Get shellCheck
-      run: |
-        curl -Lf https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz | tar xJfv - --strip-components=1 shellcheck-stable/shellcheck -C /bin
-    - name: Run shellcheck
-      run: |
-        git ls-files --exclude='*.sh' --ignored | xargs shellcheck
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
This PR fixes [shellcheck github action errors.](https://github.com/shirou/gopsutil/runs/2941835339?check_suite_focus=true) by using [ludeeus's shellcheck github actions](https://github.com/ludeeus/action-shellcheck).