### PR TITLE
Fix telegraf 1.22.0 build on OpenBSD/arm64

### DIFF
--- a/cpu/cpu_openbsd_arm64.go
+++ b/cpu/cpu_openbsd_arm64.go
@@ -1,0 +1,10 @@
+package cpu
+
+type cpuTimes struct {
+	User uint64
+	Nice uint64
+	Sys  uint64
+	Spin uint64
+	Intr uint64
+	Idle uint64
+}


### PR DESCRIPTION
In v1.21.4, telegraf gained support for OpenBSD/arm64.
With v1.22.0 and the switch to gopsutil/v3 we now see:

../../../go/pkg/mod/github.com/shirou/gopsutil/v3@v3.22.2/cpu/cpu_openbsd.go:63:14: undefined: cpuTimes

PR adds support for OpenBSD/arm64 in v3/cpu.