### PR TITLE
Update github.com/tklauser/go-sysconf to v0.3.9

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,20 +48,20 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:3f14c2e97a330f13c73db03a73dc3f0f4bb601d759c16d73263a6cf3c7c20a77"
+  digest = "1:dc2f804edbbcc4e7c5385791b8703da9b6bc6e22e698233f919c19da6286cf11"
   name = "github.com/tklauser/go-sysconf"
   packages = ["."]
   pruneopts = "UT"
-  revision = "18e8c84cb3317596497f8994bc890794c5ab5d4b"
-  version = "v0.3.8"
+  revision = "18f67506ef17458385cd85f6f7678623087ba043"
+  version = "v0.3.9"
 
 [[projects]]
-  digest = "1:e7bf47a37e6d0fb2f4bd0f65f574f8a92922f048cab3f106b0a7a413cbb14714"
+  digest = "1:40a9f481f2c76a04fb1a0c083e317907875cd6405e96117f2aa81fd17aa28000"
   name = "github.com/tklauser/numcpus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c03481b99a3f0b56b010e938559fddce19d3cf53"
-  version = "v0.1.0"
+  revision = "ce6ed4c574066004ab884122d989748388233cad"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/tklauser/go-sysconf"
-  version = "0.3.8"
+  version = "0.3.9"
 
 [[constraint]]
   branch = "master"

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/StackExchange/wmi v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tklauser/go-sysconf v0.3.8
+	github.com/tklauser/go-sysconf v0.3.9
 	golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71
 )

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -9,12 +9,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tklauser/go-sysconf v0.3.8 h1:41Nq9J+pxKud4IQ830J5LlS5nl67dVQC7AuisUooaOU=
-github.com/tklauser/go-sysconf v0.3.8/go.mod h1:z4zYWRS+X53WUKtBcmDg1comV3fPhdQnzasnIHUoLDU=
-github.com/tklauser/numcpus v0.2.3 h1:nQ0QYpiritP6ViFhrKYsiv6VVxOpum2Gks5GhnJbS/8=
-github.com/tklauser/numcpus v0.2.3/go.mod h1:vpEPS/JC+oZGGQ/My/vJnNsvMDQL6PwOqt8dsCw5j+E=
+github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=
+github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
+github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2biQ=
+github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71 h1:ikCpsnYR+Ew0vu99XlDp55lGgDJdIMx3f4a18jfse/s=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
This fixes the build with older Go versions due to missing GOARCH build
tags.

Release notes: https://github.com/tklauser/go-sysconf/releases/tag/v0.3.9
List of changes: https://github.com/tklauser/go-sysconf/compare/v0.3.8...v0.3.9