### PR TITLE
fix some kylin linux bug

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -205,6 +205,9 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		} else if lsb.ID == "LinuxMint" {
 			platform = "linuxmint"
 			version = lsb.Release
+		} else if lsb.ID == "Kylin" {
+			platform = "Kylin"
+			version = lsb.Release
 		} else {
 			if common.PathExistsWithContents("/usr/bin/raspi-config") {
 				platform = "raspbian"


### PR DESCRIPTION
For Kylin Linux Desktop V10, It has `/etc/debian_version` which will cause the error to get host info.