### PR TITLE
Fix 'send on closed channel' bug with windows disks

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -90,12 +91,20 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	var ret []PartitionStat
 	retChan := make(chan []PartitionStat)
 	errChan := make(chan error)
-	defer close(retChan)
-	defer close(errChan)
-
 	lpBuffer := make([]byte, 254)
 
+	var waitgrp sync.WaitGroup
+	waitgrp.Add(1)
+	defer waitgrp.Done()
+
 	f := func() {
+		defer func() {
+			waitgrp.Wait()
+			// fires when this func and the outside func finishes.
+			close(errChan)
+			close(retChan)
+		}()
+
 		diskret, _, err := procGetLogicalDriveStringsW.Call(
 			uintptr(len(lpBuffer)),
 			uintptr(unsafe.Pointer(&lpBuffer[0])))


### PR DESCRIPTION
Fixes this panic:
```
goroutine 138166 [running]:
github.com/shirou/gopsutil/v3/disk.PartitionsWithContext.func1()
	github.com/shirou/gopsutil/v3@v3.23.2/disk/disk_windows.go:159 +0x7e7
created by github.com/shirou/gopsutil/v3/disk.PartitionsWithContext
	github.com/shirou/gopsutil/v3@v3.23.2/disk/disk_windows.go:162 +0x1ea
```

- Mentioned in #1415.