### PR TITLE
[host][darwin]: fix Users

### DIFF
--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -64,6 +64,9 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 		return ret, err
 	}
 
+	// Skip macOS utmpx header part
+	buf = buf[604:]
+
 	u := Utmpx{}
 	entrySize := int(unsafe.Sizeof(u))
 	count := len(buf) / entrySize

--- a/host/host_test.go
+++ b/host/host_test.go
@@ -89,6 +89,7 @@ func TestUsers(t *testing.T) {
 		if u == empty {
 			t.Errorf("Could not Users %v", v)
 		}
+		t.Log(u)
 	}
 }
 


### PR DESCRIPTION
perhaps related: #1510

`host.Users()` returns empty(not nil) on at least my Apple M2, 13.3.1. (Note: This mac is temporarily borrowed.)

I found macOS's `utmpx` file has some header. According to [this page](https://github.com/libyal/dtformats/blob/main/documentation/Utmp%20login%20records%20format.asciidoc), the header exists at least from 10.5.

I went through trial and error until I found the right values to skip header. So the `604` is is not created based on anything. I am looking for references to provide evidence of this. And hence it is not known if it will work in other macOS versions.
