### PR TITLE
fix: moves common.Warnings to common OS files

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -9,6 +9,8 @@ import (
 
 var invoke common.Invoker = common.Invoke{}
 
+type Warnings = common.Warnings
+
 type UsageStat struct {
 	Path              string  `json:"path"`
 	Fstype            string  `json:"fstype"`

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -15,8 +15,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-type Warnings = common.Warnings
-
 var (
 	procGetDiskFreeSpaceExW     = common.Modkernel32.NewProc("GetDiskFreeSpaceExW")
 	procGetLogicalDriveStringsW = common.Modkernel32.NewProc("GetLogicalDriveStringsW")

--- a/host/host.go
+++ b/host/host.go
@@ -11,6 +11,8 @@ import (
 	"github.com/shirou/gopsutil/v3/internal/common"
 )
 
+type Warnings = common.Warnings
+
 var invoke common.Invoker = common.Invoke{}
 
 // A HostInfoStat describes the host status.

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -19,8 +19,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type Warnings = common.Warnings
-
 type lsbStruct struct {
 	ID          string
 	Release     string


### PR DESCRIPTION
This allows all OS types to unwrap the Warnings from errors, and not just linux in host or windows in disk.

fixes: #1429