### PR TITLE
Enable setting of vendor and related information for all Power versions

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -259,8 +259,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			}
 		case "Model Name", "model name", "cpu":
 			c.ModelName = value
-			if strings.Contains(value, "POWER8") ||
-				strings.Contains(value, "POWER7") {
+			if strings.Contains(value, "POWER") {
 				c.Model = strings.Split(value, " ")[0]
 				c.Family = "POWER"
 				c.VendorID = "IBM"


### PR DESCRIPTION
This PR contains the changes to set VendorID, Model and Family for all generations of POWER.
Fixes: https://github.com/shirou/gopsutil/issues/1494