### PR TITLE
Normalize CPU value in TimesStat struct

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -352,7 +352,7 @@ func parseStatLine(line string) (*TimesStat, error) {
 	}
 
 	ct := &TimesStat{
-		CPU:     cpu,
+		CPU:     cpu / ClocksPerSec,
 		User:    user / ClocksPerSec,
 		Nice:    nice / ClocksPerSec,
 		System:  system / ClocksPerSec,


### PR DESCRIPTION
In the current implementation of the `TimesStat` struct, the CPU value is not normalized by dividing it by `ClocksPerSec`. However, all the values in the lines starting with "cpu" in the `/proc/stat` file are measured in terms of Jiffies, which means the CPU value should also be normalized.