### PR TITLE
refactor: remove unnecessary exec.LookPath calls

### DIFF
--- a/cpu/cpu_linux_test.go
+++ b/cpu/cpu_linux_test.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"strconv"
@@ -43,14 +44,13 @@ func TestCPUparseStatLine_424(t *testing.T) {
 }
 
 func TestCPUCountsAgainstLscpu(t *testing.T) {
-	lscpu, err := exec.LookPath("lscpu")
-	if err != nil {
-		t.Skip("no lscpu to compare with")
-	}
-	cmd := exec.Command(lscpu)
+	cmd := exec.Command("lscpu")
 	cmd.Env = []string{"LC_ALL=C"}
 	out, err := cmd.Output()
 	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			t.Skip("no lscpu to compare with")
+		}
 		t.Errorf("error executing lscpu: %v", err)
 	}
 	var threadsPerCore, coresPerSocket, sockets int

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -168,11 +167,7 @@ func getFsType(stat unix.Statfs_t) string {
 }
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
-	geom, err := exec.LookPath("geom")
-	if err != nil {
-		return "", fmt.Errorf("find geom: %w", err)
-	}
-	geomOut, err := invoke.CommandWithContext(ctx, geom, "disk", "list", name)
+	geomOut, err := invoke.CommandWithContext(ctx, "geom", "disk", "list", name)
 	if err != nil {
 		return "", fmt.Errorf("exec geom: %w", err)
 	}

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/shirou/gopsutil/v3/internal/common"
@@ -116,11 +115,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 }
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
-	cfgadm, err := exec.LookPath("cfgadm")
-	if err != nil {
-		return "", fmt.Errorf("find cfgadm: %w", err)
-	}
-	out, err := invoke.CommandWithContext(ctx, cfgadm, "-ls", "select=type(disk),cols=ap_id:info,cols2=,noheadings")
+	out, err := invoke.CommandWithContext(ctx, "cfgadm", "-ls", "select=type(disk),cols=ap_id:info,cols2=,noheadings")
 	if err != nil {
 		return "", fmt.Errorf("exec cfgadm: %w", err)
 	}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 	"unsafe"
 
@@ -23,12 +22,7 @@ import (
 const user_PROCESS = 7
 
 func HostIDWithContext(ctx context.Context) (string, error) {
-	ioreg, err := exec.LookPath("ioreg")
-	if err != nil {
-		return "", err
-	}
-
-	out, err := invoke.CommandWithContext(ctx, ioreg, "-rd1", "-c", "IOPlatformExpertDevice")
+	out, err := invoke.CommandWithContext(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
 	if err != nil {
 		return "", err
 	}
@@ -102,17 +96,12 @@ func PlatformInformationWithContext(ctx context.Context) (string, string, string
 	family := ""
 	pver := ""
 
-	sw_vers, err := exec.LookPath("sw_vers")
-	if err != nil {
-		return "", "", "", err
-	}
-
 	p, err := unix.Sysctl("kern.ostype")
 	if err == nil {
 		platform = strings.ToLower(p)
 	}
 
-	out, err := invoke.CommandWithContext(ctx, sw_vers, "-productVersion")
+	out, err := invoke.CommandWithContext(ctx, "sw_vers", "-productVersion")
 	if err == nil {
 		pver = strings.ToLower(strings.TrimSpace(string(out)))
 	}

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -148,11 +147,7 @@ func getlsbStruct() (*lsbStruct, error) {
 			}
 		}
 	} else if common.PathExists("/usr/bin/lsb_release") {
-		lsb_release, err := exec.LookPath("lsb_release")
-		if err != nil {
-			return ret, err
-		}
-		out, err := invoke.Command(lsb_release)
+		out, err := invoke.Command("/usr/bin/lsb_release")
 		if err != nil {
 			return ret, err
 		}

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -14,11 +14,7 @@ import (
 )
 
 func DoSysctrlWithContext(ctx context.Context, mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("sysctl")
-	if err != nil {
-		return []string{}, err
-	}
-	cmd := exec.CommandContext(ctx, sysctl, "-n", mib)
+	cmd := exec.CommandContext(ctx, "sysctl", "-n", mib)
 	cmd.Env = getSysctrlEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/common/common_freebsd.go
+++ b/internal/common/common_freebsd.go
@@ -29,11 +29,7 @@ func SysctlUint(mib string) (uint64, error) {
 }
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("sysctl")
-	if err != nil {
-		return []string{}, err
-	}
-	cmd := exec.Command(sysctl, "-n", mib)
+	cmd := exec.Command("sysctl", "-n", mib)
 	cmd.Env = getSysctrlEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -16,11 +16,7 @@ import (
 )
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("sysctl")
-	if err != nil {
-		return []string{}, err
-	}
-	cmd := exec.Command(sysctl, "-n", mib)
+	cmd := exec.Command("sysctl", "-n", mib)
 	cmd.Env = getSysctrlEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/common/common_openbsd.go
+++ b/internal/common/common_openbsd.go
@@ -13,11 +13,7 @@ import (
 )
 
 func DoSysctrl(mib string) ([]string, error) {
-	sysctl, err := exec.LookPath("sysctl")
-	if err != nil {
-		return []string{}, err
-	}
-	cmd := exec.Command(sysctl, "-n", mib)
+	cmd := exec.Command("sysctl", "-n", mib)
 	cmd.Env = getSysctrlEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -18,12 +19,11 @@ func CallLsofWithContext(ctx context.Context, invoke Invoker, pid int32, args ..
 		cmd = []string{"-a", "-n", "-P", "-p", strconv.Itoa(int(pid))}
 	}
 	cmd = append(cmd, args...)
-	lsof, err := exec.LookPath("lsof")
+	out, err := invoke.CommandWithContext(ctx, "lsof", cmd...)
 	if err != nil {
-		return []string{}, err
-	}
-	out, err := invoke.CommandWithContext(ctx, lsof, cmd...)
-	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return []string{}, err
+		}
 		// if no pid found, lsof returns code 1.
 		if err.Error() == "exit status 1" && len(out) == 0 {
 			return []string{}, nil
@@ -42,12 +42,7 @@ func CallLsofWithContext(ctx context.Context, invoke Invoker, pid int32, args ..
 }
 
 func CallPgrepWithContext(ctx context.Context, invoke Invoker, pid int32) ([]int32, error) {
-	cmd := []string{"-P", strconv.Itoa(int(pid))}
-	pgrep, err := exec.LookPath("pgrep")
-	if err != nil {
-		return []int32{}, err
-	}
-	out, err := invoke.CommandWithContext(ctx, pgrep, cmd...)
+	out, err := invoke.CommandWithContext(ctx, "pgrep", "-P", strconv.Itoa(int(pid)))
 	if err != nil {
 		return []int32{}, err
 	}

--- a/load/load_bsd.go
+++ b/load/load_bsd.go
@@ -5,7 +5,6 @@ package load
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"unsafe"
 
@@ -52,11 +51,7 @@ func Misc() (*MiscStat, error) {
 }
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
-	bin, err := exec.LookPath("ps")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
+	out, err := invoke.CommandWithContext(ctx, "ps", "axo", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/load/load_darwin.go
+++ b/load/load_darwin.go
@@ -5,7 +5,6 @@ package load
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 	"unsafe"
 
@@ -48,11 +47,7 @@ func Misc() (*MiscStat, error) {
 }
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
-	bin, err := exec.LookPath("ps")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, bin, "axo", "state")
+	out, err := invoke.CommandWithContext(ctx, "ps", "axo", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/load/load_solaris.go
+++ b/load/load_solaris.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -17,12 +16,7 @@ func Avg() (*AvgStat, error) {
 }
 
 func AvgWithContext(ctx context.Context) (*AvgStat, error) {
-	kstat, err := exec.LookPath("kstat")
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := invoke.CommandWithContext(ctx, kstat, "-p", "unix:0:system_misc:avenrun_*")
+	out, err := invoke.CommandWithContext(ctx, "kstat", "-p", "unix:0:system_misc:avenrun_*")
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +57,7 @@ func Misc() (*MiscStat, error) {
 }
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
-	bin, err := exec.LookPath("ps")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, bin, "-efo", "s")
+	out, err := invoke.CommandWithContext(ctx, "ps", "-efo", "s")
 	if err != nil {
 		return nil, err
 	}

--- a/mem/mem_bsd.go
+++ b/mem/mem_bsd.go
@@ -6,7 +6,6 @@ package mem
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -25,11 +24,7 @@ func SwapDevices() ([]*SwapDevice, error) {
 }
 
 func SwapDevicesWithContext(ctx context.Context) ([]*SwapDevice, error) {
-	swapCommandPath, err := exec.LookPath(swapCommand)
-	if err != nil {
-		return nil, fmt.Errorf("could not find command %q: %w", swapCommand, err)
-	}
-	output, err := invoke.CommandWithContext(ctx, swapCommandPath, "-lk")
+	output, err := invoke.CommandWithContext(ctx, swapCommand, "-lk")
 	if err != nil {
 		return nil, fmt.Errorf("could not execute %q: %w", swapCommand, err)
 	}

--- a/mem/mem_darwin_nocgo.go
+++ b/mem/mem_darwin_nocgo.go
@@ -5,7 +5,6 @@ package mem
 
 import (
 	"context"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -14,11 +13,7 @@ import (
 
 // Runs vm_stat and returns Free and inactive pages
 func getVMStat(vms *VirtualMemoryStat) error {
-	vm_stat, err := exec.LookPath("vm_stat")
-	if err != nil {
-		return err
-	}
-	out, err := invoke.Command(vm_stat)
+	out, err := invoke.Command("vm_stat")
 	if err != nil {
 		return err
 	}

--- a/mem/mem_openbsd.go
+++ b/mem/mem_openbsd.go
@@ -9,8 +9,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os/exec"
-
 	"github.com/shirou/gopsutil/v3/internal/common"
 	"golang.org/x/sys/unix"
 )
@@ -76,12 +74,7 @@ func SwapMemory() (*SwapMemoryStat, error) {
 }
 
 func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
-	swapctl, err := exec.LookPath("swapctl")
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := invoke.CommandWithContext(ctx, swapctl, "-sk")
+	out, err := invoke.CommandWithContext(ctx, "swapctl", "-sk")
 	if err != nil {
 		return &SwapMemoryStat{}, nil
 	}

--- a/mem/mem_solaris.go
+++ b/mem/mem_solaris.go
@@ -5,8 +5,8 @@ package mem
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -54,13 +54,8 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 }
 
 func zoneName() (string, error) {
-	zonename, err := exec.LookPath("zonename")
-	if err != nil {
-		return "", err
-	}
-
 	ctx := context.Background()
-	out, err := invoke.CommandWithContext(ctx, zonename)
+	out, err := invoke.CommandWithContext(ctx, "zonename")
 	if err != nil {
 		return "", err
 	}
@@ -71,20 +66,15 @@ func zoneName() (string, error) {
 var globalZoneMemoryCapacityMatch = regexp.MustCompile(`[Mm]emory size: (\d+) Megabytes`)
 
 func globalZoneMemoryCapacity() (uint64, error) {
-	prtconf, err := exec.LookPath("prtconf")
-	if err != nil {
-		return 0, err
-	}
-
 	ctx := context.Background()
-	out, err := invoke.CommandWithContext(ctx, prtconf)
+	out, err := invoke.CommandWithContext(ctx, "prtconf")
 	if err != nil {
 		return 0, err
 	}
 
 	match := globalZoneMemoryCapacityMatch.FindAllStringSubmatch(string(out), -1)
 	if len(match) != 1 {
-		return 0, fmt.Errorf("memory size not contained in output of %q", prtconf)
+		return 0, errors.New("memory size not contained in output of prtconf")
 	}
 
 	totalMB, err := strconv.ParseUint(match[0][1], 10, 64)
@@ -98,13 +88,8 @@ func globalZoneMemoryCapacity() (uint64, error) {
 var kstatMatch = regexp.MustCompile(`(\S+)\s+(\S*)`)
 
 func nonGlobalZoneMemoryCapacity() (uint64, error) {
-	kstat, err := exec.LookPath("kstat")
-	if err != nil {
-		return 0, err
-	}
-
 	ctx := context.Background()
-	out, err := invoke.CommandWithContext(ctx, kstat, "-p", "-c", "zone_memory_cap", "memory_cap:*:*:physcap")
+	out, err := invoke.CommandWithContext(ctx, "kstat", "-p", "-c", "zone_memory_cap", "memory_cap:*:*:physcap")
 	if err != nil {
 		return 0, err
 	}
@@ -141,11 +126,7 @@ func SwapDevices() ([]*SwapDevice, error) {
 }
 
 func SwapDevicesWithContext(ctx context.Context) ([]*SwapDevice, error) {
-	swapCommandPath, err := exec.LookPath(swapCommand)
-	if err != nil {
-		return nil, fmt.Errorf("could not find command %q: %w", swapCommand, err)
-	}
-	output, err := invoke.CommandWithContext(ctx, swapCommandPath, "-l")
+	output, err := invoke.CommandWithContext(ctx, swapCommand, "-l")
 	if err != nil {
 		return nil, fmt.Errorf("could not execute %q: %w", swapCommand, err)
 	}

--- a/net/net_aix.go
+++ b/net/net_aix.go
@@ -6,7 +6,6 @@ package net
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -86,11 +85,7 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 }
 
 func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, error) {
-	netstat, err := exec.LookPath("netstat")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, netstat, "-idn")
+	out, err := invoke.CommandWithContext(ctx, "netstat", "-idn")
 	if err != nil {
 		return nil, err
 	}
@@ -360,11 +355,7 @@ func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat,
 		args = append(args, "-funix")
 	}
 
-	netstat, err := exec.LookPath("netstat")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, netstat, args...)
+	out, err := invoke.CommandWithContext(ctx, "netstat", args...)
 	if err != nil {
 		return nil, err
 	}

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -207,11 +207,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		}
 	} else {
 		// duplicated interface, list all interfaces
-		ifconfig, err := exec.LookPath("ifconfig")
-		if err != nil {
-			return nil, err
-		}
-		if out, err = invoke.CommandWithContext(ctx, ifconfig, "-l"); err != nil {
+		if out, err = invoke.CommandWithContext(ctx, "ifconfig", "-l"); err != nil {
 			return nil, err
 		}
 		interfaceNames := strings.Fields(strings.TrimRight(string(out), endOfLine))

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -5,7 +5,6 @@ package net
 
 import (
 	"context"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -17,11 +16,7 @@ func IOCounters(pernic bool) ([]IOCountersStat, error) {
 }
 
 func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, error) {
-	netstat, err := exec.LookPath("netstat")
-	if err != nil {
-		return nil, err
-	}
-	out, err := invoke.CommandWithContext(ctx, netstat, "-ibdnW")
+	out, err := invoke.CommandWithContext(ctx, "netstat", "-ibdnW")
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -6,7 +6,6 @@ package process
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -112,11 +111,7 @@ func (p *Process) StatusWithContext(ctx context.Context) ([]string, error) {
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
-	ps, err := exec.LookPath("ps")
-	if err != nil {
-		return false, err
-	}
-	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	out, err := invoke.CommandWithContext(ctx, "ps", "-o", "stat=", "-p", strconv.Itoa(int(pid)))
 	if err != nil {
 		return false, err
 	}
@@ -292,11 +287,6 @@ func (p *Process) getKProc() (*unix.KinfoProc, error) {
 // And splited by Space. Caller have responsibility to manage.
 // If passed arg pid is 0, get information from all process.
 func callPsWithContext(ctx context.Context, arg string, pid int32, threadOption bool, nameOption bool) ([][]string, error) {
-	bin, err := exec.LookPath("ps")
-	if err != nil {
-		return [][]string{}, err
-	}
-
 	var cmd []string
 	if pid == 0 { // will get from all processes.
 		cmd = []string{"-ax", "-o", arg}
@@ -308,7 +298,7 @@ func callPsWithContext(ctx context.Context, arg string, pid int32, threadOption 
 	if nameOption {
 		cmd = append(cmd, "-c")
 	}
-	out, err := invoke.CommandWithContext(ctx, bin, cmd...)
+	out, err := invoke.CommandWithContext(ctx, "ps", cmd...)
 	if err != nil {
 		return [][]string{}, err
 	}

--- a/process/process_darwin_nocgo.go
+++ b/process/process_darwin_nocgo.go
@@ -6,7 +6,6 @@ package process
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -19,11 +18,7 @@ func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
-	lsof_bin, err := exec.LookPath("lsof")
-	if err != nil {
-		return "", err
-	}
-	out, err := invoke.CommandWithContext(ctx, lsof_bin, "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
+	out, err := invoke.CommandWithContext(ctx, "lsof", "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
 	if err != nil {
 		return "", fmt.Errorf("bad call to lsof: %s", err)
 	}

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -6,7 +6,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -147,11 +146,7 @@ func (p *Process) StatusWithContext(ctx context.Context) ([]string, error) {
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
-	ps, err := exec.LookPath("ps")
-	if err != nil {
-		return false, err
-	}
-	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	out, err := invoke.CommandWithContext(ctx, "ps", "-o", "stat=", "-p", strconv.Itoa(int(pid)))
 	if err != nil {
 		return false, err
 	}

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -167,11 +166,7 @@ func (p *Process) StatusWithContext(ctx context.Context) ([]string, error) {
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
-	ps, err := exec.LookPath("ps")
-	if err != nil {
-		return false, err
-	}
-	out, err := invoke.CommandWithContext(ctx, ps, "-o", "stat=", "-p", strconv.Itoa(int(pid)))
+	out, err := invoke.CommandWithContext(ctx, "ps", "-o", "stat=", "-p", strconv.Itoa(int(pid)))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Executing the command does the lookup if needed and returns the same
error when not found, no need to do it separately.