### PR TITLE
change test support version to 1.15 and 1.16.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test_v3_module:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-18.04, ubuntu-16.04, windows-2019, windows-2016, macOS-10.14, macos-11.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,7 +25,7 @@ jobs:
       GO111MODULE: off
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-18.04, ubuntu-16.04, windows-2019, windows-2016, macOS-10.14, macos-11.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +50,7 @@ jobs:
       GO111MODULE: off
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-18.04, ubuntu-16.04, windows-2019, windows-2016, macOS-10.14, macos-11.0]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Change test version from "1.13.x, 1.14.x, 1.15.x" to "1.15.x, 1.16.x" which current [official go supported version.](https://endoflife.date/go)