### PR TITLE
feat: use lsof for net_connections on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Some code is ported from Ohai. Many thanks.
 |users                 |x      |x        |x        |x       |x        |         |         |
 |pids                  |x      |x        |x        |x       |x        |         |         |
 |pid\_exists           |x      |x        |x        |x       |x        |         |         |
-|net\_connections      |x      |         |x        |x       |         |         |         |
+|net\_connections      |x      |x        |x        |x       |         |         |         |
 |net\_protocols        |x      |         |         |        |         |         |         |
 |net\_if\_addrs        |       |         |         |        |         |         |         |
 |net\_if\_stats        |       |         |         |        |         |         |         |

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -286,11 +286,11 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 }
 
 func (p *Process) ConnectionsWithContext(ctx context.Context) ([]net.ConnectionStat, error) {
-	return nil, common.ErrNotImplementedError
+	return net.ConnectionsPidWithContext(ctx, "all", p.Pid)
 }
 
 func (p *Process) ConnectionsMaxWithContext(ctx context.Context, max int) ([]net.ConnectionStat, error) {
-	return nil, common.ErrNotImplementedError
+	return net.ConnectionsPidMaxWithContext(ctx, "all", p.Pid, max)
 }
 
 func ProcessesWithContext(ctx context.Context) ([]*Process, error) {


### PR DESCRIPTION
Use net.ConnectionsPidWithContext on FreeBSD, similarly to how it is done on Darwin. This uses common.CallLsofWithContext underneath the hood, which will use lsof under the hood, if available.

Tested on FreeBSD 13.2-RELEASE