### PR TITLE
Refresh boot time

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -69,6 +69,12 @@ func EnableBootTimeCache(enable bool) {
 	enableBootTimeCache = enable
 }
 
+// RefreshBootTimeCache manually refreshes the cached BootTime value.
+func RefreshBootTimeCache(ctx context.Context) error {
+	_, err := common.BootTimeWithContext(ctx, false)
+	return err
+}
+
 func Info() (*InfoStat, error) {
 	return InfoWithContext(context.Background())
 }

--- a/process/process.go
+++ b/process/process.go
@@ -178,6 +178,12 @@ func EnableBootTimeCache(enable bool) {
 	enableBootTimeCache = enable
 }
 
+// RefreshBootTimeCache manually refreshes the cached BootTime value.
+func RefreshBootTimeCache(ctx context.Context) error {
+	_, err := common.BootTimeWithContext(ctx, false)
+	return err
+}
+
 // Pids returns a slice of process ID list which are running now.
 func Pids() ([]int32, error) {
 	return PidsWithContext(context.Background())


### PR DESCRIPTION
This PR adds a function to `process` and `host` to manually refresh the cached boot time value. This is very helpful in scenarios where you are reading all the processes on the system at a given time, want the performance gains of using the boot time cache, but want to update the cached boot time when you read all the processes.