### PR TITLE
[linux][disk]: fix Rdev cast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ build_test:  ## test only buildable
 	GOOS=linux GOARCH=loong64 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=linux GOARCH=riscv64 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=linux GOARCH=s390x go test ./... | $(BUILD_FAIL_PATTERN)
+	GOOS=linux GOARCH=mips go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd GOARCH=amd64 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd GOARCH=386 go test ./... | $(BUILD_FAIL_PATTERN)
 	GOOS=freebsd GOARCH=arm go test ./... | $(BUILD_FAIL_PATTERN)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -507,8 +507,8 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	if err := unix.Stat(name, &stat); err != nil {
 		return "", err
 	}
-	major := unix.Major(stat.Rdev)
-	minor := unix.Minor(stat.Rdev)
+	major := unix.Major(uint64(stat.Rdev))
+	minor := unix.Minor(uint64(stat.Rdev))
 
 	sserial, _ := udevData(ctx, major, minor, "E:ID_SERIAL")
 	if sserial != "" {
@@ -541,8 +541,8 @@ func LabelWithContext(ctx context.Context, name string) (string, error) {
 	if err := unix.Stat(common.HostDevWithContext(ctx, name), &stat); err != nil {
 		return "", err
 	}
-	major := unix.Major(stat.Rdev)
-	minor := unix.Minor(stat.Rdev)
+	major := unix.Major(uint64(stat.Rdev))
+	minor := unix.Minor(uint64(stat.Rdev))
 
 	label, err := udevData(ctx, major, minor, "E:ID_FS_LABEL")
 	if err != nil {


### PR DESCRIPTION
Add uint64 cast. perhaps this can fix #1574, but we need more information.

related: #1573