### PR TITLE
[net][linux] Fix #1198 "f.ReadDir undefined" on Go 1.15 by redefining a custom readDir according to go version

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -549,7 +549,7 @@ func getProcInodes(root string, pid int32, max int) (map[string][]inodeMap, erro
 		return ret, err
 	}
 	defer f.Close()
-	dirEntries, err := f.ReadDir(max)
+	dirEntries, err := readDir(f, max)
 	if err != nil {
 		return ret, err
 	}

--- a/net/net_linux_111.go
+++ b/net/net_linux_111.go
@@ -1,0 +1,12 @@
+//go:build !go1.16
+// +build !go1.16
+
+package net
+
+import (
+	"os"
+)
+
+func readDir(f *os.File, max int) ([]os.FileInfo, error) {
+	return f.Readdir(max)
+}

--- a/net/net_linux_116.go
+++ b/net/net_linux_116.go
@@ -1,0 +1,12 @@
+//go:build go1.16
+// +build go1.16
+
+package net
+
+import (
+	"os"
+)
+
+func readDir(f *os.File, max int) ([]os.DirEntry, error) {
+	return f.ReadDir(max)
+}


### PR DESCRIPTION
Using os.File.Readdir pre Go 1.16 and os.File.ReadDir post Go 1.16

If you don't want to support older Go versions (as a best effort basis), feel free to reject this PR @shirou.