### PR TITLE
change minimum version to 1.16 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ see http://godoc.org/github.com/shirou/gopsutil
 
 ## Requirements
 
-- go1.11 or above is required.
+- go1.16 or above is required.
 
 ## More Info
 


### PR DESCRIPTION
Change minimum version to 1.16. Since the test is already change to running on 1.16 and 1.17, this PR includes only README change.

(Then, I will merge #1105)