### PR TITLE
mem: linux: fix vmstat field names

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -371,25 +371,25 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 				continue
 			}
 			ret.Sout = value * 4 * 1024
-		case "pgpgIn":
+		case "pgpgin":
 			value, err := strconv.ParseUint(fields[1], 10, 64)
 			if err != nil {
 				continue
 			}
 			ret.PgIn = value * 4 * 1024
-		case "pgpgOut":
+		case "pgpgout":
 			value, err := strconv.ParseUint(fields[1], 10, 64)
 			if err != nil {
 				continue
 			}
 			ret.PgOut = value * 4 * 1024
-		case "pgFault":
+		case "pgfault":
 			value, err := strconv.ParseUint(fields[1], 10, 64)
 			if err != nil {
 				continue
 			}
 			ret.PgFault = value * 4 * 1024
-		case "pgMajFault":
+		case "pgmajfault":
 			value, err := strconv.ParseUint(fields[1], 10, 64)
 			if err != nil {
 				continue


### PR DESCRIPTION
The field names are read from /proc/vmstat were capitalized as their output fields by mistake