### PR TITLE
Ensure rhel platform family for Rocky Linux

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -279,7 +279,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "debian"
 	case "fedora":
 		family = "fedora"
-	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm":
+	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky":
 		family = "rhel"
 	case "suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sles", "sled", "caasp":
 		family = "suse"

--- a/v3/host/host_linux.go
+++ b/v3/host/host_linux.go
@@ -283,7 +283,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "debian"
 	case "fedora":
 		family = "fedora"
-	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm":
+	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky":
 		family = "rhel"
 	case "suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sles", "sled", "caasp":
 		family = "suse"


### PR DESCRIPTION
Change: Ensure that the platform family field is set to rhel when using Rocky Linux. 