### PR TITLE
Detect Docker also using /.dockerenv

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -364,6 +364,10 @@ func HostDev(combineWith ...string) string {
 	return GetEnv("HOST_DEV", "/dev", combineWith...)
 }
 
+func HostRoot(combineWith ...string) string {
+	return GetEnv("HOST_ROOT", "/", combineWith...)
+}
+
 // getSysctrlEnv sets LC_ALL=C in a list of env vars for use when running
 // sysctl commands (see DoSysctrl).
 func getSysctrlEnv(env []string) []string {

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -259,6 +259,11 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 		}
 	}
 
+	if PathExists(HostRoot(".dockerenv")) {
+		system = "docker"
+		role = "guest"
+	}
+
 	// before returning for the first time, cache the system and role
 	cachedVirtOnce.Do(func() {
 		cachedVirtMutex.Lock()


### PR DESCRIPTION
Docker itself does that too, for example in https://github.com/moby/libnetwork/blob/1f3b98be6833a93f254aa0f765ff55d407dfdd69/drivers/bridge/setup_bridgenetfiltering.go#L161

/proc/self/cgroup doesn't necessarily contain "docker".