### PR TITLE
fix(host,linux): when platform is detected to be 'amazon' cleanup os-release ID

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -274,6 +274,12 @@ func GetOSRelease() (platform string, version string, err error) {
 			version = trimQuotes(field[1])
 		}
 	}
+
+	// cleanup amazon ID
+	if platform == "amzn" {
+		platform = "amazon"
+	}
+
 	return platform, version, nil
 }
 


### PR DESCRIPTION
This PR created from https://github.com/DataDog/gopsutil/pull/42. Thank you so much!