### PR TITLE
deps: switch to recommended fork of StackExchange/wmi

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:3a991e1f8ab48d1445b5106b628609285cecb1bfe5abdd078b4320d32ec0f3ee"
-  name = "github.com/StackExchange/wmi"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "441642c1665945335b93778e496324884ce569e7"
-  version = "v1.2.1"
-
-[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -29,12 +21,43 @@
   version = "v1.2.6"
 
 [[projects]]
+  digest = "1:465db2de82a3f7483baead1dc4eddd2510d6340729bbcc988e238e8cf3d0d18b"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/cmpopts",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "d103655696d8ae43c4125ee61454dbf03d8e8324"
+  version = "v0.5.6"
+
+[[projects]]
+  branch = "main"
+  digest = "1:dc1c9a9e26fc2b80713a51c26f8443314eed7d33e2e12df259d7f722df7fd355"
+  name = "github.com/lufia/plan9stats"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "39d0f177ccd07bdf5eb6f051ab9b09651f05d6f2"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "main"
+  digest = "1:9ad2b62016ecf07e6c97a45a1bd6b66467a77be6ed88b618fb908f5cf312a304"
+  name = "github.com/power-devops/perfstat"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5aafc221ea8c1ff54b0835cbd5f2386a8410be11"
 
 [[projects]]
   digest = "1:5c7b4a9fefe5b7b160d2cf0ec8457de81db92038c45c88d7d59493568308cc5d"
@@ -64,8 +87,16 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:50a80d9d302a50c9f5ae5fb4e44c82cf40f0fa184ac847bec897438f28da21ee"
+  name = "github.com/yusufpapurcu/wmi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "253c5f0cb35e666c4c0fc42083824e7c89f0cc8d"
+  version = "v1.2.2"
+
+[[projects]]
   branch = "master"
-  digest = "1:cded1795a2d143aa9940244639afeaeecc5cfb9bb2a01bdcaa4087e9beb989c0"
+  digest = "1:6eed2fd291874d17d37ecb2bda20d141a475992f3deb80989657325620e01962"
   name = "golang.org/x/sys"
   packages = [
     "internal/unsafeheader",
@@ -75,7 +106,18 @@
     "windows/svc/mgr",
   ]
   pruneopts = "UT"
-  revision = "69063c4bb744bc56492b1a0533d73a23406b0bc2"
+  revision = "dee7805ff2e13b1c4206de89b1c06e95ab66ae0d"
+
+[[projects]]
+  branch = "master"
+  digest = "1:918a46e4a2fb83df33f668f5a6bd51b2996775d073fce1800d3ec01b0a5ddd2b"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "5ec99f83aff198f5fbd629d6c8d8eb38a04218ca"
 
 [[projects]]
   branch = "v3"
@@ -89,10 +131,14 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/StackExchange/wmi",
+    "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
+    "github.com/lufia/plan9stats",
+    "github.com/power-devops/perfstat",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/tklauser/go-sysconf",
+    "github.com/yusufpapurcu/wmi",
     "golang.org/x/sys/unix",
     "golang.org/x/sys/windows",
     "golang.org/x/sys/windows/svc",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
 
 
 [[constraint]]
-  name = "github.com/StackExchange/wmi"
-  version = "1.0.0"
+  name = "github.com/yusufpapurcu/wmi"
+  version = "1.2.2"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
+	"github.com/yusufpapurcu/wmi"
 	"github.com/shirou/gopsutil/internal/common"
 	"golang.org/x/sys/windows"
 )

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -13,9 +13,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
 	"github.com/shirou/gopsutil/internal/common"
 	"github.com/shirou/gopsutil/process"
+	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows"
 )
 

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
+	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows"
 )
 

--- a/v3/cpu/cpu_windows.go
+++ b/v3/cpu/cpu_windows.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
+	"github.com/yusufpapurcu/wmi"
 	"github.com/shirou/gopsutil/v3/internal/common"
 	"golang.org/x/sys/windows"
 )

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,11 +3,11 @@ module github.com/shirou/gopsutil/v3
 go 1.15
 
 require (
-	github.com/StackExchange/wmi v1.2.1
 	github.com/google/go-cmp v0.5.6
-	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.3.9
+	github.com/yusufpapurcu/wmi v1.2.2
 	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c
 )

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,8 +1,5 @@
-github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
-github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
@@ -15,6 +12,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -22,10 +21,14 @@ github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2biQ=
 github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
+github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
+github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c h1:taxlMj0D/1sOAuv/CbSD+MMDof2vbyPTqz5FNYKpXt8=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/v3/host/host_windows.go
+++ b/v3/host/host_windows.go
@@ -13,7 +13,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
+	"github.com/yusufpapurcu/wmi"
 	"github.com/shirou/gopsutil/v3/internal/common"
 	"github.com/shirou/gopsutil/v3/process"
 	"golang.org/x/sys/windows"

--- a/v3/internal/common/common_windows.go
+++ b/v3/internal/common/common_windows.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/StackExchange/wmi"
+	"github.com/yusufpapurcu/wmi"
 	"golang.org/x/sys/windows"
 )
 


### PR DESCRIPTION
The README at https://github.com/StackExchange/wmi notes that this library is no longer actively maintained, and recommends switching to the fork at https://github.com/yusufpapurcu/wmi.

The primary change so far in the fork has been bumping https://github.com/go-ole/go-ole to v1.2.6 to fix Windows ARM and ARM64 compatibility, so this may not strictly be necessary since https://github.com/shirou/gopsutil/pull/1145 did bump that transitive dependency (and updating to a version of gopsutil with that PR included did resolve the build errors I was seeing in my project).

I wasn't able to update `Gopkg.lock` as I'm having some issues getting the `dep` build system installed with Go 1.17, would appreciate a maintainer adding a commit to fixup the lockfile.