### PR TITLE
[host] windows: use millisecond precision for BootTime()

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -155,3 +155,7 @@ func SensorsTemperatures() ([]TemperatureStat, error) {
 func timeSince(ts uint64) uint64 {
 	return uint64(time.Now().Unix()) - ts
 }
+
+func timeSinceMillis(ts uint64) uint64 {
+	return uint64(time.Now().UnixMilli()) - ts
+}

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -103,6 +103,14 @@ func numProcs(ctx context.Context) (uint64, error) {
 }
 
 func UptimeWithContext(ctx context.Context) (uint64, error) {
+	up, err := uptimeMillis()
+	if err != nil {
+		return 0, err
+	}
+	return uint64((time.Duration(up) * time.Millisecond).Seconds()), nil
+}
+
+func uptimeMillis() (uint64, error) {
 	procGetTickCount := procGetTickCount64
 	err := procGetTickCount64.Find()
 	if err != nil {
@@ -112,7 +120,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	if lastErr != 0 {
 		return 0, lastErr
 	}
-	return uint64((time.Duration(r1) * time.Millisecond).Seconds()), nil
+	return uint64(r1), nil
 }
 
 // cachedBootTime must be accessed via atomic.Load/StoreUint64
@@ -123,11 +131,11 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	if t != 0 {
 		return t, nil
 	}
-	up, err := Uptime()
+	up, err := uptimeMillis()
 	if err != nil {
 		return 0, err
 	}
-	t = timeSince(up)
+	t = uint64((time.Duration(timeSinceMillis(up)) * time.Millisecond).Seconds())
 	atomic.StoreUint64(&cachedBootTime, t)
 	return t, nil
 }


### PR DESCRIPTION
Previously, system uptime is truncated to seconds, and then the subtraction from `time.Now()` is performed. Because uptime does not roll over to the next second at the same instant as `time.Now()`, then `BootTime()` ends up not being precise, and often varies by 1 second.

This commit does the subtraction before truncating to seconds, which results in a significantly lower chance of variance in `BootTime()`.

Old behaviour before change:

```
PS C:\Users\jefferbrecht\go\src\boottime> cat main.go
package main
import (
        "fmt"
        "syscall"
        "time"
        "github.com/shirou/gopsutil/v3/host"
        "golang.org/x/sys/windows"
)
var (
        kernel32DLL      = windows.NewLazyDLL("kernel32.dll")
        procGetTickCount = kernel32DLL.NewProc("GetTickCount64")
)
func main() {
        ticks, _, _ := syscall.Syscall(procGetTickCount.Addr(), 0, 0, 0, 0)
        boot, _ := host.BootTime()
        now := time.Now().Unix()
        fmt.Printf("%d\t%d\t%d\n", ticks, boot, now)
}
PS C:\Users\jefferbrecht\go\src\boottime> go build .
PS C:\Users\jefferbrecht\go\src\boottime> for ($i = 0; $i -lt 5; $i++) { .\boottime.exe }
GetTickCount()  host.BootTime() time.Now()
374255953       1671094442      1671468697
374255984       1671094442      1671468697
374256000       1671094441      1671468697  <-- host.BootTime() rolls over
374256031       1671094441      1671468697
374256093       1671094441      1671468697
```

New behaviour after change:

```
PS C:\Users\jefferbrecht\go\src\boottime> for ($i = 0; $i -lt 5; $i++) { .\boottime.exe }
GetTickCount()  host.BootTime() time.Now()
374009953       1671094441      1671468451
374009968       1671094441      1671468451
374010000       1671094441      1671468451  <-- host.BootTime() does not roll over
374010015       1671094441      1671468451
374010046       1671094441      1671468451
```

Note that there is still a chance for `BootTime()` to roll over e.g. if the true boot time's milliseconds portion is close to 0. There is not much to be done about this since we cannot get both `GetTickCount` and `time.Now` atomically at the same instant.