### PR TITLE
Add additional process states

### DIFF
--- a/v3/process/process_test.go
+++ b/v3/process/process_test.go
@@ -660,7 +660,11 @@ func Test_CPUTimes(t *testing.T) {
 
 func Test_OpenFiles(t *testing.T) {
 	fp, err := os.Open("process_test.go")
-	defer fp.Close()
+	assert.Nil(t, err)
+	defer func() {
+		err := fp.Close()
+		assert.Nil(t, err)
+	}()
 
 	pid := os.Getpid()
 	p, err := NewProcess(int32(pid))


### PR DESCRIPTION
In the move from v1 to v3, process states has changed from returning a single character for status to an enum. https://github.com/open-telemetry/opentelemetry-collector was depending on some of these states.

I've looked through the documentation for most platforms and ensured that we are capturing all the cases (FreeBSD, OpenBSD, Linux, Solaris, Darwin).

See tracking issue: #1171 

