### PR TITLE
mem: use unix.SysctlUint64 for hw.memsize on darwin

### DIFF
--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -4,7 +4,6 @@ package mem
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"unsafe"
 
@@ -13,17 +12,10 @@ import (
 )
 
 func getHwMemsize() (uint64, error) {
-	totalString, err := unix.Sysctl("hw.memsize")
+	total, err := unix.SysctlUint64("hw.memsize")
 	if err != nil {
 		return 0, err
 	}
-
-	// unix.sysctl() helpfully assumes the result is a null-terminated string and
-	// removes the last byte of the result if it's 0 :/
-	totalString += "\x00"
-
-	total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
-
 	return total, nil
 }
 

--- a/v3/mem/mem_darwin.go
+++ b/v3/mem/mem_darwin.go
@@ -4,7 +4,6 @@ package mem
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"unsafe"
 
@@ -13,17 +12,10 @@ import (
 )
 
 func getHwMemsize() (uint64, error) {
-	totalString, err := unix.Sysctl("hw.memsize")
+	total, err := unix.SysctlUint64("hw.memsize")
 	if err != nil {
 		return 0, err
 	}
-
-	// unix.sysctl() helpfully assumes the result is a null-terminated string and
-	// removes the last byte of the result if it's 0 :/
-	totalString += "\x00"
-
-	total := uint64(binary.LittleEndian.Uint64([]byte(totalString)))
-
 	return total, nil
 }
 


### PR DESCRIPTION
Use unix.SysctlUint64 which directly returns an uint64 rather than
converting it from a string.