### PR TITLE
Retract deleted tag v3.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2
 	golang.org/x/sys v0.2.0
 )
+
+retract v3.22.11


### PR DESCRIPTION
This is to disallow to re-tag v3.22.11 since you will generate security issues/warnings (different checksum)