### PR TITLE
Update github.com/tklauser/go-sysconf to v0.3.8

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,12 +48,12 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:75b5c63e0eae3f1b290c91ff3084b80c9a51066c6dff1a6aca31ccbdab4aeee4"
+  digest = "1:3f14c2e97a330f13c73db03a73dc3f0f4bb601d759c16d73263a6cf3c7c20a77"
   name = "github.com/tklauser/go-sysconf"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bf420f795f20e170808c4d27a6b083f08725911f"
-  version = "v0.3.6"
+  revision = "18e8c84cb3317596497f8994bc890794c5ab5d4b"
+  version = "v0.3.8"
 
 [[projects]]
   digest = "1:e7bf47a37e6d0fb2f4bd0f65f574f8a92922f048cab3f106b0a7a413cbb14714"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/tklauser/go-sysconf"
-  version = "0.3.6"
+  version = "0.3.8"
 
 [[constraint]]
   branch = "master"

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/StackExchange/wmi v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tklauser/go-sysconf v0.3.7
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+	github.com/tklauser/go-sysconf v0.3.8
+	golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71
 )

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -9,13 +9,14 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tklauser/go-sysconf v0.3.7 h1:HT7h4+536gjqeq1ZIJPgOl1rg1XFatQGVZWp7Py53eg=
-github.com/tklauser/go-sysconf v0.3.7/go.mod h1:JZIdXh4RmBvZDBZ41ld2bGxRV3n4daiiqA3skYhAoQ4=
+github.com/tklauser/go-sysconf v0.3.8 h1:41Nq9J+pxKud4IQ830J5LlS5nl67dVQC7AuisUooaOU=
+github.com/tklauser/go-sysconf v0.3.8/go.mod h1:z4zYWRS+X53WUKtBcmDg1comV3fPhdQnzasnIHUoLDU=
 github.com/tklauser/numcpus v0.2.3 h1:nQ0QYpiritP6ViFhrKYsiv6VVxOpum2Gks5GhnJbS/8=
 github.com/tklauser/numcpus v0.2.3/go.mod h1:vpEPS/JC+oZGGQ/My/vJnNsvMDQL6PwOqt8dsCw5j+E=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71 h1:ikCpsnYR+Ew0vu99XlDp55lGgDJdIMx3f4a18jfse/s=
+golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
This fixes the build of go-sysconf on openbsd/386 and openbsd/arm, see
tklauser/go-sysconf#21 and rclone/rclone#5402 for context.

List of changes: https://github.com/tklauser/go-sysconf/compare/v0.3.6...v0.3.8