### PR TITLE
memory: expose virtual totals / avail values on windows

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -80,6 +80,11 @@ type VirtualMemoryStat struct {
 	HugePagesSurp  uint64 `json:"hugePagesSurp"`
 	HugePageSize   uint64 `json:"hugePageSize"`
 	AnonHugePages  uint64 `json:"anonHugePages"`
+
+	// Windows specific numbers
+	// https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
+	VirtualTotal uint64 `json:"virtualTotal"`
+	VirtualAvail uint64 `json:"virtualAvail"`
 }
 
 type SwapMemoryStat struct {

--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -45,10 +45,12 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 	}
 
 	ret := &VirtualMemoryStat{
-		Total:       memInfo.ullTotalPhys,
-		Available:   memInfo.ullAvailPhys,
-		Free:        memInfo.ullAvailPhys,
-		UsedPercent: float64(memInfo.dwMemoryLoad),
+		Total:        memInfo.ullTotalPhys,
+		Available:    memInfo.ullAvailPhys,
+		Free:         memInfo.ullAvailPhys,
+		UsedPercent:  float64(memInfo.dwMemoryLoad),
+		VirtualTotal: memInfo.ullTotalVirtual,
+		VirtualAvail: memInfo.ullAvailVirtual,
 	}
 
 	ret.Used = ret.Total - ret.Available


### PR DESCRIPTION
There are 2 more memory values i'd like to use. They are there already, just not exposed by the module yet.

- https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex