### PR TITLE
interface speed for windows, linux, darwin and freebsd

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -22,6 +22,8 @@ type IOCountersStat struct {
 	Dropout     uint64 `json:"dropout"`     // total number of outgoing packets which were dropped (always 0 on OSX and BSD)
 	Fifoin      uint64 `json:"fifoin"`      // total number of FIFO buffers errors while receiving
 	Fifoout     uint64 `json:"fifoout"`     // total number of FIFO buffers errors while sending
+	TransmitSpeed uint64 `json:"transmitSpeed"` // transmission speed of interface
+	ReceiveSpeed  uint64 `json:"receiveSpeed"` // receiving speed of interface
 }
 
 // Addr is implemented compatibility to psutil

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -134,7 +134,7 @@ func parseIfconfigOutput(iface *netstatInterface) error {
 		return err
 	}
 
-	re := regexp.MustCompile(`media:\s+.*\((\d+)baseT\)`)
+	re := regexp.MustCompile(`media:\s+.*\((\d+)baseT`)
 	match := re.FindStringSubmatch(string(out))
 	if len(match) >= 2 {
 		speed, err := strconv.ParseUint(match[1], 10, 64)

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"os/exec"
+	"regexp"
 
 	"github.com/shirou/gopsutil/v3/internal/common"
 )
@@ -80,6 +82,10 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			BytesSent:   parsed[6],
 			Dropout:     parsed[7],
 		}
+		err := parseIfconfigOutput(&n)
+		if err != nil {
+			return nil, err
+		}
 		ret = append(ret, n)
 	}
 
@@ -88,6 +94,27 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 	}
 
 	return ret, nil
+}
+
+func parseIfconfigOutput(istat *IOCountersStat) error {
+	cmd := exec.Command("ifconfig", istat.Name)
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(`media:\s+.*\((\d+)baseT`)
+	match := re.FindStringSubmatch(string(out))
+	if len(match) >= 2 {
+		speed, err := strconv.ParseUint(match[1], 10, 64)
+		if err != nil {
+			speed = 0
+		}
+		istat.TransmitSpeed = speed
+		istat.ReceiveSpeed = speed
+	}
+
+	return nil
 }
 
 // IOCountersByFile exists just for compatibility with Linux.

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -83,6 +83,18 @@ func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename stri
 			continue
 		}
 
+		speed, err := common.ReadLines(common.HostSys("class/net/"+interfaceName+"/speed"))
+		if err != nil {
+			if strings.Contains(err.Error(), "no such file or directory") {
+				speed = []string{"0"}
+			} else {
+				return ret, err
+			}
+		}
+		if speed[0] == "-1" {
+			speed = []string{"0"}
+		}
+
 		fields := strings.Fields(strings.TrimSpace(parts[1]))
 		bytesRecv, err := strconv.ParseUint(fields[0], 10, 64)
 		if err != nil {
@@ -124,6 +136,14 @@ func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename stri
 		if err != nil {
 			return ret, err
 		}
+		transmitSpeed, err := strconv.ParseUint(speed[0], 10, 64)
+		if err != nil {
+			return ret, err
+		}
+		receiveSpeed, err := strconv.ParseUint(speed[0], 10, 64)
+		if err != nil {
+			return ret, err
+		}
 
 		nic := IOCountersStat{
 			Name:        interfaceName,
@@ -137,6 +157,8 @@ func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename stri
 			Errout:      errOut,
 			Dropout:     dropOut,
 			Fifoout:     fifoOut,
+			TransmitSpeed: transmitSpeed,
+			ReceiveSpeed: receiveSpeed,
 		}
 		ret = append(ret, nic)
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -30,7 +30,7 @@ func TestNetIOCountersStatString(t *testing.T) {
 		Name:      "test",
 		BytesSent: 100,
 	}
-	e := `{"name":"test","bytesSent":100,"bytesRecv":0,"packetsSent":0,"packetsRecv":0,"errin":0,"errout":0,"dropin":0,"dropout":0,"fifoin":0,"fifoout":0}`
+	e := `{"name":"test","bytesSent":100,"bytesRecv":0,"packetsSent":0,"packetsRecv":0,"errin":0,"errout":0,"dropin":0,"dropout":0,"fifoin":0,"fifoout":0,"transmitSpeed":0,"receiveSpeed":0}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("NetIOCountersStat string is invalid: %v", v)
 	}

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -167,8 +167,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			c.Errout = uint64(row.OutErrors)
 			c.Dropin = uint64(row.InDiscards)
 			c.Dropout = uint64(row.OutDiscards)
-			c.TransmitSpeed = uint64(row.TransmitLinkSpeed)
-			c.ReceiveSpeed = uint64(row.ReceiveLinkSpeed)
+			c.TransmitSpeed = uint64(row.TransmitLinkSpeed) / 1e6
+			c.ReceiveSpeed = uint64(row.ReceiveLinkSpeed) / 1e6
 
 			counters = append(counters, c)
 		}
@@ -191,8 +191,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			c.Errout = uint64(row.OutErrors)
 			c.Dropin = uint64(row.InDiscards)
 			c.Dropout = uint64(row.OutDiscards)
-			c.TransmitSpeed = uint64(row.Speed)
-			c.ReceiveSpeed = uint64(row.Speed)
+			c.TransmitSpeed = uint64(row.Speed) / 1e6
+			c.ReceiveSpeed = uint64(row.Speed) / 1e6
 
 			counters = append(counters, c)
 		}

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -167,6 +167,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			c.Errout = uint64(row.OutErrors)
 			c.Dropin = uint64(row.InDiscards)
 			c.Dropout = uint64(row.OutDiscards)
+			c.TransmitSpeed = uint64(row.TransmitLinkSpeed)
+			c.ReceiveSpeed = uint64(row.ReceiveLinkSpeed)
 
 			counters = append(counters, c)
 		}
@@ -189,6 +191,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			c.Errout = uint64(row.OutErrors)
 			c.Dropin = uint64(row.InDiscards)
 			c.Dropout = uint64(row.OutDiscards)
+			c.TransmitSpeed = uint64(row.Speed)
+			c.ReceiveSpeed = uint64(row.Speed)
 
 			counters = append(counters, c)
 		}


### PR DESCRIPTION
Implemented interface speed for windows, linux, darwin, and freebsd as discussed here #465 

Windows is self-explanatory since the speed data was already in mibIfRow2

Linux reads the speed directly out of the /sys/class/net files for each interface

Darwin and Freebsd call ifconfig and parse the output (since the other data is also obtained by calling netstat and parsing it i figured that would be the best way)