### PR TITLE
Rename `readdrivestat` function on v3

### DIFF
--- a/v3/disk/disk_darwin_cgo.go
+++ b/v3/disk/disk_darwin_cgo.go
@@ -19,7 +19,7 @@ import (
 
 func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOCountersStat, error) {
 	var buf [C.NDRIVE]C.DriveStats
-	n, err := C.readdrivestat(&buf[0], C.int(len(buf)))
+	n, err := C.v3readdrivestat(&buf[0], C.int(len(buf)))
 	if err != nil {
 		return nil, err
 	}

--- a/v3/disk/iostat_darwin.c
+++ b/v3/disk/iostat_darwin.c
@@ -16,7 +16,7 @@ static int getdrivestat(io_registry_entry_t d, DriveStats *stat);
 static int fillstat(io_registry_entry_t d, DriveStats *stat);
 
 int
-readdrivestat(DriveStats a[], int n)
+v3readdrivestat(DriveStats a[], int n)
 {
 	mach_port_t port;
 	CFMutableDictionaryRef match;

--- a/v3/disk/iostat_darwin.h
+++ b/v3/disk/iostat_darwin.h
@@ -29,5 +29,4 @@ struct CPUStats {
 	natural_t idle;
 };
 
-extern int readdrivestat(DriveStats a[], int n);
-extern int readcpustat(CPUStats *cpu);
+extern int v3readdrivestat(DriveStats a[], int n);


### PR DESCRIPTION
- Rename `readdrivestat` function on v3 to `v3readdrivestat`
- Delete unused `extern` declaration `readcpustat`.

This fixes #1136.

Signed-off-by: Pablo Baeyens <pablo.baeyens@datadoghq.com>
