### PR TITLE
chore(golangci-lint): exlucde unused-parameters and empty-block rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,13 +3,19 @@ issues:
   exclude-rules: 
   - linters: 
     - gosec
-    text:  "G204"
+    text: "G204"
   - linters: 
     - revive
-    text:  "var-naming"
+    text: "var-naming"
   - linters: 
     - revive
-    text:  "exported"
+    text: "exported"
+  - linters: 
+    - revive
+    text: "empty-block"
+  - linters: 
+    - revive
+    text: "unused-parameter"
 linters:
   enable:
     - asciicheck


### PR DESCRIPTION
These are intentional.