### PR TITLE
mem.VirtualMemory(): wrong page size on darwin arm64

### DIFF
--- a/mem/mem_darwin_cgo.go
+++ b/mem/mem_darwin_cgo.go
@@ -5,6 +5,7 @@ package mem
 
 /*
 #include <mach/mach_host.h>
+#include <mach/vm_page_size.h>
 */
 import "C"
 
@@ -12,8 +13,6 @@ import (
 	"context"
 	"fmt"
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 // VirtualMemory returns VirtualmemoryStat.
@@ -34,7 +33,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 		return nil, fmt.Errorf("host_statistics error=%d", status)
 	}
 
-	pageSize := uint64(unix.Getpagesize())
+	pageSize := uint64(C.vm_kernel_page_size)
 	total, err := getHwMemsize()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`mem.VirtualMemory()` returns values that are 4x larger/smaller than they should be on darwin arm64.

Generally speaking, `unix.Getpagesize()` returns the correct page size on macOS; 4K on Intel Macs and 16K on M1 Macs.

However, that is not the unit that `host_statistics()` values are measured in; they are  _kernel_ memory pages which are `vm_kernel_page_size` bytes long.

You can see this in the source code of `vm_stat`, which is the executable that the non-CGO version of the darwin VM stats runs and parses.

https://github.com/unofficial-opensource-apple/system_cmds/blob/master/vm_stat.tproj/vm_stat.c#L126-L132
> ```
>printf("Mach Virtual Memory Statistics: (page size of %llu bytes)\n", (mach_vm_size_t)vm_kernel_page_size);
>```

This PR replaces `unix.Getpagesize()` with `C.vm_kernel_page_size`