### PR TITLE
refactor CpuUtilTotalStat as CpuUtilStat

### DIFF
--- a/cpu/cpu_aix_cgo.go
+++ b/cpu/cpu_aix_cgo.go
@@ -5,6 +5,7 @@ package cpu
 
 import (
 	"context"
+	"time"
 
 	"github.com/power-devops/perfstat"
 )
@@ -27,7 +28,7 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 			ret = append(ret, *ct)
 		}
 	} else {
-		c, err := perfstat.CpuUtilTotalStat()
+		c, err := perfstat.CpuUtilStat(1 * time.Second)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR fixes a bug (wrong function name) in the AIX support of the CPU package. 
<img width="756" alt="Screenshot 2023-08-18 at 11 40 34" src="https://github.com/shirou/gopsutil/assets/3696314/2aa248af-b7a1-40d2-bba6-7941d41b855a">
