### PR TITLE
[v4] Implements v4 for v4.24.0-beta

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -17,6 +17,18 @@ func skipIfNotImplementedErr(t *testing.T, err error) {
 	}
 }
 
+func TestHostID(t *testing.T) {
+	v, err := HostID()
+	skipIfNotImplementedErr(t, err)
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+	if v == "" {
+		t.Errorf("Could not get host id %v", v)
+	}
+	t.Log(v)
+}
+
 func TestInfo(t *testing.T) {
 	v, err := Info()
 	skipIfNotImplementedErr(t, err)

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -136,6 +136,14 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 }
 
 func PlatformInformationWithContext(ctx context.Context) (platform string, family string, version string, err error) {
+	platform, family, _, displayVersion, err := platformInformation(ctx)
+	if err != nil {
+		return "", "", "", err
+	}
+	return platform, family, displayVersion, nil
+}
+
+func platformInformation(ctx context.Context) (platform, family, version, displayVersion string, err error) {
 	// GetVersionEx lies on Windows 8.1 and returns as Windows 8 if we don't declare compatibility in manifest
 	// RtlGetVersion bypasses this lying layer and returns the true Windows version
 	// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-rtlgetversion
@@ -199,6 +207,14 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		copy((*[4]byte)(unsafe.Pointer(&UBR))[:], regBuf)
 	}
 
+	// Get DisplayVersion(ex: 23H2) as platformVersion
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`DisplayVersion`), nil, &valType, nil, &bufLen)
+	if err == nil {
+		regBuf := make([]uint16, bufLen/2+1)
+		err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`DisplayVersion`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+		displayVersion = windows.UTF16ToString(regBuf[:])
+	}
+
 	// PlatformFamily
 	switch osInfo.wProductType {
 	case 1:
@@ -214,7 +230,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		osInfo.dwMajorVersion, osInfo.dwMinorVersion, osInfo.dwBuildNumber, UBR,
 		osInfo.dwBuildNumber, UBR)
 
-	return platform, family, version, nil
+	return platform, family, version, displayVersion, nil
 }
 
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
@@ -228,7 +244,7 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 }
 
 func KernelVersionWithContext(ctx context.Context) (string, error) {
-	_, _, version, err := PlatformInformationWithContext(ctx)
+	_, _, version, _, err := platformInformation(ctx)
 	return version, err
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -103,10 +103,18 @@ type RlimitStat struct {
 }
 
 type IOCountersStat struct {
-	ReadCount  uint64 `json:"readCount"`
+	// ReadCount is a number of read I/O operations such as syscalls.
+	ReadCount uint64 `json:"readCount"`
+	// WriteCount is a number of read I/O operations such as syscalls.
 	WriteCount uint64 `json:"writeCount"`
-	ReadBytes  uint64 `json:"readBytes"`
+	// ReadBytes is a number of all I/O read in bytes. This includes disk I/O on Linux and Windows.
+	ReadBytes uint64 `json:"readBytes"`
+	// WriteBytes is a number of all I/O write in bytes. This includes disk I/O on Linux and Windows.
 	WriteBytes uint64 `json:"writeBytes"`
+	// DiskReadBytes is a number of disk I/O write in bytes. Currently only Linux has this value.
+	DiskReadBytes uint64 `json:"diskReadBytes"`
+	// DiskWriteBytes is a number of disk I/O read in bytes.  Currently only Linux has this value.
+	DiskWriteBytes uint64 `json:"diskWriteBytes"`
 }
 
 type NumCtxSwitchesStat struct {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -727,8 +727,12 @@ func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, e
 		case "syscw":
 			ret.WriteCount = t
 		case "read_bytes":
-			ret.ReadBytes = t
+			ret.DiskReadBytes = t
 		case "write_bytes":
+			ret.DiskWriteBytes = t
+		case "rchar":
+			ret.ReadBytes = t
+		case "wchar":
 			ret.WriteBytes = t
 		}
 	}


### PR DESCRIPTION
This PR introduce new release v4, discussed at https://github.com/shirou/gopsutil/discussions/1553.
This is a sub-PR. The main PR is https://github.com/shirou/gopsutil/pull/1628.

# Breaking Changes

- [host][windows] change `platformVersion` on PlatformInfo() from build version (ex: `10.0.22631.3447 Build 22631.3447`) to display version(ex: `23H2`). You can still use `kernelVersion` to get build version. #1503
