### PR TITLE
[disk][host][mac] fix deprecated code in macOS Monterey

### DIFF
--- a/disk/iostat_darwin.c
+++ b/disk/iostat_darwin.c
@@ -25,7 +25,7 @@ gopsutil_v3_readdrivestat(DriveStats a[], int n)
 	kern_return_t status;
 	int na, rv;
 
-	IOMasterPort(bootstrap_port, &port);
+	IOMainPort(bootstrap_port, &port);
 	match = IOServiceMatching("IOMedia");
 	CFDictionaryAddValue(match, CFSTR(kIOMediaWholeKey), kCFBooleanTrue);
 	status = IOServiceGetMatchingServices(port, match, &drives);

--- a/disk/iostat_darwin.h
+++ b/disk/iostat_darwin.h
@@ -30,3 +30,7 @@ struct CPUStats {
 };
 
 extern int gopsutil_v3_readdrivestat(DriveStats a[], int n);
+
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
+       #define IOMainPort IOMasterPort
+#endif

--- a/host/smc_darwin.c
+++ b/host/smc_darwin.c
@@ -72,7 +72,7 @@ kern_return_t gopsutil_v3_open_smc(void) {
   kern_return_t result;
   io_service_t service;
 
-  service = IOServiceGetMatchingService(kIOMasterPortDefault,
+  service = IOServiceGetMatchingService(kIOMainPortDefault,
                                         IOServiceMatching(IOSERVICE_SMC));
   if (service == 0) {
     // Note: IOServiceMatching documents 0 on failure

--- a/host/smc_darwin.h
+++ b/host/smc_darwin.h
@@ -29,4 +29,9 @@ kern_return_t gopsutil_v3_open_smc(void);
 kern_return_t gopsutil_v3_close_smc(void);
 double gopsutil_v3_get_temperature(char *);
 
+#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
+	#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
+
 #endif // __SMC_H__


### PR DESCRIPTION
This PR fixes  #1164

Thank you for the sponsors (@erwanor and @fwessels !), now I can use m1 mac on VPS for 24hours. And thank you @Lomanic for [initial patch](https://github.com/shirou/gopsutil/issues/1164#issuecomment-980653282) on #1164 and @dt for the comment. This PR can fix the deprecated warning on at least the mac environment.

```
ProductName:    macOS
ProductVersion: 12.0.1
BuildVersion:   21A559
```