### PR TITLE
Streaming algorithm for `MemoryMapsWithContext` on linux

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -378,9 +378,18 @@ func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net
 	return net.ConnectionsPidMaxWithContext(ctx, "all", p.Pid, max)
 }
 
+// strings.Cut is only available from Go 1.18 and onwards, `stringsCut` is an implementation of it
+// working on older Go versions
+func stringsCut(s, sep string) (string, string, bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
+}
+
 // function of parsing a block
 func readBlock(line string, m *MemoryMapsStat) error {
-	name, value, found := strings.Cut(line, ":")
+	name, value, found := stringsCut(line, ":")
 	if !found {
 		return nil
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -380,18 +380,19 @@ func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net
 
 // function of parsing a block
 func readBlock(line string, m *MemoryMapsStat) error {
-	field := strings.Split(line, ":")
-	if len(field) < 2 {
+	name, value, found := strings.Cut(line, ":")
+	if !found {
 		return nil
 	}
-	v := strings.Trim(field[1], "kB") // remove last "kB"
+
+	v := strings.Trim(value, "kB") // remove last "kB"
 	v = strings.TrimSpace(v)
 	t, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
 		return err
 	}
 
-	switch field[0] {
+	switch name {
 	case "Size":
 		m.Size = t
 	case "Rss":

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -442,14 +442,13 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		fields := strings.Fields(line)
 
 		if strings.Contains(line, "VmFlags") {
 			if !grouped {
 				ret = append(ret, current)
 				current = MemoryMapsStat{}
 			}
-		} else if len(fields) > 0 && !strings.HasSuffix(fields[0], ":") {
+		} else if fields := strings.Fields(line); len(fields) > 0 && !strings.HasSuffix(fields[0], ":") {
 			current.Path = fields[len(fields)-1]
 		} else {
 			if err := readBlock(line, &current); err != nil {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -457,9 +457,10 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 	defer smapsFile.Close()
 
 	scanner := bufio.NewScanner(smapsFile)
+	scanner.Buffer(make([]byte, 120), bufio.MaxScanTokenSize)
 
 	var firstLine []string
-	blocks := make([]string, 0, 16)
+	blocks := make([]string, 0, 32)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -478,7 +479,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 				}
 			}
 			// starts new block
-			blocks = make([]string, 0, 16)
+			blocks = blocks[:0]
 			firstLine = fields
 		} else {
 			blocks = append(blocks, line)

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -175,3 +175,19 @@ func Test_fillFromTIDStatWithContext_lx_brandz(t *testing.T) {
 		assert.Equal(t, float64(0), cpuTimes.Iowait)
 	}
 }
+
+func BenchmarkMemoryMapsGroupedTrue(b *testing.B) {
+	p := testGetProcess()
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		p.MemoryMapsWithContext(ctx, true)
+	}
+}
+
+func BenchmarkMemoryMapsGroupedFalse(b *testing.B) {
+	p := testGetProcess()
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		p.MemoryMapsWithContext(ctx, false)
+	}
+}


### PR DESCRIPTION
The current algorithm behind `MemoryMapsWithContext` reads the whole file ahead of time, but the smaps file can be quite huge in some cases. This PR switches the function to a streaming algorithm that should use less memory.

This PR also extracts the `getBlock` function out of the function body to make reading/understanding the function easier.