### PR TITLE
v3/process (Win): fix Kill() DuplicateHandle error

### DIFF
--- a/v3/process/process_windows.go
+++ b/v3/process/process_windows.go
@@ -650,7 +650,10 @@ func (p *Process) TerminateWithContext(ctx context.Context) error {
 }
 
 func (p *Process) KillWithContext(ctx context.Context) error {
-	process := os.Process{Pid: int(p.Pid)}
+	process, err := os.FindProcess(int(p.Pid))
+	if err != nil {
+		return err
+	}
 	return process.Kill()
 }
 


### PR DESCRIPTION
On golang 1.17 and latest windows 10, go test failed on testing Kill method because of DuplicateHandle error.
`DuplicateHandle: The handle is invalid.`