### PR TITLE
[host] [linux] merge kylin platform to rhel family.

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -286,7 +286,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "debian"
 	case "fedora":
 		family = "fedora"
-	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky", "almalinux":
+	case "oracle", "centos", "redhat", "scientific", "enterpriseenterprise", "amazon", "xenserver", "cloudlinux", "ibm_powerkvm", "rocky", "almalinux", "kylin":
 		family = "rhel"
 	case "suse", "opensuse", "opensuse-leap", "opensuse-tumbleweed", "opensuse-tumbleweed-kubic", "sles", "sled", "caasp":
 		family = "suse"


### PR DESCRIPTION
About kylin linux: https://eco.kylinos.cn/
Without any redhat or other version files, there is just a /etc/kylin-release (/etc/system-release is linked from it).
```
[root@host]# ls /etc/*release
/etc/kylin-release  /etc/lsb-release  /etc/os-release  /etc/system-release
[root@host]# ls /etc/*version
```
So it will match this code block:
> https://github.com/shirou/gopsutil/blob/master/host/host_linux.go#L231
```
else if common.PathExists(common.HostEtc("system-release")) {
		contents, err := common.ReadLines(common.HostEtc("system-release"))
		if err == nil {
			version = getRedhatishVersion(contents)
			platform = getRedhatishPlatform(contents)
		}
	}
```
By this file:
```
[root@host]# cat /etc/system-release
Kylin Linux Advanced Server release V10 (Sword)
```
version is `v10`
platform is `kylin`
As a result, the function will return: `"kylin" "" "v10" nil`. So I add merge kylin platform to rhel family.
After this PR, will return: `"kylin" "rhel" "v10" nil`.