### PR TITLE
fix IOCounters() SerialNumber enumeration

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -474,7 +474,11 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		}
 		d.Name = name
 
-		d.SerialNumber, _ = SerialNumberWithContext(ctx, name)
+		// Names passed in can be full paths (/dev/sda) or just device names (sda).
+		// Since `name`` here is already a basename, re-add a hardcoded /dev path.
+		// This is not ideal, but we may break the API by changing how SerialNumberWithContext
+		// works.
+		d.SerialNumber, _ = SerialNumberWithContext(ctx, "/dev/"+name)
 		d.Label, _ = LabelWithContext(ctx, name)
 
 		ret[name] = d

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -475,7 +475,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		d.Name = name
 
 		// Names passed in can be full paths (/dev/sda) or just device names (sda).
-		// Since `name`` here is already a basename, re-add the /dev path.
+		// Since `name` here is already a basename, re-add the /dev path.
 		// This is not ideal, but we may break the API by changing how SerialNumberWithContext
 		// works.
 		d.SerialNumber, _ = SerialNumberWithContext(ctx, common.HostDevWithContext(ctx, name))

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -475,7 +475,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		d.Name = name
 
 		// Names passed in can be full paths (/dev/sda) or just device names (sda).
-		// Since `name`` here is already a basename, re-add a hardcoded /dev path.
+		// Since `name`` here is already a basename, re-add the /dev path.
 		// This is not ideal, but we may break the API by changing how SerialNumberWithContext
 		// works.
 		d.SerialNumber, _ = SerialNumberWithContext(ctx, common.HostDevWithContext(ctx, name))

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -478,7 +478,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		// Since `name`` here is already a basename, re-add a hardcoded /dev path.
 		// This is not ideal, but we may break the API by changing how SerialNumberWithContext
 		// works.
-		d.SerialNumber, _ = SerialNumberWithContext(ctx, "/dev/"+name)
+		d.SerialNumber, _ = SerialNumberWithContext(ctx, common.HostDevWithContext(ctx, name))
 		d.Label, _ = LabelWithContext(ctx, name)
 
 		ret[name] = d


### PR DESCRIPTION
Addresses https://github.com/shirou/gopsutil/issues/1139.

I think @jbliao's analysis was correct. We end up basename-ing the device names passed in, so `/dev/sda` -> `sda`, and then we try to look up the serial number using `sda`, but the first thing that happens is a `unix.Stat("sda")`, which errors silently here.

Because the API is this way, just prepend a hardcoded `/dev/` to the device name so this lookup can succeed. I think this has a minimal chance for breakage.

Alternatively, we could maybe check for a leading `/` in the `SerialNumber()` func, and prepend `/dev/` there. Probably also pretty safe, and does improve the API usability.