### PR TITLE
fill modelName for all cores in arm64 devices

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -242,6 +242,17 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Family = value
 		case "model", "CPU part":
 			c.Model = value
+			// if CPU is arm based, model name is found via model number. refer to: arch/arm64/kernel/cpuinfo.c
+			if c.VendorID == "ARM" {
+				if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
+					modelName, exist := armModelToModelName[v]
+					if exist {
+						c.ModelName = modelName
+					} else {
+						c.ModelName = "Undefined"
+					}
+				}
+			}
 		case "model name", "cpu":
 			c.ModelName = value
 			if strings.Contains(value, "POWER8") ||
@@ -283,16 +294,6 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			})
 		case "microcode":
 			c.Microcode = value
-		}
-	}
-	if c.VendorID == "ARM" && c.ModelName == "" {
-		if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
-			modelName, exist := armModelToModelName[v]
-			if exist {
-				c.ModelName = modelName
-			} else {
-				c.ModelName = "Undefined"
-			}
 		}
 	}
 	if c.CPU >= 0 {


### PR DESCRIPTION
If there are more than one core for arm64 based devices, model name of CPU was not filled for all the cores except the last core. For instance, if there are 4 cores, only the last core's model name info is filled. As there is no model name line in **/proc/cpuinfo** file for arm64 devices(refer to: **arch/arm64/kernel/cpuinfo.c** in linux kernel code), it is better to move the code under case _"model", "CPU part"_. Also, all the core's model names will filled as this case is inside of loop. 

The code is tested for both amd64 and arm64 devices:

- Arm Cortex-A53
- 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz