### PR TITLE
Total Processes in `MiscStat` Corrected

### DIFF
--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -107,21 +107,13 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 
 	}
 
-	procsTotal, err := getProcsTotal(ctx)
+	procsTotal, err := common.NumProcsWithContext(ctx)
 	if err != nil {
 		return ret, err
 	}
 	ret.ProcsTotal = int(procsTotal)
 
 	return ret, nil
-}
-
-func getProcsTotal(ctx context.Context) (int64, error) {
-	values, err := readLoadAvgFromFile(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return strconv.ParseInt(strings.Split(values[3], "/")[1], 10, 64)
 }
 
 func readLoadAvgFromFile(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
The `ProcsTotal` in the `MiscStat` structure was very inaccurate. It was reading a value which is the total number of kernel scheduling entities. This includes both processes and threads significantly overcounting.

This instead uses an existing method already in common to count the number of processes via the /proc filesystem where any directory is a number. This should still be a single syscall to read that directory entry.

I don't see any existing automated test with this functionality so I did not add any but I did do my own manual testing by writing the following program:

```go
package main

import (
	"fmt"
	"github.com/shirou/gopsutil/v3/load"
)

func main() {
	stats, _ := load.Misc()
	fmt.Printf("Count: %v\n", stats.ProcsTotal)
}
```

With the previous code it was returning a value of over 1200. After the change the count was around 320 and matched `ps -A | wc -l`.

This fixes #1606.