### PR TITLE
fix(actions): add write permission to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
 
 name: Release
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
Since release GitHub action [failed](https://github.com/shirou/gopsutil/runs/6681457141?check_suite_focus=true), this PR changes permission to `contents: write`.