### PR TITLE
Truncate the Getfsstat result to the count of items that were returned

### DIFF
--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -20,9 +20,11 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		return ret, err
 	}
 	fs := make([]unix.Statfs_t, count)
-	if _, err = unix.Getfsstat(fs, unix.MNT_WAIT); err != nil {
+	count, err := unix.Getfsstat(fs, unix.MNT_WAIT)
+	if err != nil {
 		return ret, err
 	}
+	fs = fs[:count] // Actual count may be less than from the first call.
 	for _, stat := range fs {
 		opts := []string{"rw"}
 		if stat.Flags&unix.MNT_RDONLY != 0 {

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -27,6 +27,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	// On 10.14, and possibly other OS versions, the actual count may
 	// be less than from the first call. Truncate to the returned count
 	// to prevent accessing uninitialized entries.
+	// https://github.com/shirou/gopsutil/issues/1390
 	fs = fs[:count]
 	for _, stat := range fs {
 		opts := []string{"rw"}

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -20,7 +20,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		return ret, err
 	}
 	fs := make([]unix.Statfs_t, count)
-	count, err := unix.Getfsstat(fs, unix.MNT_WAIT)
+	count, err = unix.Getfsstat(fs, unix.MNT_WAIT)
 	if err != nil {
 		return ret, err
 	}

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -24,7 +24,10 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	if err != nil {
 		return ret, err
 	}
-	fs = fs[:count] // Actual count may be less than from the first call.
+	// On 10.14, and possibly other OS versions, the actual count may
+	// be less than from the first call. Truncate to the returned count
+	// to prevent accessing uninitialized entries.
+	fs = fs[:count]
 	for _, stat := range fs {
 		opts := []string{"rw"}
 		if stat.Flags&unix.MNT_RDONLY != 0 {


### PR DESCRIPTION
This count may be less than what was returned by the first call to Getfsstat.

Fixes #1390 