### PR TITLE
Let almalinux be part of the rhel family

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -283,7 +283,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "debian"
 	case "fedora":
 		family = "fedora"
-	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky":
+	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky", "almalinux":
 		family = "rhel"
 	case "suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sles", "sled", "caasp":
 		family = "suse"


### PR DESCRIPTION
As almalinux is also one of the redhat based OS'es, let it also be part of the rhel family.