### PR TITLE
feat(actions): go-version will be latest two version automatically on CI

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,10 +4,21 @@ permissions:
   contents: read
 
 jobs:
+  go-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.value }}
+    steps:
+      - id: versions
+        run: |
+          versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
+          echo "::set-output name=value::${versions}"
   build_test_v3:
+    needs: go-versions
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
     runs-on: ubuntu-20.04
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,21 @@ permissions:
   contents: read
 
 jobs:
+  go-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.value }}
+    steps:
+      - id: versions
+        run: |
+          versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
+          echo "::set-output name=value::${versions}"
   test_v3_module:
+    needs: go-versions
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
         os: [ubuntu-20.04, ubuntu-18.04, windows-2019, macOS-10.15, macos-11]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
`https://go.dev/dl/?mode=json` returns latest two versions which means golang supported versions. This PR changes version in GitHub workflows to those two versions automatically.