### PR TITLE
Fix panic on OpenBSD and FreeBSD systems if KinfoProc size has an unexpected size

### DIFF
--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -6,6 +6,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -329,7 +330,7 @@ func (p *Process) getKProc() (*KinfoProc, error) {
 		return nil, err
 	}
 	if length != sizeOfKinfoProc {
-		return nil, err
+		return nil, errors.New("unexpected size of KinfoProc")
 	}
 
 	k, err := parseKinfoProc(buf)

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -343,7 +344,7 @@ func (p *Process) getKProc() (*KinfoProc, error) {
 		return nil, err
 	}
 	if length != sizeOfKinfoProc {
-		return nil, err
+		return nil, errors.New("unexpected size of KinfoProc")
 	}
 
 	k, err := parseKinfoProc(buf)


### PR DESCRIPTION
Hello!

We observed the below panic in our application:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x714230]

goroutine 8 [running]:
github.com/shirou/gopsutil/process.(*Process).NameWithContext(0xc0000d0a80, {0xcb9678, 0x11e8860})
        /usr/local/stork/tools/golang/gopath/pkg/mod/github.com/shirou/gopsutil@v3.21.11+incompatible/process/process_openbsd.go:52 +0x30
github.com/shirou/gopsutil/process.(*Process).Name(...)
        /usr/local/stork/tools/golang/gopath/pkg/mod/github.com/shirou/gopsutil@v3.21.11+incompatible/process/process.go:347
isc.org/stork/agent.(*processWrapper).GetName(0xc0003f2e70?)
```

The application was running on the OpenBSD system.

The line where the panic occurs is `process/process_freebsd.go#L49` and `process/process_openbsd.go#L53`:

```go
name := common.IntToString(k.Comm[:])
```

Access to the' k's member is the only thing that can cause the `nil pointer dereference` error. It panics if `k` is nil.

`k` is instantiated a few lines above:

```go
k, err := p.getKProc()
if err != nil {
	return "", err
}
name := common.IntToString(k.Comm[:])
```

The `p.getKProc()` is system-specific. Its implementation for the FreeBSD (`process/process_freebsd.go#L325`) and OpenBSD (`process/process_openbsd.go#L341`) systems includes a bug.

```go
	buf, length, err := common.CallSyscall(mib)
	if err != nil {
		return nil, err
	}
	if length != sizeOfKinfoProc {
		return nil, err
	}
```

If the `common.CallSyscall(mib)` function returns an empty buffer without any error or the buffer has an unexpected length, the `getKProc` returns two `nil`s (the first `nil` is provided explicitly, and the `err` is `nil`).

Unfortunately, the `NameWithContext` expects that the first value is not `nil` when the `err` is `nil`. The code panics because the above case is not handled.

The problem affects only OpenBSD and FreeBSD systems. Darwin (MacOS)-specific implementation doesn't have this bug.

This pull request solves the problem by returning a non-nil error if the returned buffer has an unexpected length.

Regards!