### PR TITLE
Fix typing issues in createTimeWithContext on Freebsd/i386

### DIFF
--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -115,7 +115,7 @@ func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return k.Start.Sec*1000 + k.Start.Usec/1000, nil
+	return int64(k.Start.Sec)*1000 + int64(k.Start.Usec)/1000, nil
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
Before change:
```
$ GOOS=freebsd GOARCH=386 go build ./process
process\process_freebsd.go:118:26: cannot use k.Start.Sec * 1000 + k.Start.Usec / 1000 (type int32) as type int64 in return argument
```