### PR TITLE
fix unstable boot time because of float conversion

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package common
@@ -100,8 +101,9 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		t := uint64(time.Now().Unix()) - uint64(b)
-		return t, nil
+		currentTime := float64(time.Now().UnixNano()) / float64(time.Second)
+		t := currentTime - b
+		return uint64(t), nil
 	}
 
 	return 0, fmt.Errorf("could not find btime")


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

The original calculation of create time inside a container may cause unstable result:

```go
b, err := strconv.ParseFloat(f[0], 64)
if err != nil {
    return 0, err
}
t := uint64(time.Now().Unix()) - uint64(b)
```

The `b` is a float number, converting it to a integer will discard the fraction part. Considering following situation:

```
uptime: 5.5
now: 6.9
```

Then, the boot time is `1`. After 0.1 seconds, the uptime will be `5.6` and the `now` is `7.0`, which will give us `2` as the boot time. Converting after subtraction will solve this problem.

This issue will also affect the `createTime` of a process.