### PR TITLE
Revert "chore(deps): bump actions/labeler from 4.3.0 to 5.0.0"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts shirou/gopsutil#1559

[labeler configuration structure has been changed from v5](https://github.com/actions/labeler/issues/712). So we need to consider adapting these changes.

However, according to [this issue](https://github.com/actions/labeler/issues/715), there is a possibility that the structure of the configuration file will return in the future. Therefore, this PR reverts the upgrade now. I fully appreciate the work of the labeler.