### PR TITLE
Issue 1658: Fix for parsing error where 'day,' is ignored on AIX uptime check

### DIFF
--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -65,7 +65,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	var days uint64 = 0
 	var hours uint64 = 0
 	var minutes uint64 = 0
-	if ut[3] == "days," {
+	if ut[3] == "day," || ut[3] == "days," {
 		days, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Resolution for issue 1658 - where on AIX when the uptime is one day, the day parser fails.

This is fixed by parsing 'day,' as well as 'days,'.