### PR TITLE
refactor(process): compare error with `errors.Is`

### DIFF
--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -122,7 +122,7 @@ func PidExistsWithContext(ctx context.Context, pid int32) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if err.Error() == "os: process already finished" {
+	if errors.Is(err, os.ErrProcessDone) {
 		return false, nil
 	}
 	var errno syscall.Errno


### PR DESCRIPTION
Starting from Go 1.13, `errors.Is` is the preferable way to compare error equality [^1].

[^1]: https://go.dev/blog/go1.13-errors