### PR TITLE
Prefix C function by gopsutil_v3_

### DIFF
--- a/v3/disk/disk_darwin_cgo.go
+++ b/v3/disk/disk_darwin_cgo.go
@@ -19,7 +19,7 @@ import (
 
 func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOCountersStat, error) {
 	var buf [C.NDRIVE]C.DriveStats
-	n, err := C.v3readdrivestat(&buf[0], C.int(len(buf)))
+	n, err := C.gopsutil_v3_readdrivestat(&buf[0], C.int(len(buf)))
 	if err != nil {
 		return nil, err
 	}

--- a/v3/disk/iostat_darwin.c
+++ b/v3/disk/iostat_darwin.c
@@ -16,7 +16,7 @@ static int getdrivestat(io_registry_entry_t d, DriveStats *stat);
 static int fillstat(io_registry_entry_t d, DriveStats *stat);
 
 int
-v3readdrivestat(DriveStats a[], int n)
+gopsutil_v3_readdrivestat(DriveStats a[], int n)
 {
 	mach_port_t port;
 	CFMutableDictionaryRef match;

--- a/v3/disk/iostat_darwin.h
+++ b/v3/disk/iostat_darwin.h
@@ -29,4 +29,4 @@ struct CPUStats {
 	natural_t idle;
 };
 
-extern int v3readdrivestat(DriveStats a[], int n);
+extern int gopsutil_v3_readdrivestat(DriveStats a[], int n);

--- a/v3/host/host_darwin_cgo.go
+++ b/v3/host/host_darwin_cgo.go
@@ -34,13 +34,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 	}
 	var temperatures []TemperatureStat
 
-	C.open_smc()
-	defer C.close_smc()
+	C.gopsutil_v3_open_smc()
+	defer C.gopsutil_v3_close_smc()
 
 	for _, key := range temperatureKeys {
 		temperatures = append(temperatures, TemperatureStat{
 			SensorKey:   key,
-			Temperature: float64(C.get_temperature(C.CString(key))),
+			Temperature: float64(C.gopsutil_v3_get_temperature(C.CString(key))),
 		})
 	}
 	return temperatures, nil

--- a/v3/host/smc_darwin.c
+++ b/v3/host/smc_darwin.c
@@ -68,7 +68,7 @@ typedef struct {
 static const int SMC_KEY_SIZE = 4; // number of characters in an SMC key.
 static io_connect_t conn;          // our connection to the SMC.
 
-kern_return_t open_smc(void) {
+kern_return_t gopsutil_v3_open_smc(void) {
   kern_return_t result;
   io_service_t service;
 
@@ -86,7 +86,7 @@ kern_return_t open_smc(void) {
   return result;
 }
 
-kern_return_t close_smc(void) { return IOServiceClose(conn); }
+kern_return_t gopsutil_v3_close_smc(void) { return IOServiceClose(conn); }
 
 static uint32_t to_uint32(char *key) {
   uint32_t ans = 0;
@@ -155,7 +155,7 @@ static kern_return_t read_smc(char *key, smc_return_t *result_smc) {
   return result;
 }
 
-double get_temperature(char *key) {
+double gopsutil_v3_get_temperature(char *key) {
   kern_return_t result;
   smc_return_t result_smc;
 

--- a/v3/host/smc_darwin.h
+++ b/v3/host/smc_darwin.h
@@ -25,8 +25,8 @@
 #define THUNDERBOLT_1          "TI1P"
 #define WIRELESS_MODULE        "TW0P"
 
-kern_return_t open_smc(void);
-kern_return_t close_smc(void);
-double get_temperature(char *);
+kern_return_t gopsutil_v3_open_smc(void);
+kern_return_t gopsutil_v3_close_smc(void);
+double gopsutil_v3_get_temperature(char *);
 
 #endif // __SMC_H__


### PR DESCRIPTION
Fix #1175

With this hopefully unique enough prefix, the C functions defined by gopsutil should not longer conflict with either version 2 of gopsutil or another CGO library

With this change, the following program works:
```
package main

import (
	"fmt"
	v2disk "github.com/shirou/gopsutil/disk"
	v2host "github.com/shirou/gopsutil/host"
	v3disk "github.com/shirou/gopsutil/v3/disk"
	v3host "github.com/shirou/gopsutil/v3/host"
)

func main() {
	fmt.Println(v3host.SensorsTemperatures())
	fmt.Println(v3disk.IOCounters())
	fmt.Println(v2host.SensorsTemperatures())
	fmt.Println(v2disk.IOCounters())
}
```