### PR TITLE
add ConnectionsOptions api for walker callback instead of large slice return (only support in linux)

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -42,6 +42,59 @@ type ConnectionStat struct {
 	Pid    int32   `json:"pid"`
 }
 
+type ConnectionStatOptions struct {
+	Context  context.Context
+	Kind     string
+	Pid      int32
+	Max      int
+	SkipUids bool
+	Walker   func(ConnectionStat) error
+}
+
+type ConnectionStatOptionsFn func(*ConnectionStatOptions)
+
+func WithSkipUids(skipUids bool) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.SkipUids = skipUids
+	}
+}
+
+func WithMax(max int) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.Max = max
+	}
+}
+
+func WithKind(kind string) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.Kind = kind
+	}
+}
+
+func WithPid(pid int32) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.Pid = pid
+	}
+}
+func WithContext(ctx context.Context) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.Context = ctx
+	}
+}
+func WithWalker(walker func(ConnectionStat) error) ConnectionStatOptionsFn {
+	return func(options *ConnectionStatOptions) {
+		options.Walker = walker
+	}
+}
+
+func createOptions(fns ...ConnectionStatOptionsFn) *ConnectionStatOptions {
+	options := &ConnectionStatOptions{Context: context.Background(), Kind: "all"}
+	for _, fn := range fns {
+		fn(options)
+	}
+	return options
+}
+
 // System wide stats about different network protocols
 type ProtoCountersStat struct {
 	Protocol string           `json:"protocol"`

--- a/net/net_aix.go
+++ b/net/net_aix.go
@@ -1,3 +1,4 @@
+//go:build aix
 // +build aix
 
 package net
@@ -336,6 +337,12 @@ func parseNetstatA(output string, kind string) ([]ConnectionStat, error) {
 
 	return ret, nil
 
+}
+
+// Return a list of network connections opened.
+func ConnectionsOptions(fns ...ConnectionStatOptionsFn) ([]ConnectionStat, error) {
+	options := createOptions(fns...)
+	return ConnectionsWithContext(options.Context, options.Kind)
 }
 
 func Connections(kind string) ([]ConnectionStat, error) {

--- a/net/net_fallback.go
+++ b/net/net_fallback.go
@@ -1,3 +1,4 @@
+//go:build !aix && !darwin && !linux && !freebsd && !openbsd && !windows
 // +build !aix,!darwin,!linux,!freebsd,!openbsd,!windows
 
 package net
@@ -38,6 +39,12 @@ func ProtoCounters(protocols []string) ([]ProtoCountersStat, error) {
 
 func ProtoCountersWithContext(ctx context.Context, protocols []string) ([]ProtoCountersStat, error) {
 	return []ProtoCountersStat{}, common.ErrNotImplementedError
+}
+
+// Return a list of network connections opened.
+func ConnectionsOptions(fns ...ConnectionStatOptionsFn) ([]ConnectionStat, error) {
+	options := createOptions(fns...)
+	return ConnectionsWithContext(options.Context, options.Kind)
 }
 
 func Connections(kind string) ([]ConnectionStat, error) {

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -1,3 +1,4 @@
+//go:build openbsd
 // +build openbsd
 
 package net
@@ -253,6 +254,12 @@ func parseNetstatAddr(local string, remote string, family uint32) (laddr Addr, r
 	}
 
 	return laddr, raddr, err
+}
+
+// Return a list of network connections opened.
+func ConnectionsOptions(fns ...ConnectionStatOptionsFn) ([]ConnectionStat, error) {
+	options := createOptions(fns...)
+	return ConnectionsWithContext(options.Context, options.Kind)
 }
 
 // Return a list of network connections opened.

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -1,3 +1,4 @@
+//go:build freebsd || darwin
 // +build freebsd darwin
 
 package net
@@ -12,6 +13,12 @@ import (
 
 	"github.com/shirou/gopsutil/v3/internal/common"
 )
+
+// Return a list of network connections opened.
+func ConnectionsOptions(fns ...ConnectionStatOptionsFn) ([]ConnectionStat, error) {
+	options := createOptions(fns...)
+	return ConnectionsPidWithContext(options.Context, options.Kind, options.Pid)
+}
 
 // Return a list of network connections opened.
 func Connections(kind string) ([]ConnectionStat, error) {

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package net
@@ -205,6 +206,12 @@ func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename stri
 	return IOCounters(pernic)
 }
 
+// Return a list of network connections opened.
+func ConnectionsOptions(fns ...ConnectionStatOptionsFn) ([]ConnectionStat, error) {
+	options := createOptions(fns...)
+	return ConnectionsPidWithContext(options.Context, options.Kind, options.Pid)
+}
+
 // Return a list of network connections
 // Available kind:
 //   reference to netConnectionKindMap
@@ -332,7 +339,6 @@ func ConntrackStats(percpu bool) ([]ConntrackStat, error) {
 func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
 	return nil, common.ErrNotImplementedError
 }
-
 
 // NetProtoCounters returns network statistics for the entire system
 // If protocols is empty then all protocols are returned, otherwise


### PR DESCRIPTION
When there's amount of TIME_WAIT in the system ( when keep-alive does not work), for example, more than 10K, the memory used for the existing `Connections` will return a slice which has more than 10K elements and then use and free it.
A new ConnectionsOptions api which can support a walker callback func as an option to avoid the large slice return.

a memory usage difference can be checked in the following charts:

![image](https://user-images.githubusercontent.com/1940588/145670818-fdb96bc7-0c07-480b-a550-73188becad7b.png)
