### PR TITLE
fix(process): fix the bug that the program is hung when getting the f…

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -751,6 +751,8 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 				})
 				fileExists[fileName] = true
 			}
+		case <-ctx.Done():
+			return files, nil
 		}
 	}
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -752,7 +752,7 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 				fileExists[fileName] = true
 			}
 		case <-ctx.Done():
-			return files, nil
+			return files, ctx.Err()
 		}
 	}
 

--- a/v3/process/process_windows.go
+++ b/v3/process/process_windows.go
@@ -738,6 +738,8 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 				})
 				fileExists[fileName] = true
 			}
+		case <-ctx.Done():
+			return files, nil
 		}
 	}
 

--- a/v3/process/process_windows.go
+++ b/v3/process/process_windows.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
+	"time"
 	"unicode/utf16"
 	"unsafe"
 
@@ -707,24 +708,36 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 			continue
 		}
 
-		var buf [syscall.MAX_LONG_PATH]uint16
-		n, err := windows.GetFinalPathNameByHandle(windows.Handle(file), &buf[0], syscall.MAX_LONG_PATH, 0)
-		if err != nil {
-			continue
-		}
+		var fileName string
+		ch := make(chan struct{})
 
-		fileName := string(utf16.Decode(buf[:n]))
-		fileInfo, _ := os.Stat(fileName)
-		if fileInfo.IsDir() {
-			continue
-		}
+		go func() {
+			var buf [syscall.MAX_LONG_PATH]uint16
+			n, err := windows.GetFinalPathNameByHandle(windows.Handle(file), &buf[0], syscall.MAX_LONG_PATH, 0)
+			if err != nil {
+				return
+			}
 
-		if _, exists := fileExists[fileName]; !exists {
-			files = append(files, OpenFilesStat{
-				Path: fileName,
-				Fd:   uint64(file),
-			})
-			fileExists[fileName] = true
+			fileName = string(utf16.Decode(buf[:n]))
+			ch <- struct{}{}
+		}()
+
+		select {
+		case <-time.NewTimer(100 * time.Millisecond).C:
+			continue
+		case <-ch:
+			fileInfo, _ := os.Stat(fileName)
+			if fileInfo.IsDir() {
+				continue
+			}
+
+			if _, exists := fileExists[fileName]; !exists {
+				files = append(files, OpenFilesStat{
+					Path: fileName,
+					Fd:   uint64(file),
+				})
+				fileExists[fileName] = true
+			}
 		}
 	}
 

--- a/v3/process/process_windows.go
+++ b/v3/process/process_windows.go
@@ -739,7 +739,7 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 				fileExists[fileName] = true
 			}
 		case <-ctx.Done():
-			return files, nil
+			return files, ctx.Err()
 		}
 	}
 


### PR DESCRIPTION
psutil(https://psutil.readthedocs.io/en/latest/index.html?highlight=oepn_files#psutil.Process.open_files): Warning on Windows this method is not reliable due to some limitations of the underlying Windows API which may hang when retrieving certain file handles. In order to work around that psutil spawns a thread to determine the file handle name and kills it if it’s not responding after 100ms. That implies that this method on Windows is not guaranteed to enumerate all regular file handles (see issue 597). Tools like ProcessHacker has the same limitation.

I tried it, and when I called the OpenFile method to the graphics driver, the program was suspended. So, I use the same method as psutil to deal with it.