### PR TITLE
Fix []int8 to []byte in disk/disk_openbsd.go due to x/sys/unix type change

### DIFF
--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -57,9 +57,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		}
 
 		d := PartitionStat{
-			Device:     common.IntToString(stat.F_mntfromname[:]),
-			Mountpoint: common.IntToString(stat.F_mntonname[:]),
-			Fstype:     common.IntToString(stat.F_fstypename[:]),
+			Device:     common.ByteToString(stat.F_mntfromname[:]),
+			Mountpoint: common.ByteToString(stat.F_mntonname[:]),
+			Fstype:     common.ByteToString(stat.F_fstypename[:]),
 			Opts:       opts,
 		}
 
@@ -147,7 +147,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 }
 
 func getFsType(stat unix.Statfs_t) string {
-	return common.IntToString(stat.F_fstypename[:])
+	return common.ByteToString(stat.F_fstypename[:])
 }
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/tklauser/go-sysconf v0.3.10
 	github.com/yusufpapurcu/wmi v1.2.2
-	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,9 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This was noticed in the Hashicorp Vault CI pipelines during cross-compilation to OpenBSD. 

See also: #1309 for context around this change in upstream `x/sys/unix`.

---

N.B.: I don't have access to a OpenBSD box to test this out natively. 