### PR TITLE
[process][windows] Retrieve process name as basename of executable 

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -294,7 +294,7 @@ func Test_Process_Name(t *testing.T) {
 		t.Errorf("getting name error %v", err)
 	}
 	if !strings.Contains(n, "process.test") {
-		t.Errorf("invalid Exe %s", n)
+		t.Errorf("invalid Name %s", n)
 	}
 }
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"syscall"
@@ -319,18 +320,19 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
-	ppid, _, name, err := getFromSnapProcess(p.Pid)
+	if p.Pid == 0 {
+		return "System Idle Process", nil
+	}
+	if p.Pid == 4 {
+		return "System", nil
+	}
+
+	exe, err := p.ExeWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("could not get Name: %s", err)
 	}
 
-	// if no errors and not cached already, cache ppid
-	p.parent = ppid
-	if 0 == p.getPpid() {
-		p.setPpid(ppid)
-	}
-
-	return name, nil
+	return filepath.Base(exe), nil
 }
 
 func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -987,15 +987,9 @@ func is32BitProcess(h windows.Handle) bool {
 
 	var procIs32Bits bool
 	switch processorArchitecture {
-	case PROCESSOR_ARCHITECTURE_INTEL:
-		fallthrough
-	case PROCESSOR_ARCHITECTURE_ARM:
+	case PROCESSOR_ARCHITECTURE_INTEL, PROCESSOR_ARCHITECTURE_ARM:
 		procIs32Bits = true
-	case PROCESSOR_ARCHITECTURE_ARM64:
-		fallthrough
-	case PROCESSOR_ARCHITECTURE_IA64:
-		fallthrough
-	case PROCESSOR_ARCHITECTURE_AMD64:
+	case PROCESSOR_ARCHITECTURE_ARM64, PROCESSOR_ARCHITECTURE_IA64, PROCESSOR_ARCHITECTURE_AMD64:
 		var wow64 uint
 
 		ret, _, _ := common.ProcNtQueryInformationProcess.Call(


### PR DESCRIPTION
We align ourself with psutil
https://github.com/giampaolo/psutil/blob/8e4099d9f063ceb4ee3da5845562c5b934f83544/psutil/_pswindows.py#L749-L759

Benchmarks show vast improvements

    go test -run=BenchmarkProcessName -bench=BenchmarkProcessName ./process
    goos: windows
    goarch: amd64
    pkg: github.com/shirou/gopsutil/v3/process
    cpu: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
    BenchmarkProcessName-4               180           6564033 ns/op
    BenchmarkProcessNameViaExe-4       22111             51153 ns/op
    PASS
    ok      github.com/shirou/gopsutil/v3/process   3.914s

Fixes #1368