### PR TITLE
chore: Drop PROCESS_QUERY_INFORMATION support

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -40,7 +40,7 @@ var (
 	processorArchitecture uint
 )
 
-const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION | windows.PROCESS_QUERY_INFORMATION // WinXP doesn't know PROCESS_QUERY_LIMITED_INFORMATION
+const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION
 
 type SystemProcessInformation struct {
 	NextEntryOffset   uint64

--- a/v3/process/process_windows.go
+++ b/v3/process/process_windows.go
@@ -40,7 +40,7 @@ var (
 	processorArchitecture uint
 )
 
-const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION | windows.PROCESS_QUERY_INFORMATION // WinXP doesn't know PROCESS_QUERY_LIMITED_INFORMATION
+const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION
 
 type systemProcessorInformation struct {
 	ProcessorArchitecture uint16


### PR DESCRIPTION
PROCESS_QUERY_INFORMATION was used for compatibility reasons with
Windows XP / Server 2003. Both are no longer supported in Golang
and haven't been for a while (since Go 1.11). It should be safe
to drop this flag. PROCESS_QUERY_LIMITED_INFORMATION supports
PPL process such as LSASS, which are not queryable without this
change.