### PR TITLE
fix(disk): correctly replace /dev in /dev/mapper

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -341,7 +341,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 			}
 
 			if strings.HasPrefix(d.Device, "/dev/mapper/") {
-				devpath, err := filepath.EvalSymlinks(common.HostDev(strings.Replace(d.Device, "/dev", "", -1)))
+				devpath, err := filepath.EvalSymlinks(common.HostDev(strings.Replace(d.Device, "/dev", "", 1)))
 				if err == nil {
 					d.Device = devpath
 				}

--- a/internal/common/binary.go
+++ b/internal/common/binary.go
@@ -21,6 +21,7 @@ package common
 // high-performance serialization, especially for large data structures,
 // should look at more advanced solutions such as the encoding/gob
 // package or protocol buffers.
+
 import (
 	"errors"
 	"io"

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -6,6 +6,7 @@ package common
 //  - linux (amd64, arm)
 //  - freebsd (amd64)
 //  - windows (amd64)
+
 import (
 	"bufio"
 	"bytes"


### PR DESCRIPTION
Only replace the first instance of /dev in a /dev/mapper string. Otherwise, if an LVM group is named dev it will replace that as well.

fixes: #1411