### PR TITLE
ensure host platform are files and have contents

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -229,47 +229,47 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 				version = contents[0]
 			}
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "neokylin-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "neokylin-release")) {
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "neokylin-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "redhat-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "redhat-release")) {
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "redhat-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "system-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "system-release")) {
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "system-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "gentoo-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "gentoo-release")) {
 		platform = "gentoo"
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "gentoo-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "SuSE-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "SuSE-release")) {
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "SuSE-release"))
 		if err == nil {
 			version = getSuseVersion(contents)
 			platform = getSusePlatform(contents)
 		}
 		// TODO: slackware detecion
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "arch-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "arch-release")) {
 		platform = "arch"
 		version = lsb.Release
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "alpine-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "alpine-release")) {
 		platform = "alpine"
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "alpine-release"))
 		if err == nil && len(contents) > 0 && contents[0] != "" {
 			version = contents[0]
 		}
-	} else if common.PathExists(common.HostEtcWithContext(ctx, "os-release")) {
+	} else if common.PathExistsWithContents(common.HostEtcWithContext(ctx, "os-release")) {
 		p, v, err := common.GetOSReleaseWithContext(ctx)
 		if err == nil {
 			platform = p

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -343,7 +343,7 @@ func PathExistsWithContents(filename string) bool {
 	if err != nil {
 		return false
 	}
-	return info.Size() > 4 // at least 4 bytes
+	return info.Size() > 4 && !info.IsDir() // at least 4 bytes
 }
 
 // GetEnvWithContext retrieves the environment variable key. If it does not exist it returns the default.


### PR DESCRIPTION
In a containerized deployment, it is common to mount several files from `/etc`. Within the container, those files will be created regardless if they exist on the host or not. In those instances, the existing code would erroneously return empty platform information.