### PR TITLE
[disk][linux] serial number name prefix fixes

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -445,7 +445,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	var stat unix.Stat_t
-	err := unix.Stat(name, &stat)
+	err := unix.Stat(common.HostDev(strings.TrimPrefix(name, "/dev/")), &stat)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Make SerialNumberWithContext work with names that don't start with /dev,
map them to host /dev. In particular, this fixes the inclusion of
SerialNumber in IOCounters, as IOCountersWithContext calls us with the
device basename only.