### PR TITLE
fix: remove macos11 and add ubuntu-24.04 on GitHub runner list.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
-        os: [ubuntu-22.04, ubuntu-20.04, windows-2022, windows-2019, macos-11, macos-12, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04, windows-2022, windows-2019, macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go


### PR DESCRIPTION
[macos-11 has been deprecated](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/). This PR fixes it. And also even if still beta, add ubuntu-2024.02.

