### PR TITLE
Fix parsing of /proc/pid/smaps when path is empty

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -400,7 +400,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 	getBlock := func(firstLine []string, block []string) (MemoryMapsStat, error) {
 		m := MemoryMapsStat{}
 		if len(firstLine) >= 6 {
-			m.Path = firstLine[5]
+			m.Path = strings.Join(firstLine[5:], " ")
 		}
 
 		for _, line := range block {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -399,7 +399,9 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 	// function of parsing a block
 	getBlock := func(firstLine []string, block []string) (MemoryMapsStat, error) {
 		m := MemoryMapsStat{}
-		m.Path = firstLine[len(firstLine)-1]
+		if len(firstLine) >= 6 {
+			m.Path = firstLine[5]
+		}
 
 		for _, line := range block {
 			if strings.Contains(line, "VmFlags") {

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitProcStat(t *testing.T) {
@@ -173,4 +174,70 @@ func TestFillFromTIDStatWithContext_lx_brandz(t *testing.T) {
 		}
 		assert.Equal(t, float64(0), cpuTimes.Iowait)
 	}
+}
+
+func TestProcessMemoryMaps(t *testing.T) {
+	t.Setenv("HOST_PROC", "testdata/linux")
+	pid := 1
+	p, err := NewProcess(int32(pid))
+	require.NoError(t, err)
+	maps, err := p.MemoryMaps(false)
+	require.NoError(t, err)
+
+	expected := &[]MemoryMapsStat{
+		{
+			"[vvar]",
+			0,
+			1,
+			0,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8,
+			9,
+		},
+		{
+			"",
+			0,
+			1,
+			2,
+			3,
+			4,
+			0,
+			6,
+			7,
+			8,
+			9,
+		},
+		{
+			"[vdso]",
+			0,
+			1,
+			2,
+			3,
+			4,
+			5,
+			0,
+			7,
+			8,
+			9,
+		},
+		{
+			"/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
+			0,
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			0,
+			9,
+		},
+	}
+
+	require.Equal(t, expected, maps)
 }

--- a/process/testdata/linux/1/smaps
+++ b/process/testdata/linux/1/smaps
@@ -1,0 +1,44 @@
+ffffb5ecc000-ffffb5ece000 r--p 00000000 00:00 0        [vvar]
+Rss:                   0 kB
+KernelPageSize:        4 kB
+Size:                  1 kB
+Shared_Clean:          3 kB
+Shared_Dirty:          4 kB
+Private_Clean:         5 kB
+Private_Dirty:         6 kB
+Referenced:            7 kB
+Anonymous:             8 kB
+Swap:                  9 kB
+ffffb5eca000-ffffb5ecc000 rw-p 00000000 00:00 0
+Rss:                   0 kB
+Size:                  1 kB
+Pss:                   2 kB
+Shared_Clean:          3 kB
+Shared_Dirty:          4 kB
+Private_Dirty:         6 kB
+LazyFree:              0 kB
+Referenced:            7 kB
+Anonymous:             8 kB
+Swap:                  9 kB
+ffffb5ece000-ffffb5ecf000 r-xp 00000000 00:00 0        [vdso]
+Rss:                   0 kB
+Size:                  1 kB
+Pss:                   2 kB
+Shared_Clean:          3 kB
+Shared_Dirty:          4 kB
+Private_Clean:         5 kB
+Private_Hugetlb:       0 kB
+Referenced:            7 kB
+Anonymous:             8 kB
+Swap:                  9 kB
+ffffb5ecf000-ffffb5ed1000 r--p 0002a000 00:3d 2238525  /usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
+Rss:                   0 kB
+Size:                  1 kB
+Pss:                   2 kB
+Shared_Clean:          3 kB
+Shared_Dirty:          4 kB
+Private_Clean:         5 kB
+Private_Dirty:         6 kB
+Referenced:            7 kB
+THPeligible:           0
+Swap:                  9 kB


### PR DESCRIPTION
As per the [documentation](https://www.kernel.org/doc/html/latest/filesystems/proc.html) of `/proc`, the path in `/proc/<pid>/maps` and `/proc/<pid>/smaps` is the 6th field of the line, and can be empty:

> The “pathname” shows the name associated file for this mapping. [...] if empty, the mapping is anonymous.

Rather than using the last field returned by `strings.Field`, using the 6th element of the slice if it exists is more correct, as it handles properly the case where the path is empty.

This PR also adds a test with a fake `smaps` file to ensure parsing is correct.