### PR TITLE
feat: Setting the model name for arm based CPUs

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -244,16 +244,6 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Model = value
 		case "model name", "cpu":
 			c.ModelName = value
-			if c.VendorID == "ARM" && c.ModelName == "" {
-				if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
-					modelName, exist := armModelToModelName[v]
-					if exist {
-						c.ModelName = modelName
-					} else {
-						c.ModelName = "Undefined"
-					}
-				}
-			}
 			if strings.Contains(value, "POWER8") ||
 				strings.Contains(value, "POWER7") {
 				c.Model = strings.Split(value, " ")[0]
@@ -298,6 +288,16 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	if c.CPU >= 0 {
 		finishCPUInfo(&c)
 		ret = append(ret, c)
+	}
+	if c.VendorID == "ARM" && c.ModelName == "" {
+		if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
+			modelName, exist := armModelToModelName[v]
+			if exist {
+				c.ModelName = modelName
+			} else {
+				c.ModelName = "Undefined"
+			}
+		}
 	}
 	return ret, nil
 }

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -244,13 +244,13 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Model = value
 		case "model name", "cpu":
 			c.ModelName = value
-			if c.ModelName == "" {
+			if c.VendorID == "ARM" && c.ModelName == "" {
 				if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
-					modelName, isThereModel := armModelToModelName[v]
-					if !isThereModel {
-						c.ModelName = "Undefined"
-					} else {
+					modelName, exist := armModelToModelName[v]
+					if exist {
 						c.ModelName = modelName
+					} else {
+						c.ModelName = "Undefined"
 					}
 				}
 			}

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -285,10 +285,6 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Microcode = value
 		}
 	}
-	if c.CPU >= 0 {
-		finishCPUInfo(&c)
-		ret = append(ret, c)
-	}
 	if c.VendorID == "ARM" && c.ModelName == "" {
 		if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
 			modelName, exist := armModelToModelName[v]
@@ -298,6 +294,10 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 				c.ModelName = "Undefined"
 			}
 		}
+	}
+	if c.CPU >= 0 {
+		finishCPUInfo(&c)
+		ret = append(ret, c)
 	}
 	return ret, nil
 }

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -17,6 +17,71 @@ import (
 
 var ClocksPerSec = float64(100)
 
+var armModelToModelName = map[uint64]string{
+	0x810: "ARM810",
+	0x920: "ARM920",
+	0x922: "ARM922",
+	0x926: "ARM926",
+	0x940: "ARM940",
+	0x946: "ARM946",
+	0x966: "ARM966",
+	0xa20: "ARM1020",
+	0xa22: "ARM1022",
+	0xa26: "ARM1026",
+	0xb02: "ARM11 MPCore",
+	0xb36: "ARM1136",
+	0xb56: "ARM1156",
+	0xb76: "ARM1176",
+	0xc05: "Cortex-A5",
+	0xc07: "Cortex-A7",
+	0xc08: "Cortex-A8",
+	0xc09: "Cortex-A9",
+	0xc0d: "Cortex-A17",
+	0xc0f: "Cortex-A15",
+	0xc0e: "Cortex-A17",
+	0xc14: "Cortex-R4",
+	0xc15: "Cortex-R5",
+	0xc17: "Cortex-R7",
+	0xc18: "Cortex-R8",
+	0xc20: "Cortex-M0",
+	0xc21: "Cortex-M1",
+	0xc23: "Cortex-M3",
+	0xc24: "Cortex-M4",
+	0xc27: "Cortex-M7",
+	0xc60: "Cortex-M0+",
+	0xd01: "Cortex-A32",
+	0xd02: "Cortex-A34",
+	0xd03: "Cortex-A53",
+	0xd04: "Cortex-A35",
+	0xd05: "Cortex-A55",
+	0xd06: "Cortex-A65",
+	0xd07: "Cortex-A57",
+	0xd08: "Cortex-A72",
+	0xd09: "Cortex-A73",
+	0xd0a: "Cortex-A75",
+	0xd0b: "Cortex-A76",
+	0xd0c: "Neoverse-N1",
+	0xd0d: "Cortex-A77",
+	0xd0e: "Cortex-A76AE",
+	0xd13: "Cortex-R52",
+	0xd20: "Cortex-M23",
+	0xd21: "Cortex-M33",
+	0xd40: "Neoverse-V1",
+	0xd41: "Cortex-A78",
+	0xd42: "Cortex-A78AE",
+	0xd43: "Cortex-A65AE",
+	0xd44: "Cortex-X1",
+	0xd46: "Cortex-A510",
+	0xd47: "Cortex-A710",
+	0xd48: "Cortex-X2",
+	0xd49: "Neoverse-N2",
+	0xd4a: "Neoverse-E1",
+	0xd4b: "Cortex-A78C",
+	0xd4c: "Cortex-X1C",
+	0xd4d: "Cortex-A715",
+	0xd4e: "Cortex-X3",
+}
+
 func init() {
 	clkTck, err := sysconf.Sysconf(sysconf.SC_CLK_TCK)
 	// ignore errors
@@ -179,6 +244,16 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Model = value
 		case "model name", "cpu":
 			c.ModelName = value
+			if c.ModelName == "" {
+				if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
+					modelName, isThereModel := armModelToModelName[v]
+					if !isThereModel {
+						c.ModelName = "Undefined"
+					} else {
+						c.ModelName = modelName
+					}
+				}
+			}
 			if strings.Contains(value, "POWER8") ||
 				strings.Contains(value, "POWER7") {
 				c.Model = strings.Split(value, " ")[0]


### PR DESCRIPTION
```
- Added arm model and model name as map.
- The modelName is set again according to the model value when the model name is empty.
- Based on lscpu source code.. https://github.com/util-linux/util-linux/blob/master/sys-utils/lscpu-arm.c

---

Signed-off-by: Yalcin Ozbek <yalcinozbekceng@gmail.com>
```

The contents of the /proc/cpuinfo file on some of the arm devices we work with are as follows. ModelName value is set to empty.. However, the model name can be obtained with commands such as **lscpu.** The source code of lscpu can be viewed [here](https://github.com/util-linux/util-linux/blob/master/sys-utils/lscpu-arm.c)
This PR has been created so that the ModelName value is not set empty.

Example 1:
```
processor	: 0
BogoMIPS	: 400.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 1
BogoMIPS	: 400.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 2
BogoMIPS	: 400.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

processor	: 3
BogoMIPS	: 400.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4
```

Example 2:
```
processor	: 0
BogoMIPS	: 243.75
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x3
CPU part	: 0xd0c
CPU revision	: 1

processor	: 1
BogoMIPS	: 243.75
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x3
CPU part	: 0xd0c
CPU revision	: 1
```