### PR TITLE
[windows][mem]: change to use Performance Counter on SwapMemory.

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"os/exec"
@@ -462,4 +463,12 @@ func getSysctrlEnv(env []string) []string {
 		env = append(env, "LC_ALL=C")
 	}
 	return env
+}
+
+// Round places rounds the number 'val' to 'n' decimal places
+func Round(val float64, n int) float64 {
+	// Calculate the power of 10 to the n
+	pow10 := math.Pow(10, float64(n))
+	// Multiply the value by pow10, round it, then divide it by pow10
+	return math.Round(val*pow10) / pow10
 }

--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -77,26 +77,40 @@ func SwapMemory() (*SwapMemoryStat, error) {
 }
 
 func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
+	// Use the performance counter to get the swap usage percentage
+	counter, err := common.NewWin32PerformanceCounter("swap_percentage", `\Paging File(_Total)\% Usage`)
+	if err != nil {
+		return nil, err
+	}
+	usedPercent, err := counter.GetValue()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get total memory from performance information
 	var perfInfo performanceInformation
 	perfInfo.cb = uint32(unsafe.Sizeof(perfInfo))
 	mem, _, _ := procGetPerformanceInfo.Call(uintptr(unsafe.Pointer(&perfInfo)), uintptr(perfInfo.cb))
 	if mem == 0 {
 		return nil, windows.GetLastError()
 	}
-	tot := perfInfo.commitLimit * perfInfo.pageSize
-	used := perfInfo.commitTotal * perfInfo.pageSize
-	free := tot - used
-	var usedPercent float64
-	if tot == 0 {
-		usedPercent = 0
+	totalPhys := perfInfo.physicalTotal * perfInfo.pageSize
+	totalSys := perfInfo.commitLimit * perfInfo.pageSize
+	total := totalSys - totalPhys
+
+	var used uint64
+	if total > 0 {
+		used = uint64(0.01 * usedPercent * float64(total))
 	} else {
-		usedPercent = float64(used) / float64(tot) * 100
+		usedPercent = 0.0
+		used = 0
 	}
+
 	ret := &SwapMemoryStat{
-		Total:       tot,
+		Total:       total,
 		Used:        used,
-		Free:        free,
-		UsedPercent: usedPercent,
+		Free:        total - used,
+		UsedPercent: common.Round(usedPercent, 1),
 	}
 
 	return ret, nil


### PR DESCRIPTION
Fixes: #1511

SwapMemory on windows was incorrect. This PR change `SwapMemory` to adjust [psutil implementation](https://github.com/giampaolo/psutil/blob/c034e6692cf736b5e87d14418a8153bb03f6cf42/psutil/_pswindows.py#L250-L273). It is a method of calculating the actual value by using the `Paging File(_Total)% Usage` from the `Performance Counter` to determine the value.

Note: This PR will significantly change the value of `SwapMemory` on windows.

- psutil
```
PS gopsutil\mem> python3 -c "import psutil; print(psutil.swap_memory())"
sswap(total=15569256448, used=119250944, free=15450005504, percent=0.8, sin=0, sout=0)
```

- Before
```
PS gopsutil\mem> go test -run TestSwapMemory -v
=== RUN   TestSwapMemory
    mem_test.go:81: {"total":32110739456,"used":17000914944,"free":15109824512,"usedPercent":52.944638560241316,"sin":0,"sout":0,"pgIn":0,"pgOut":0,"pgFault":0,"pgMajFault":0}
```
- After
```
PS gopsutil\mem> go test -run TestSwapMemory -v
=== RUN   TestSwapMemory
    mem_test.go:81: {"total":15569256448,"used":119250944,"free":15450005504,"usedPercent":0.8,"sin":0,"sout":0,"pgIn":0,"pgOut":0,"pgFault":0,"pgMajFault":0}
```