### PR TITLE
Replace IOMainPort/IOMasterPort() and kIOMainPortDefault/kIOMasterPortDefault with NULL

### DIFF
--- a/disk/iostat_darwin.c
+++ b/disk/iostat_darwin.c
@@ -26,7 +26,7 @@ gopsutil_v3_readdrivestat(DriveStats a[], int n)
 
 	match = IOServiceMatching("IOMedia");
 	CFDictionaryAddValue(match, CFSTR(kIOMediaWholeKey), kCFBooleanTrue);
-	status = IOServiceGetMatchingServices((mach_port_t) NULL, match, &drives);
+	status = IOServiceGetMatchingServices(0, match, &drives);
 	if(status != KERN_SUCCESS)
 		return -1;
 

--- a/disk/iostat_darwin.c
+++ b/disk/iostat_darwin.c
@@ -18,17 +18,15 @@ static int fillstat(io_registry_entry_t d, DriveStats *stat);
 int
 gopsutil_v3_readdrivestat(DriveStats a[], int n)
 {
-	mach_port_t port;
 	CFMutableDictionaryRef match;
 	io_iterator_t drives;
 	io_registry_entry_t d;
 	kern_return_t status;
 	int na, rv;
 
-	IOMainPort(bootstrap_port, &port);
 	match = IOServiceMatching("IOMedia");
 	CFDictionaryAddValue(match, CFSTR(kIOMediaWholeKey), kCFBooleanTrue);
-	status = IOServiceGetMatchingServices(port, match, &drives);
+	status = IOServiceGetMatchingServices((mach_port_t) NULL, match, &drives);
 	if(status != KERN_SUCCESS)
 		return -1;
 

--- a/disk/iostat_darwin.h
+++ b/disk/iostat_darwin.h
@@ -30,7 +30,3 @@ struct CPUStats {
 };
 
 extern int gopsutil_v3_readdrivestat(DriveStats a[], int n);
-
-#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
-       #define IOMainPort IOMasterPort
-#endif

--- a/host/smc_darwin.c
+++ b/host/smc_darwin.c
@@ -72,7 +72,7 @@ kern_return_t gopsutil_v3_open_smc(void) {
   kern_return_t result;
   io_service_t service;
 
-  service = IOServiceGetMatchingService(kIOMainPortDefault,
+  service = IOServiceGetMatchingService((mach_port_t) NULL,
                                         IOServiceMatching(IOSERVICE_SMC));
   if (service == 0) {
     // Note: IOServiceMatching documents 0 on failure

--- a/host/smc_darwin.c
+++ b/host/smc_darwin.c
@@ -72,8 +72,7 @@ kern_return_t gopsutil_v3_open_smc(void) {
   kern_return_t result;
   io_service_t service;
 
-  service = IOServiceGetMatchingService((mach_port_t) NULL,
-                                        IOServiceMatching(IOSERVICE_SMC));
+  service = IOServiceGetMatchingService(0, IOServiceMatching(IOSERVICE_SMC));
   if (service == 0) {
     // Note: IOServiceMatching documents 0 on failure
     printf("ERROR: %s NOT FOUND\n", IOSERVICE_SMC);

--- a/host/smc_darwin.h
+++ b/host/smc_darwin.h
@@ -29,9 +29,4 @@ kern_return_t gopsutil_v3_open_smc(void);
 kern_return_t gopsutil_v3_close_smc(void);
 double gopsutil_v3_get_temperature(char *);
 
-#if (MAC_OS_X_VERSION_MIN_REQUIRED < 120000) // Before macOS 12 Monterey
-	#define kIOMainPortDefault kIOMasterPortDefault
-#endif
-
-
 #endif // __SMC_H__


### PR DESCRIPTION
The code introduced in https://github.com/shirou/gopsutil/pull/1191 needlessly breaks backwards compatibility with macOS 10.15 and macOS 11, when code is compiled on a macOS 12 host.

Code built on macOS 12 results in binaries that fail because there is no `_kIOMainPortDefault` symbol in macOS 10 or macOS 11.

It is more useful if the code is OS version invariant.

Let's look at the documentation of the function being called, [`IOServiceGetMatchingServices()`](https://developer.apple.com/documentation/iokit/1514494-ioservicegetmatchingservices):
> Declaration
>* **mainPort**: mach_port_t,
>
> Parameters
> * **masterPort**: The primary port obtained from IOMasterPort(_:_:). Pass kIOMasterPortDefault to look up the default primary port.

(Yes, Apple hastily and only partially renamed this parameter, but it's a key core value of Apple that they needlessly break backwards compatibility)

We do not need to call IOMasterPort() or IOMainPort(). We can supply kIOMasterPortDefault or kIOMainPortDefault and it will get the default port for us.

Furthemore, note the kIOMasterPortDefault / kIOMainPortDefault discussion, which makes it clear that it is merely a synonym for NULL. You _can_ use NULL as an alternative: 
> Discussion
> * When specifying a primary port to IOKit functions, the NULL argument indicates "use the default". This is a synonym for NULL, if you'd rather use a named constant.

So this PR replaces all calls to either function and constant with the documented and acceptable alternative of passing NULL (cast to mach_port_t) as the first parameter to IOServiceGetMatchingServices()