### PR TITLE
use VERSION_ID from os-release

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -329,7 +329,7 @@ func GetOSReleaseWithContext(ctx context.Context) (platform string, version stri
 		switch field[0] {
 		case "ID": // use ID for lowercase
 			platform = trimQuotes(field[1])
-		case "VERSION":
+		case "VERSION_ID":
 			version = trimQuotes(field[1])
 		}
 	}


### PR DESCRIPTION
`VERSION_ID` is more appropriate for scripts and other usages, since `VERSION` can contain spaces and codenames

from `os-release` manpage:
```
VERSION=
           A string identifying the operating system version, excluding
           any OS name information, possibly including a release code
           name, and suitable for presentation to the user. This field
           is optional.

           Examples: "VERSION=17", "VERSION="17 (Beefy Miracle)"".

 VERSION_ID=
           A lower-case string (mostly numeric, no spaces or other
           characters outside of 0–9, a–z, ".", "_" and "-") identifying
           the operating system version, excluding any OS name
           information or release code name, and suitable for processing
           by scripts or usage in generated filenames. This field is
           optional.

           Examples: "VERSION_ID=17", "VERSION_ID=11.04".
```