### PR TITLE
Switch usage from os.*File.Readdir to os.*File.ReadDir.

### DIFF
--- a/v3/net/net_linux.go
+++ b/v3/net/net_linux.go
@@ -545,12 +545,12 @@ func getProcInodes(root string, pid int32, max int) (map[string][]inodeMap, erro
 		return ret, err
 	}
 	defer f.Close()
-	files, err := f.Readdir(max)
+	dirEntries, err := f.ReadDir(max)
 	if err != nil {
 		return ret, err
 	}
-	for _, fd := range files {
-		inodePath := fmt.Sprintf("%s/%d/fd/%s", root, pid, fd.Name())
+	for _, dirEntry := range dirEntries {
+		inodePath := fmt.Sprintf("%s/%d/fd/%s", root, pid, dirEntry.Name())
 
 		inode, err := os.Readlink(inodePath)
 		if err != nil {
@@ -566,7 +566,7 @@ func getProcInodes(root string, pid int32, max int) (map[string][]inodeMap, erro
 		if !ok {
 			ret[inode] = make([]inodeMap, 0)
 		}
-		fd, err := strconv.Atoi(fd.Name())
+		fd, err := strconv.Atoi(dirEntry.Name())
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
I suggest theses changes because I could see some improvements on my tests regarding the following benchmark:

```
import (
        "testing"

        "github.com/shirou/gopsutil/v3/net"
)

func BenchmarkConnections(b *testing.B) {
        for i := 0; i < b.N; i++ {
                net.Connections("all")
        }
}
```


```
✦ ➜ benchstat old.txt new.txt
name           old time/op    new time/op    delta
Connections-8    20.8ms ± 0%    16.7ms ± 0%   ~     (p=1.000 n=1+1)

name           old alloc/op   new alloc/op   delta
Connections-8    4.38MB ± 0%    4.01MB ± 0%   ~     (p=1.000 n=1+1)

name           old allocs/op  new allocs/op  delta
Connections-8     45.2k ± 0%     42.4k ± 0%   ~     (p=1.000 n=1+1)
```

Can you confirm that these improvements are relevants?