### PR TITLE
Resolved Issue 1661 - AIX Runtime Panic in Host

### DIFF
--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -65,7 +65,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	var days uint64 = 0
 	var hours uint64 = 0
 	var minutes uint64 = 0
-	if ut[3] == "days," {
+	if ut[3] == "day," || ut[3] == "days," {
 		days, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0, err

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -65,14 +65,6 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	// Initialise variables
 	var days, hours, mins uint64
 
-	// Check if days are specified and parse them
-	if ut[3] == "day," || ut[3] == "days," {
-		days, err = strconv.ParseUint(ut[2], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-	}
-
 	switch {
 	case ut[3] == "day," || ut[3] == "days,":
 		days, err = strconv.ParseUint(ut[2], 10, 64)

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -52,6 +52,7 @@ func BootTimeWithContext(ctx context.Context) (btime uint64, err error) {
 // 07:43PM   up 5 hrs,  1 user,  load average: 3.27, 2.91, 2.72
 // 11:18:23  up 83 days, 18:29,  4 users,  load average: 0.16, 0.03, 0.01
 // 08:47PM   up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17
+// 01:16AM   up 4 days, 29 mins,  1 user,  load average: 2.29, 2.31, 2.21
 func UptimeWithContext(ctx context.Context) (uint64, error) {
 	out, err := invoke.CommandWithContext(ctx, "uptime")
 	if err != nil {
@@ -74,9 +75,18 @@ func parseUptime(uptime string) uint64 {
 		}
 
 		// day provided along with a single hour or hours
-		// ie: up 2 days, 20 hrs
+		// ie: up 2 days, 20 hrs,
 		if ut[5] == "hr," || ut[5] == "hrs," {
 			hours, err = strconv.ParseUint(ut[4], 10, 64)
+			if err != nil {
+				return 0
+			}
+		}
+
+		// mins provided along with a single min or mins
+		// ie: up 4 days, 29 mins,
+		if ut[5] == "min," || ut[5] == "mins," {
+			mins, err = strconv.ParseUint(ut[4], 10, 64)
 			if err != nil {
 				return 0
 			}

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -78,11 +78,13 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 			return 0, fmt.Errorf("expected 'hours:minutes,' format but got '%s'", ut[4])
 		}
 
+		// Parse hours
 		hours, err = strconv.ParseUint(hm[0], 10, 64)
 		if err != nil {
 			return 0, err
 		}
 
+		// Remove trailing comma from minutes and parse
 		minutes, err = strconv.ParseUint(strings.Replace(hm[1], ",", "", -1), 10, 64)
 		if err != nil {
 			return 0, err

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -65,6 +65,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	var days uint64 = 0
 	var hours uint64 = 0
 	var minutes uint64 = 0
+
 	if ut[3] == "day," || ut[3] == "days," {
 		days, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
@@ -73,14 +74,20 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 
 		// Split field 4 into hours and minutes
 		hm := strings.Split(ut[4], ":")
+		if len(hm) < 2 {
+			return 0, fmt.Errorf("expected 'hours:minutes,' format but got '%s'", ut[4])
+		}
+
 		hours, err = strconv.ParseUint(hm[0], 10, 64)
 		if err != nil {
 			return 0, err
 		}
+
 		minutes, err = strconv.ParseUint(strings.Replace(hm[1], ",", "", -1), 10, 64)
 		if err != nil {
 			return 0, err
 		}
+
 	} else if ut[3] == "hr," || ut[3] == "hrs," {
 		hours, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -114,10 +114,8 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 		}
 	}
 
-	total_time := (days * 24 * 60) + (hours * 60) + mins
-
 	// Calculate total time in minutes
-	log.Println("days / hrs / mins ", days, hours, mins, total_time)
+	total_time := (days * 24 * 60) + (hours * 60) + mins
 
 	return total_time, nil
 }

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -63,7 +63,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	ut := strings.Fields(string(out[:]))
 
 	// Initialise variables
-	var days, hours, minutes uint64
+	var days, hours, mins uint64
 
 	// Check if days are specified and parse them
 	if ut[3] == "day," || ut[3] == "days," {
@@ -73,39 +73,53 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 		}
 	}
 
-	// Identify and parse hours and minutes based on the format present
 	switch {
-	case ut[4] == "hrs," || ut[4] == "hr,":
-		// Only hours are given, and they are placed in ut[4]
-		hours, err = strconv.ParseUint(ut[2], 10, 64)
+	case ut[3] == "day," || ut[3] == "days,":
+		days, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0, err
 		}
-	case strings.Contains(ut[4], ":"):
-		// Hours and minutes are specified in the format "hours:minutes"
-		hm := strings.Split(ut[4], ":")
-		hours, err = strconv.ParseUint(hm[0], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		minutes, err = strconv.ParseUint(strings.Trim(hm[1], ","), 10, 64)
-		if err != nil {
-			return 0, err
-		}
-	default:
-		// No explicit hours or "hours:minutes" format after days, check if minutes are given directly
-		if ut[3] == "mins," {
-			minutes, err = strconv.ParseUint(ut[2], 10, 64)
+
+		// day provided along with a single hour or hours
+		// ie: up 2 days, 20 hrs
+		if ut[5] == "hr," || ut[5] == "hrs," {
+			hours, err = strconv.ParseUint(ut[4], 10, 64)
 			if err != nil {
 				return 0, err
 			}
 		}
+
+		// alternatively day provided with hh:mm
+		// ie: up 83 days, 18:29
+		if strings.Contains(ut[4], ":") {
+			hm := strings.Split(ut[4], ":")
+			hours, err = strconv.ParseUint(hm[0], 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			mins, err = strconv.ParseUint(strings.Trim(hm[1], ","), 10, 64)
+			if err != nil {
+				return 0, err
+			}
+		}
+	case ut[3] == "hr," || ut[3] == "hrs,":
+		hours, err = strconv.ParseUint(ut[2], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+	case ut[3] == "mins," || ut[3] == "mins,":
+		mins, err = strconv.ParseUint(ut[2], 10, 64)
+		if err != nil {
+			return 0, err
+		}
 	}
 
-	// Calculate total time in minutes
-	totalTime := (days * 24 * 60) + (hours * 60) + minutes
+	total_time := (days * 24 * 60) + (hours * 60) + mins
 
-	return totalTime, nil
+	// Calculate total time in minutes
+	log.Println("days / hrs / mins ", days, hours, mins, total_time)
+
+	return total_time, nil
 }
 
 // This is a weak implementation due to the limitations on retrieving this data in AIX

--- a/host/host_aix_test.go
+++ b/host/host_aix_test.go
@@ -12,11 +12,11 @@ func TestParseUptimeValidInput(t *testing.T) {
 		input    string
 		expected uint64
 	}{
-		{"11:54AM   up 13 mins,  1 user,  load average: 2.78, 2.62, 1.79", 10},
-		{"12:41PM   up 1 hr,  1 user,  load average: 2.47, 2.85, 2.83", 180},
-		{"07:43PM   up 5 hrs,  1 user,  load average: 3.27, 2.91, 2.72", 2},
-		{"11:18:23  up 83 days, 18:29,  4 users,  load average: 0.16, 0.03, 0.01", 2},
-		{"08:47PM   up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17", 2},
+		{"11:54AM   up 13 mins,  1 user,  load average: 2.78, 2.62, 1.79", 13},
+		{"12:41PM   up 1 hr,  1 user,  load average: 2.47, 2.85, 2.83", 60},
+		{"07:43PM   up 5 hrs,  1 user,  load average: 3.27, 2.91, 2.72", 300},
+		{"11:18:23  up 83 days, 18:29,  4 users,  load average: 0.16, 0.03, 0.01", 120629},
+		{"08:47PM   up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17", 4080},
 	}
 	for _, tc := range testCases {
 		got := parseUptime(tc.input)

--- a/host/host_aix_test.go
+++ b/host/host_aix_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix
+
+package host
+
+import (
+	"testing"
+)
+
+func TestParseUptimeValidInput(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected uint64
+	}{
+		{"11:54AM   up 13 mins,  1 user,  load average: 2.78, 2.62, 1.79", 10},
+		{"12:41PM   up 1 hr,  1 user,  load average: 2.47, 2.85, 2.83", 180},
+		{"07:43PM   up 5 hrs,  1 user,  load average: 3.27, 2.91, 2.72", 2},
+		{"11:18:23  up 83 days, 18:29,  4 users,  load average: 0.16, 0.03, 0.01", 2},
+		{"08:47PM   up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17", 2},
+	}
+	for _, tc := range testCases {
+		got := parseUptime(tc.input)
+		if got != tc.expected {
+			t.Errorf("parseUptime(%q) = %v, want %v", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestParseUptimeInvalidInput(t *testing.T) {
+	testCases := []string{
+		"",    // blank
+		"2x",  // invalid string
+		"150", // integer
+	}
+
+	for _, tc := range testCases {
+		got := parseUptime(tc)
+		if got > 0 {
+			t.Errorf("parseUptime(%q) expected zero to be returned, received %v", tc, got)
+		}
+	}
+}

--- a/host/host_aix_test.go
+++ b/host/host_aix_test.go
@@ -17,6 +17,7 @@ func TestParseUptimeValidInput(t *testing.T) {
 		{"07:43PM   up 5 hrs,  1 user,  load average: 3.27, 2.91, 2.72", 300},
 		{"11:18:23  up 83 days, 18:29,  4 users,  load average: 0.16, 0.03, 0.01", 120629},
 		{"08:47PM   up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17", 4080},
+		{"01:16AM   up 4 days, 29 mins,  1 user,  load average: 2.29, 2.31, 2.21", 5789},
 	}
 	for _, tc := range testCases {
 		got := parseUptime(tc.input)


### PR DESCRIPTION
Resolved an issue on AIX where a software panic was caused at 0 minutes on the hour when uptime was called.

When uptime is called at 00 minutes it shows as this:

`08:47PM up 2 days, 20 hrs, 1 user, load average: 2.47, 2.17, 2.17`

At 20:21 it shows as this:

`08:47PM up 2 days, 20:21, 1 user, load average: 2.47, 2.17, 2.17`

I've added logic to parse this new case, code now passes all given examples (tried to add some tests, not sure how you want to mock the command line use, would be happy to add with an example).