### PR TITLE
[process][openbsd]: add cwd on openbsd.

### DIFF
--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -68,7 +68,12 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 }
 
 func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
-	return "", common.ErrNotImplementedError
+	mib := []int32{CTLKern, KernProcCwd, p.Pid}
+	buf, _, err := common.CallSyscall(mib)
+	if err != nil {
+		return "", err
+	}
+	return common.ByteToString(buf), nil
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {

--- a/process/process_openbsd_386.go
+++ b/process/process_openbsd_386.go
@@ -14,6 +14,7 @@ const (
 	KernProcProc     = 8
 	KernProcPathname = 12
 	KernProcArgs     = 55
+	KernProcCwd      = 78
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )

--- a/process/process_openbsd_amd64.go
+++ b/process/process_openbsd_amd64.go
@@ -11,6 +11,7 @@ const (
 	KernProcProc     = 8
 	KernProcPathname = 12
 	KernProcArgs     = 55
+	KernProcCwd      = 78
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )

--- a/process/process_openbsd_arm.go
+++ b/process/process_openbsd_arm.go
@@ -14,6 +14,7 @@ const (
 	KernProcProc     = 8
 	KernProcPathname = 12
 	KernProcArgs     = 55
+	KernProcCwd      = 78
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )

--- a/process/process_openbsd_arm64.go
+++ b/process/process_openbsd_arm64.go
@@ -14,6 +14,7 @@ const (
 	KernProcProc     = 8
 	KernProcPathname = 12
 	KernProcArgs     = 55
+	KernProcCwd      = 78
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )

--- a/process/process_openbsd_riscv64.go
+++ b/process/process_openbsd_riscv64.go
@@ -14,6 +14,7 @@ const (
 	KernProcProc     = 8
 	KernProcPathname = 12
 	KernProcArgs     = 55
+	KernProcCwd      = 78
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )

--- a/process/types_openbsd.go
+++ b/process/types_openbsd.go
@@ -44,6 +44,7 @@ const (
 	KernProcProc     = 8  // only return procs
 	KernProcPathname = 12 // path to executable
 	KernProcArgs     = 55 // get/set arguments/proctitle
+	KernProcCwd      = 78 // get current working directory
 	KernProcArgv     = 1
 	KernProcEnv      = 3
 )


### PR DESCRIPTION
This PR fixes #1648.

environment:
- `go version go1.22.1 openbsd/amd64`
- `OpenBSD test.localdomain 7.5 GENERIC#79 amd64`
- VirtualBox 7.0 on Windows 11