### PR TITLE
feat(host, windows): add UBR (Update Build Revision) to kernel version

### DIFF
--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -188,6 +188,14 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		}
 	}
 
+	var UBR uint32 // Update Build Revision
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`UBR`), nil, &valType, nil, &bufLen)
+	if err == nil {
+		regBuf := make([]byte, 4)
+		err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`UBR`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+		copy((*[4]byte)(unsafe.Pointer(&UBR))[:], regBuf)
+	}
+
 	// PlatformFamily
 	switch osInfo.wProductType {
 	case 1:
@@ -199,7 +207,9 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	}
 
 	// Platform Version
-	version = fmt.Sprintf("%d.%d.%d Build %d", osInfo.dwMajorVersion, osInfo.dwMinorVersion, osInfo.dwBuildNumber, osInfo.dwBuildNumber)
+	version = fmt.Sprintf("%d.%d.%d.%d Build %d.%d",
+		osInfo.dwMajorVersion, osInfo.dwMinorVersion, osInfo.dwBuildNumber, UBR,
+		osInfo.dwBuildNumber, UBR)
 
 	return platform, family, version, nil
 }


### PR DESCRIPTION
fixes #1372

This PR adds UBR (Update Build Revision) to current Build Version.

# Notice: this PR breaks compatibility

This PR changes the format of the string returned by `host.KernelVersion()` as follows. I do not believe there are any applications that parses this string and uses numbers, but if there are such applications and they implement a naive parser, this might be a problem.

From

```
    host_test.go:181: KernelVersion(): 10.0.22000 Build 22000
```
to

```
    host_test.go:181: KernelVersion(): 10.0.22000.1098 Build 22000.1098
```