### PR TITLE
[process][linux] Fix error handling on Children.

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -351,10 +351,10 @@ func (p *Process) PageFaultsWithContext(ctx context.Context) (*PageFaultsStat, e
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
 	if err != nil {
-		if len(pids) == 0 {
-			return nil, ErrorNoChildren
-		}
 		return nil, err
+	}
+	if len(pids) == 0 {
+		return nil, ErrorNoChildren
 	}
 	ret := make([]*Process, 0, len(pids))
 	for _, pid := range pids {


### PR DESCRIPTION
reported in #1211

If `pgrep` returns error, `CallPgrepWithContext` always returns empty pids with that error. So this `Children()` always returns `ErrorNoChildren`. This PR fixes to return original error.

Before
```
--- FAIL: Test_Children (0.10s)
    process_test.go:604: error process does not have children
```

After
```
--- FAIL: Test_Children (0.10s)
    process_test.go:604: error exec: "pgrep": executable file not found in $PATH
```