### PR TITLE
[disk][linux] add HOST_PROC_MOUNTINFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ environment variable.
 You can set an alternative location to `/dev` by setting the `HOST_DEV`
 environment variable.
 
+You can set an alternative location to `/proc/N/mountinfo` by setting the
+`HOST_PROC_MOUNTINFO` environment variable.
+
 ## Documentation
 
 see http://godoc.org/github.com/shirou/gopsutil


### PR DESCRIPTION
The changes to gopsutil for reading /proc/1/mountinfo affected applications running under restricted environments that disallows access to /proc/1/mountinfo. #1159 was filed for android but other restricted environments are also affected (eg, snaps)). The fix for #1159 addressed the application behavior to work under confinement for non-android as well. However, depending on the system, the attempt to read /proc/1/mountinfo could cause a sandbox denial in the logs which can be quite noisy if using gopsutil as part of a monitoring solution that polls often.

This introduces HOST_PROC_MOUNTINFO to force reading from the parent dir of the specified path instead of first trying /proc/1. When unset, retain the current behavior with fallback. This allows people, for example, to set HOST_PROC_MOUNTINFO=/proc/self/mountinfo when gopsutil is running under these restricted environments.

This change updates the private readMountFile() to use a root path instead of a root subpath, and adjusts PartitionsWithContext() to set the root path to /proc/1 initially and falling back to /proc/self. When HOST_PROC_MOUNTINFO is not empty, set the root path to the parent directory of HOST_PROC_MOUNTINFO.

Tested on linux with `HOST_PROC_MOUNTINFO` unset, set to /proc/self/mountinfo as well as other values and it behaves as expected (eg, when unset, has the current behavior with fallback, else tries the specified path without fallback). Also `make build_test` passed all tests.

NOTE: originally this used `SELF_MOUNTINFO`. Thanks to @shirou and @Lomanic for the feedback.