### PR TITLE
fix cpu_openbsd.go once and for all

### DIFF
--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -9,8 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"runtime"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/shirou/gopsutil/v3/internal/common"
@@ -18,18 +16,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// sys/sched.h
-var (
+const (
+	// sys/sched.h
 	CPUser    = 0
 	cpNice    = 1
 	cpSys     = 2
-	cpIntr    = 3
-	cpIdle    = 4
-	cpUStates = 5
-)
+	cpSpin    = 3
+	cpIntr    = 4
+	cpIdle    = 5
+	cpUStates = 6
 
-// sys/sysctl.h
-const (
+	// sys/sysctl.h
 	ctlKern     = 1  // "high kernel": proc, limits
 	ctlHw       = 6  // CTL_HW
 	sMT         = 24 // HW_sMT
@@ -45,23 +42,6 @@ func init() {
 	if err == nil {
 		ClocksPerSec = float64(clkTck)
 	}
-
-	func() {
-		v, err := unix.Sysctl("kern.osrelease") // can't reuse host.PlatformInformation because of circular import
-		if err != nil {
-			return
-		}
-		v = strings.ToLower(v)
-		version, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return
-		}
-		if version >= 6.4 {
-			cpIntr = 4
-			cpIdle = 5
-			cpUStates = 6
-		}
-	}()
 }
 
 func smt() (bool, error) {

--- a/cpu/cpu_openbsd_386.go
+++ b/cpu/cpu_openbsd_386.go
@@ -1,0 +1,10 @@
+package cpu
+
+type cpuTimes struct {
+	User uint32
+	Nice uint32
+	Sys  uint32
+	Spin uint32
+	Intr uint32
+	Idle uint32
+}

--- a/cpu/cpu_openbsd_amd64.go
+++ b/cpu/cpu_openbsd_amd64.go
@@ -1,0 +1,10 @@
+package cpu
+
+type cpuTimes struct {
+	User uint64
+	Nice uint64
+	Sys  uint64
+	Spin uint64
+	Intr uint64
+	Idle uint64
+}


### PR DESCRIPTION
Hello,

as reported in #1241 currently cpu_openbsd.go doesn't retrieve the correct values in all situations.  It's completely my fault for not implementing it correctly the first time, I was only thinking about amd64.

This is PR has a number of improvements, I suggest reading the diffs per-commit rather than a whole.

First of all, it drops support for OpenBSD <6.3, which was EOL'd more than three years ago!  This allows to semplify the code a bit and to "const-ify" some parameters.

The second commit is aestetic: it just fixes some typos.

The third commit changes the way we parse the data we get from `common.CallSyscall`.  Should make this library work on big endians.

The fourth commit is the real fix: it changes the way we obtain statistics from the CPU.  There were multiple things wrong there:

 - `KERN_CPTIME` returns an array of `long`s, while `KERN_CPTIME2` an array of uint64_t.  longs depends on the platform (on amd64 are 64bits, on i386 are 32bits).  
 - Also, instead of trying to guess which CPUs are online, use `KERN_CPUSTATS` that gives us the statistics and an handy flags field from which we can observe is the cpu is online or not.

I've tested this on amd64 (4 real cores, works correctly with both `hw.smt` enabled and not) and i386 (2 real cores, no smt), both running OpenBSD-CURRENT.