### PR TITLE
fix wmi version

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/StackExchange/wmi v1.2.0
-	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/tklauser/go-sysconf v0.3.6
 	golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,5 +1,5 @@
-github.com/StackExchange/wmi v1.2.0 h1:noJEYkMQVlFCEAc+2ma5YyRhlfjcWfZqk5sBRYozdyM=
-github.com/StackExchange/wmi v1.2.0/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/StackExchange/wmi v1.2.0 h1:BfLCNdXnvwgy5RrRI3IyQ64ZItZngXHN+7PxU5RvKxA=
+github.com/StackExchange/wmi v1.2.0/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=


### PR DESCRIPTION
It seems like the StackExchange/wmi tag was changed after being installed to this repo, and it's caused us major problems trying to use the latest gopsutil:

```
verifying github.com/StackExchange/wmi@v1.2.0/go.mod: checksum mismatch
        downloaded: h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
        go.sum:     h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
For more information, see 'go help module-auth'.
```

This PR redownloads dependencies so the tag actually matches the commit again.