### PR TITLE
Increasing precision for virtual memory used percent on windows

### DIFF
--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -48,7 +48,7 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 		Total:       memInfo.ullTotalPhys,
 		Available:   memInfo.ullAvailPhys,
 		Free:        memInfo.ullAvailPhys,
-		UsedPercent: float64(memInfo.dwMemoryLoad),
+		UsedPercent: float64(memInfo.ullTotalPhys-memInfo.ullAvailPhys) / float64(memInfo.ullTotalPhys) * 100,
 	}
 
 	ret.Used = ret.Total - ret.Available


### PR DESCRIPTION
Hey! Nice library!!

I found that the `virtualMemory.UsedPercent` returned by windows is just a whole number and we lose some precision there. I computed it instead using `total - available / total * 100` so we can get the same precision we get on linux.

```
virtMemTest - Old 28.000000 : New 28.606437
virtMemTest - Old 28.000000 : New 28.594666
virtMemTest - Old 28.000000 : New 28.637374
```