### PR TITLE
[disk] Modify stat free, from bavail to bfree

### DIFF
--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -132,7 +132,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 		Path:        path,
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.F_blocks) * uint64(bsize)),
-		Free:        (uint64(stat.F_bavail) * uint64(bsize)),
+		Free:        (uint64(stat.F_bfree) * uint64(bsize)),
 		InodesTotal: (uint64(stat.F_files)),
 		InodesFree:  (uint64(stat.F_ffree)),
 	}

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -21,7 +21,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 		Path:        unescapeFstab(path),
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.Blocks) * uint64(bsize)),
-		Free:        (uint64(stat.Bavail) * uint64(bsize)),
+		Free:        (uint64(stat.Bfree) * uint64(bsize)),
 		InodesTotal: (uint64(stat.Files)),
 		InodesFree:  (uint64(stat.Ffree)),
 	}


### PR DESCRIPTION
```
From:
Free:        (uint64(stat.Bavail) * uint64(bsize)), 
To:
Free:        (uint64(stat.Bfree) * uint64(bsize)),
```

https://pkg.go.dev/golang.org/x/sys/unix#Statfs_t
```
type Statfs_t
type Statfs_t struct {
	Type    int64
	Bsize   int64
	Blocks  uint64
	Bfree   uint64   /* free blocks in fs */
	Bavail  uint64   /* free blocks avail to non-superuser */
	Files   uint64
	Ffree   uint64
	Fsid    Fsid
	Namelen int64
	Frsize  int64
	Flags   int64
	Spare   [4]int64
}
```
In some cases, the old implementation may have Total-Free!=Used。
