### PR TITLE
Fix memory leaks in process_darwin_cgo

### DIFF
--- a/process/process_darwin_cgo.go
+++ b/process/process_darwin_cgo.go
@@ -175,6 +175,7 @@ func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
 func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 	const tiSize = C.sizeof_struct_proc_taskinfo
 	ti := (*C.struct_proc_taskinfo)(C.malloc(tiSize))
+	defer C.free(unsafe.Pointer(ti))
 
 	_, err := C.proc_pidinfo(C.int(p.Pid), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(ti), tiSize)
 	if err != nil {
@@ -187,6 +188,7 @@ func (p *Process) NumThreadsWithContext(ctx context.Context) (int32, error) {
 func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) {
 	const tiSize = C.sizeof_struct_proc_taskinfo
 	ti := (*C.struct_proc_taskinfo)(C.malloc(tiSize))
+	defer C.free(unsafe.Pointer(ti))
 
 	_, err := C.proc_pidinfo(C.int(p.Pid), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(ti), tiSize)
 	if err != nil {
@@ -204,6 +206,7 @@ func (p *Process) TimesWithContext(ctx context.Context) (*cpu.TimesStat, error) 
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
 	const tiSize = C.sizeof_struct_proc_taskinfo
 	ti := (*C.struct_proc_taskinfo)(C.malloc(tiSize))
+	defer C.free(unsafe.Pointer(ti))
 
 	_, err := C.proc_pidinfo(C.int(p.Pid), C.PROC_PIDTASKINFO, 0, unsafe.Pointer(ti), tiSize)
 	if err != nil {


### PR DESCRIPTION
`NumThreadsWithContext`, `TimesWithContext`, and `MemoryInfoWithContext` were calling `C.malloc` but not calling `C.free` on the returned pointer, causing a leak. This change fixes that.