### PR TITLE
ci(lint): ensure io/ioutil replacement

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.17
+          cache: false
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Setup golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,21 @@
 issues:
   max-same-issues: 0
-  exclude-rules: 
-  - linters: 
-    - gosec
-    text: "G204"
-  - linters: 
-    - revive
-    text: "var-naming"
-  - linters: 
-    - revive
-    text: "exported"
-  - linters: 
-    - revive
-    text: "empty-block"
-  - linters: 
-    - revive
-    text: "unused-parameter"
+  exclude-rules:
+    - linters:
+        - gosec
+      text: "G204"
+    - linters:
+        - revive
+      text: "var-naming"
+    - linters:
+        - revive
+      text: "exported"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "unused-parameter"
 linters:
   enable:
     - asciicheck
@@ -26,6 +26,7 @@ linters:
     - gofmt
     - gofumpt
     - goimports
+    - gomodguard
     - gosec
     - gosimple
     - importas
@@ -46,10 +47,16 @@ linters:
     - structcheck
     - unused
     - varcheck
-
 linters-settings:
   gci:
     sections:
-    - standard
-    - default
-    - prefix(github.com/shirou)
+      - standard
+      - default
+      - prefix(github.com/shirou)
+  gomodguard:
+    blocked:
+      modules:
+        - io/ioutil:
+            recommandations:
+              - io
+              - os

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -60,7 +59,7 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 
 // Count number of processes based on the number of entries in /proc
 func numProcs(ctx context.Context) (uint64, error) {
-	dirs, err := ioutil.ReadDir("/proc")
+	dirs, err := os.ReadDir("/proc")
 	if err != nil {
 		return 0, err
 	}

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -3,7 +3,6 @@ package net
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestIOCountersByFileParsing(t *testing.T) {
 	// Prpare a temporary file, which will be read during the test
-	tmpfile, err := ioutil.TempFile("", "proc_dev_net")
+	tmpfile, err := os.CreateTemp("", "proc_dev_net")
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
@@ -195,7 +195,7 @@ func TestReverse(t *testing.T) {
 }
 
 func TestConntrackStatFileParsing(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "proc_net_stat_conntrack")
+	tmpfile, err := os.CreateTemp("", "proc_net_stat_conntrack")
 	defer os.Remove(tmpfile.Name())
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
 

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -58,7 +58,7 @@ func Test_Process_splitProcStat(t *testing.T) {
 }
 
 func Test_Process_splitProcStat_fromFile(t *testing.T) {
-	pids, err := ioutil.ReadDir("testdata/linux/")
+	pids, err := os.ReadDir("testdata/linux/")
 	if err != nil {
 		t.Error(err)
 	}
@@ -94,7 +94,7 @@ func Test_Process_splitProcStat_fromFile(t *testing.T) {
 }
 
 func Test_fillFromCommWithContext(t *testing.T) {
-	pids, err := ioutil.ReadDir("testdata/linux/")
+	pids, err := os.ReadDir("testdata/linux/")
 	if err != nil {
 		t.Error(err)
 	}
@@ -115,7 +115,7 @@ func Test_fillFromCommWithContext(t *testing.T) {
 }
 
 func Test_fillFromStatusWithContext(t *testing.T) {
-	pids, err := ioutil.ReadDir("testdata/linux/")
+	pids, err := os.ReadDir("testdata/linux/")
 	if err != nil {
 		t.Error(err)
 	}

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -153,7 +153,7 @@ func Benchmark_fillFromStatusWithContext(b *testing.B) {
 }
 
 func Test_fillFromTIDStatWithContext_lx_brandz(t *testing.T) {
-	pids, err := ioutil.ReadDir("testdata/lx_brandz/")
+	pids, err := os.ReadDir("testdata/lx_brandz/")
 	if err != nil {
 		t.Error(err)
 	}

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -6,7 +6,6 @@ package process
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -303,7 +302,7 @@ func Test_Process_Name(t *testing.T) {
 }
 
 func Test_Process_Long_Name_With_Spaces(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}
@@ -349,7 +348,7 @@ func Test_Process_Long_Name_With_Spaces(t *testing.T) {
 }
 
 func Test_Process_Long_Name(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}
@@ -406,7 +405,7 @@ func Test_Process_Name_Against_Python(t *testing.T) {
 		t.Skipf("psutil not found for %s: %s", py3Path, out)
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}
@@ -775,7 +774,7 @@ func Test_IsRunning(t *testing.T) {
 }
 
 func Test_Process_Environ(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}


### PR DESCRIPTION
This PR help golangci to ensure Io/outil is replaced by Io or os modules.

I noticed there was no warning for certain files which were using ioutil . It might worth extend the use of golangci on more goos and goarch?

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>