### PR TITLE
[disk][linux] fix readlink error which system boot by nfs mount

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -349,7 +349,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number
-			if d.Device == "/dev/root" {
+			if d.Device == "/dev/root" && d.Fstype != "nfs" {
 				devpath, err := os.Readlink(common.HostSys("/dev/block/" + blockDeviceID))
 				if err != nil {
 					return nil, err

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -349,12 +349,11 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 
 			// /dev/root is not the real device name
 			// so we get the real device name from its major/minor number
-			if d.Device == "/dev/root" && d.Fstype != "nfs" {
+			if d.Device == "/dev/root" {
 				devpath, err := os.Readlink(common.HostSys("/dev/block/" + blockDeviceID))
-				if err != nil {
-					return nil, err
+				if err == nil {
+					d.Device = strings.Replace(d.Device, "root", filepath.Base(devpath), 1)
 				}
-				d.Device = strings.Replace(d.Device, "root", filepath.Base(devpath), 1)
 			}
 		}
 		ret = append(ret, d)


### PR DESCRIPTION
Some host maybe boot the linux os with nfs mount, such as:
```
# cat /proc/self/mountinfo
14 1 0:14 / / rw,relatime - nfs /dev/root rw,vers=2,rsize=4096,wsize=4096,namlen=255,hard,nolock,proto=udp,port=65535,timeo=11,retrans=3,sec=sys,mountport=65535,addr=10.1.1.10
15 14 0:3 / /proc rw,relatime - proc /proc rw
16 15 0:13 / /proc/bus/usb rw,relatime - usbfs /proc/bus/usb rw
17 14 0:0 / /sys rw,relatime - sysfs /sys rw
18 14 0:15 / /dev rw,relatime - tmpfs none rw,mode=755
19 18 0:9 / /dev/pts rw,relatime - devpts devpts rw,gid=5,mode=620
20 14 8:0 / /export rw,relatime - xfs /dev/sda rw,noquota
21 15 0:16 / /proc/sys/fs/binfmt_misc rw,relatime - binfmt_misc none rw
```

and the device `0:14` can not found at this host:
```
# ls /sys/dev/block/ -hl
total 0
lrwxrwxrwx  1 root root 0 Apr 26 18:14 1:0 -> ../../block/ram0
lrwxrwxrwx  1 root root 0 Apr 26 18:14 1:1 -> ../../block/ram1
lrwxrwxrwx  1 root root 0 Apr 26 18:14 1:10 -> ../../block/ram10
......
lrwxrwxrwx  1 root root 0 Apr 26 18:14 7:7 -> ../../block/loop7
lrwxrwxrwx  1 root root 0 Apr 26 18:14 8:0 -> ../../block/sda
lrwxrwxrwx  1 root root 0 Apr 26 18:14 9:0 -> ../../block/md0
```

so we'll get the following error:
```
readlink /sys/dev/block/0:14: no such file or directory
``` 

this commit ignore the nfs type so that we can skip this error.