### PR TITLE
[process][posix] Realign process.Name() with python psutil to return same value on python3 scripts processes

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -82,8 +82,6 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 			extendedName := filepath.Base(cmdName)
 			if strings.HasPrefix(extendedName, p.name) {
 				name = extendedName
-			} else {
-				name = cmdName
 			}
 		}
 	}

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -55,8 +55,6 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 			extendedName := filepath.Base(cmdlineSlice[0])
 			if strings.HasPrefix(extendedName, p.name) {
 				name = extendedName
-			} else {
-				name = cmdlineSlice[0]
 			}
 		}
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -845,8 +845,6 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					extendedName := filepath.Base(cmdlineSlice[0])
 					if strings.HasPrefix(extendedName, p.name) {
 						p.name = extendedName
-					} else {
-						p.name = cmdlineSlice[0]
 					}
 				}
 			}

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -60,8 +60,6 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 			extendedName := filepath.Base(cmdlineSlice[0])
 			if strings.HasPrefix(extendedName, p.name) {
 				name = extendedName
-			} else {
-				name = cmdlineSlice[0]
 			}
 		}
 	}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -785,60 +785,6 @@ func Test_Process_Cwd(t *testing.T) {
 	t.Log(pidCwd)
 }
 
-func Test_AllProcesses_cmdLine(t *testing.T) {
-	procs, err := Processes()
-	skipIfNotImplementedErr(t, err)
-	if err != nil {
-		t.Fatalf("getting processes error %v", err)
-	}
-	for _, proc := range procs {
-		var exeName string
-		var cmdLine string
-
-		exeName, _ = proc.Exe()
-		cmdLine, err = proc.Cmdline()
-		if err != nil {
-			cmdLine = "Error: " + err.Error()
-		}
-
-		t.Logf("Process #%v: Name: %v / CmdLine: %v\n", proc.Pid, exeName, cmdLine)
-	}
-}
-
-func Test_AllProcesses_environ(t *testing.T) {
-	procs, err := Processes()
-	skipIfNotImplementedErr(t, err)
-	if err != nil {
-		t.Fatalf("getting processes error %v", err)
-	}
-	for _, proc := range procs {
-		exeName, _ := proc.Exe()
-		environ, err := proc.Environ()
-		if err != nil {
-			environ = []string{"Error: " + err.Error()}
-		}
-
-		t.Logf("Process #%v: Name: %v / Environment Variables: %v\n", proc.Pid, exeName, environ)
-	}
-}
-
-func Test_AllProcesses_Cwd(t *testing.T) {
-	procs, err := Processes()
-	skipIfNotImplementedErr(t, err)
-	if err != nil {
-		t.Fatalf("getting processes error %v", err)
-	}
-	for _, proc := range procs {
-		exeName, _ := proc.Exe()
-		cwd, err := proc.Cwd()
-		if err != nil {
-			cwd = "Error: " + err.Error()
-		}
-
-		t.Logf("Process #%v: Name: %v / Current Working Directory: %s\n", proc.Pid, exeName, cwd)
-	}
-}
-
 func BenchmarkNewProcess(b *testing.B) {
 	checkPid := os.Getpid()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
e2c79a1 started to blindly set the process name to the full path (instead of the basename) of the cmdline exectuable
if the process name from the process comm was truncated on linux. Python psutil never did that, and this is just wrong
for python (or any executable interpreted script) where the process name is not the interpreter binary but the script
itself.

A new test to check process name value against psutil value is added here, which would hopefully catch any potential
future changes in psutil.

Reverts #542

Fixes #1485