### PR TITLE
Windows, read all PIDs if there are more than 1024 PIDs.

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -253,7 +253,7 @@ func pidsWithContext(ctx context.Context) ([]int32, error) {
 		if err := windows.EnumProcesses(ps, &read); err != nil {
 			return nil, err
 		}
-		if uint32(len(ps)) == read { // ps buffer was too small to host every results, retry with a bigger one
+		if uint32(len(ps)) == read/dwordSize { // ps buffer was too small to host every results, retry with a bigger one
 			psSize += 1024
 			continue
 		}


### PR DESCRIPTION
Convert bytes read to number of uint32s that were read.