### PR TITLE
host: use unix.ByteSliceToString

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -319,7 +319,7 @@ func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return string(utsname.Release[:bytes.IndexByte(utsname.Release[:], 0)]), nil
+	return unix.ByteSliceToString(utsname.Release[:]), nil
 }
 
 func getSlackwareVersion(contents []string) string {

--- a/host/host_posix.go
+++ b/host/host_posix.go
@@ -3,14 +3,13 @@
 
 package host
 
-import (
-	"bytes"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 func KernelArch() (string, error) {
 	var utsname unix.Utsname
 	err := unix.Uname(&utsname)
-	return string(utsname.Machine[:bytes.IndexByte(utsname.Machine[:], 0)]), err
+	if err != nil {
+		return "", err
+	}
+	return unix.ByteSliceToString(utsname.Machine[:]), nil
 }


### PR DESCRIPTION
Use ByteSliceToString provided in golang.org/x/sys/unix to convert \0-terminated byte slices to strings.