### PR TITLE
fix(linux): validate cpu fields length before accessing index

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -309,7 +309,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 func parseStatLine(line string) (*TimesStat, error) {
 	fields := strings.Fields(line)
 
-	if len(fields) == 0 {
+	if len(fields) < 8 {
 		return nil, errors.New("stat does not contain cpu info")
 	}
 

--- a/load/load_windows.go
+++ b/load/load_windows.go
@@ -5,7 +5,6 @@ package load
 
 import (
 	"context"
-	"log"
 	"math"
 	"sync"
 	"time"
@@ -37,7 +36,6 @@ func loadAvgGoroutine(ctx context.Context) {
 
 	counter, err := common.ProcessorQueueLengthCounter()
 	if err != nil || counter == nil {
-		log.Printf("unexpected processor queue length counter error, %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
Two fixes in this one:
- validate the fields length before assuming we have everything. This is related to https://github.com/JanDeDobbeleer/oh-my-posh/issues/4397
- do not print things to stdout on Windows. This is related to https://github.com/JanDeDobbeleer/oh-my-posh/issues/2947