### PR TITLE
Groups in /proc/PID/status has type uint32.

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -31,7 +31,7 @@ type Process struct {
 	numCtxSwitches *NumCtxSwitchesStat
 	uids           []int32
 	gids           []int32
-	groups         []int32
+	groups         []uint32
 	numThreads     int32
 	memInfo        *MemoryInfoStat
 	sigInfo        *SignalInfoStat
@@ -361,7 +361,7 @@ func (p *Process) CPUPercentWithContext(ctx context.Context) (float64, error) {
 }
 
 // Groups returns all group IDs(include supplementary groups) of the process as a slice of the int
-func (p *Process) Groups() ([]int32, error) {
+func (p *Process) Groups() ([]uint32, error) {
 	return p.GroupsWithContext(context.Background())
 }
 

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -142,7 +142,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return gids, nil
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	return nil, common.ErrNotImplementedError
 	// k, err := p.getKProc()
 	// if err != nil {

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -90,7 +90,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -178,15 +178,15 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return gids, nil
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	k, err := p.getKProc()
 	if err != nil {
 		return nil, err
 	}
 
-	groups := make([]int32, k.Ngroups)
+	groups := make([]uint32, k.Ngroups)
 	for i := int16(0); i < k.Ngroups; i++ {
-		groups[i] = int32(k.Groups[i])
+		groups[i] = uint32(k.Groups[i])
 	}
 
 	return groups, nil

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -164,10 +164,10 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return p.gids, nil
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	err := p.fillFromStatusWithContext(ctx)
 	if err != nil {
-		return []int32{}, err
+		return []uint32{}, err
 	}
 	return p.groups, nil
 }
@@ -887,13 +887,13 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 			}
 		case "Groups":
 			groups := strings.Fields(value)
-			p.groups = make([]int32, 0, len(groups))
+			p.groups = make([]uint32, 0, len(groups))
 			for _, i := range groups {
-				v, err := strconv.ParseInt(i, 10, 32)
+				v, err := strconv.ParseUint(i, 10, 32)
 				if err != nil {
 					return err
 				}
-				p.groups = append(p.groups, int32(v))
+				p.groups = append(p.groups, uint32(v))
 			}
 		case "Threads":
 			v, err := strconv.ParseInt(value, 10, 32)

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -198,7 +198,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return gids, nil
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	k, err := p.getKProc()
 	if err != nil {
 		return nil, err

--- a/process/process_plan9.go
+++ b/process/process_plan9.go
@@ -90,7 +90,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/process/process_solaris.go
+++ b/process/process_solaris.go
@@ -104,7 +104,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -474,7 +474,7 @@ func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
+func (p *Process) GroupsWithContext(ctx context.Context) ([]uint32, error) {
 	return nil, common.ErrNotImplementedError
 }
 


### PR DESCRIPTION
Fix error of parser:
> error get info about worker process status 3150292: strconv.ParseInt:
> parsing "4294967293": value out of range

$ grep Groups /proc/self/status
Groups: 20001 [...] 4294967293