### PR TITLE
chore: replace deprecated ioutil package to os and io

### DIFF
--- a/cpu/cpu_solaris_test.go
+++ b/cpu/cpu_solaris_test.go
@@ -1,7 +1,7 @@
 package cpu
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -49,7 +49,7 @@ func TestParseISAInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}
@@ -138,7 +138,7 @@ func TestParseProcessorInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -497,7 +496,7 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 
 	// Try to get the serial from udev data
 	udevDataPath := common.HostRunWithContext(ctx, fmt.Sprintf("udev/data/b%d:%d", major, minor))
-	if udevdata, err := ioutil.ReadFile(udevDataPath); err == nil {
+	if udevdata, err := os.ReadFile(udevDataPath); err == nil {
 		scanner := bufio.NewScanner(bytes.NewReader(udevdata))
 		for scanner.Scan() {
 			values := strings.Split(scanner.Text(), "=")
@@ -510,8 +509,8 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	// Try to get the serial from sysfs, look at the disk device (minor 0) directly
 	// because if it is a partition it is not going to contain any device information
 	devicePath := common.HostSysWithContext(ctx, fmt.Sprintf("dev/block/%d:0/device", major))
-	model, _ := ioutil.ReadFile(filepath.Join(devicePath, "model"))
-	serial, _ := ioutil.ReadFile(filepath.Join(devicePath, "serial"))
+	model, _ := os.ReadFile(filepath.Join(devicePath, "model"))
+	serial, _ := os.ReadFile(filepath.Join(devicePath, "serial"))
 	if len(model) > 0 && len(serial) > 0 {
 		return fmt.Sprintf("%s_%s", string(model), string(serial)), nil
 	}
@@ -526,7 +525,7 @@ func LabelWithContext(ctx context.Context, name string) (string, error) {
 		return "", nil
 	}
 
-	dmname, err := ioutil.ReadFile(dmname_filename)
+	dmname, err := os.ReadFile(dmname_filename)
 	if err != nil {
 		return "", err
 	}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"unsafe"
@@ -59,7 +59,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -54,7 +54,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}
@@ -111,7 +111,7 @@ func getUsersFromUtmp(utmpfile string) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -91,7 +91,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -411,13 +411,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		}
 		for _, file := range files {
 			// Get the name of the temperature you are reading
-			name, err := ioutil.ReadFile(filepath.Join(file, "type"))
+			name, err := os.ReadFile(filepath.Join(file, "type"))
 			if err != nil {
 				warns.Add(err)
 				continue
 			}
 			// Get the temperature reading
-			current, err := ioutil.ReadFile(filepath.Join(file, "temp"))
+			current, err := os.ReadFile(filepath.Join(file, "temp"))
 			if err != nil {
 				warns.Add(err)
 				continue
@@ -461,13 +461,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		// Get the label of the temperature you are reading
 		label := ""
 
-		if raw, _ = ioutil.ReadFile(basepath + "_label"); len(raw) != 0 {
+		if raw, _ = os.ReadFile(basepath + "_label"); len(raw) != 0 {
 			// Format the label from "Core 0" to "core_0"
 			label = strings.Join(strings.Split(strings.TrimSpace(strings.ToLower(string(raw))), " "), "_")
 		}
 
 		// Get the name of the temperature you are reading
-		if raw, err = ioutil.ReadFile(filepath.Join(directory, "name")); err != nil {
+		if raw, err = os.ReadFile(filepath.Join(directory, "name")); err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -479,7 +479,7 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		}
 
 		// Get the temperature reading
-		if raw, err = ioutil.ReadFile(file); err != nil {
+		if raw, err = os.ReadFile(file); err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -513,7 +513,7 @@ func optionalValueReadFromFile(filename string) float64 {
 		return 0
 	}
 
-	if raw, err = ioutil.ReadFile(filename); err != nil {
+	if raw, err = os.ReadFile(filename); err != nil {
 		return 0
 	}
 

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"unsafe"
@@ -65,7 +65,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -138,7 +138,7 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 
 // Find distribution name from /etc/release
 func parseReleaseFile() (string, error) {
-	b, err := ioutil.ReadFile("/etc/release")
+	b, err := os.ReadFile("/etc/release")
 	if err != nil {
 		return "", err
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -87,7 +86,7 @@ func (i FakeInvoke) Command(name string, arg ...string) ([]byte, error) {
 		fpath += "_" + i.Suffix
 	}
 	if PathExists(fpath) {
-		return ioutil.ReadFile(fpath)
+		return os.ReadFile(fpath)
 	}
 	return []byte{}, fmt.Errorf("could not find testdata: %s", fpath)
 }
@@ -100,7 +99,7 @@ var ErrNotImplementedError = errors.New("not implemented yet")
 
 // ReadFile reads contents from a file
 func ReadFile(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -5,7 +5,7 @@ package load
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -76,7 +76,7 @@ func Misc() (*MiscStat, error) {
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 	filename := common.HostProcWithContext(ctx, "stat")
-	out, err := ioutil.ReadFile(filename)
+	out, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func getProcsTotal(ctx context.Context) (int64, error) {
 
 func readLoadAvgFromFile(ctx context.Context) ([]string, error) {
 	loadavgFilename := common.HostProcWithContext(ctx, "loadavg")
-	line, err := ioutil.ReadFile(loadavgFilename)
+	line, err := os.ReadFile(loadavgFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -643,7 +642,7 @@ func (p *process) getUids(ctx context.Context) ([]int32, error) {
 func (p *process) fillFromStatus(ctx context.Context) error {
 	pid := p.Pid
 	statPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -784,7 +783,7 @@ func processInetWithContext(ctx context.Context, file string, kind netConnection
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +844,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -136,7 +135,7 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	statPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "stat")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return false, err
 	}
@@ -391,7 +390,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 			smapsPath = smapsRollupPath
 		}
 	}
-	contents, err := ioutil.ReadFile(smapsPath)
+	contents, err := os.ReadFile(smapsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +483,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 func (p *Process) EnvironWithContext(ctx context.Context) ([]string, error) {
 	environPath := common.HostProcWithContext(ctx, strconv.Itoa(int(p.Pid)), "environ")
 
-	environContent, err := ioutil.ReadFile(environPath)
+	environContent, err := os.ReadFile(environPath)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +667,7 @@ func (p *Process) fillFromExeWithContext(ctx context.Context) (string, error) {
 func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return "", err
 	}
@@ -682,7 +681,7 @@ func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error
 func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +704,7 @@ func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string
 func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, error) {
 	pid := p.Pid
 	ioPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "io")
-	ioline, err := ioutil.ReadFile(ioPath)
+	ioline, err := os.ReadFile(ioPath)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +740,7 @@ func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, e
 func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat, *MemoryInfoExStat, error) {
 	pid := p.Pid
 	memPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "statm")
-	contents, err := ioutil.ReadFile(memPath)
+	contents, err := os.ReadFile(memPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -802,7 +801,7 @@ func (p *Process) fillNameWithContext(ctx context.Context) error {
 func (p *Process) fillFromCommWithContext(ctx context.Context) error {
 	pid := p.Pid
 	statPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "comm")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -819,7 +818,7 @@ func (p *Process) fillFromStatus() error {
 func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 	pid := p.Pid
 	statPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -1026,7 +1025,7 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 		statPath = common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "task", strconv.Itoa(int(tid)), "stat")
 	}
 
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return 0, 0, nil, 0, 0, 0, nil, err
 	}

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -72,7 +72,7 @@ func Test_Process_splitProcStat_fromFile(t *testing.T) {
 		if _, err := os.Stat(statFile); err != nil {
 			continue
 		}
-		contents, err := ioutil.ReadFile(statFile)
+		contents, err := os.ReadFile(statFile)
 		assert.NoError(t, err)
 
 		pidStr := strconv.Itoa(int(pid))

--- a/process/process_solaris.go
+++ b/process/process_solaris.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -232,7 +231,7 @@ func (p *Process) fillFromPathAOutWithContext(ctx context.Context) (string, erro
 func (p *Process) fillFromExecnameWithContext(ctx context.Context) (string, error) {
 	pid := p.Pid
 	execNamePath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "execname")
-	exe, err := ioutil.ReadFile(execNamePath)
+	exe, err := os.ReadFile(execNamePath)
 	if err != nil {
 		return "", err
 	}
@@ -242,7 +241,7 @@ func (p *Process) fillFromExecnameWithContext(ctx context.Context) (string, erro
 func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +258,7 @@ func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error
 func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -571,7 +572,7 @@ func Test_Connections(t *testing.T) {
 		defer conn.Close()
 
 		serverEstablished <- struct{}{}
-		_, err = ioutil.ReadAll(conn)
+		_, err = io.ReadAll(conn)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
`ioutil` has been deprecated from 1.16. This PR replace ioutil by io and os.
