### PR TITLE
[cpu][mac] change not return error even if cpu.frequency errors

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -87,10 +87,9 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
 	cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency")
-	if err != nil {
-		return ret, err
+	if err == nil {
+		c.Mhz = float64(cpuFrequency) / 1000000.0
 	}
-	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
 }


### PR DESCRIPTION
This PR partially fixes #1000

Still we can not get concrete cpu frequency on m1 mac. This PR changes does not return error even we can not get a value from `hw.cpufrequency`.