### PR TITLE
fixes for mem_solaris.go

### DIFF
--- a/v3/mem/mem_solaris.go
+++ b/v3/mem/mem_solaris.go
@@ -1,4 +1,3 @@
-//go:build solaris
 // +build solaris
 
 package mem


### PR DESCRIPTION
This PR includes two fixes for `v3/mem/mem_solaris.go`:

* fix: mem/mem_solaris.go:146:59: undefined: swapCommand typo `swapsCommand`
* fix: mem/mem_solaris.go:148:42: cannot use swapsCommandPath (type string) as type context.Context in argument to invoke.CommandWithContext - add `ctx` to call
