### PR TITLE
fix golangcilint errors, ignore gosec G115

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,19 +3,19 @@ issues:
   exclude-rules:
     - linters:
         - gosec
-      text: "G204"
+      text: G115
     - linters:
         - revive
-      text: "var-naming"
+      text: var-naming
     - linters:
         - revive
-      text: "exported"
+      text: exported
     - linters:
         - revive
-      text: "empty-block"
+      text: empty-block
     - linters:
         - revive
-      text: "unused-parameter"
+      text: unused-parameter
 linters:
   enable:
     - asciicheck
@@ -30,7 +30,6 @@ linters:
     - gosec
     - gosimple
     - importas
-    - megacheck
     - misspell
     - nakedret
     - nolintlint
@@ -39,14 +38,11 @@ linters:
     - typecheck
     - unparam
   disable:
-    - deadcode
     - errcheck
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
 linters-settings:
   gci:
     sections:

--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"github.com/tklauser/go-sysconf"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 var (
@@ -136,7 +137,7 @@ func parseDmesgBoot(fileName string) (InfoStat, int, error) {
 			c.Model = matches[4]
 			t, err := strconv.ParseInt(matches[5], 10, 32)
 			if err != nil {
-				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU stepping information from %q: %v", line, err)
+				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU stepping information from %q: %w", line, err)
 			}
 			c.Stepping = int32(t)
 		} else if matches := featuresMatch.FindStringSubmatch(line); matches != nil {
@@ -150,12 +151,12 @@ func parseDmesgBoot(fileName string) (InfoStat, int, error) {
 		} else if matches := cpuCores.FindStringSubmatch(line); matches != nil {
 			t, err := strconv.ParseInt(matches[1], 10, 32)
 			if err != nil {
-				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU Nums from %q: %v", line, err)
+				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU Nums from %q: %w", line, err)
 			}
 			cpuNum = int(t)
 			t2, err := strconv.ParseInt(matches[2], 10, 32)
 			if err != nil {
-				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU cores from %q: %v", line, err)
+				return c, 0, fmt.Errorf("unable to parse FreeBSD CPU cores from %q: %w", line, err)
 			}
 			c.Cores = int32(t2)
 		}

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -395,7 +395,7 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 			for _, line := range lines {
 				line = strings.ToLower(line)
 				if strings.HasPrefix(line, "processor") {
-					_, err = strconv.Atoi(strings.TrimSpace(line[strings.IndexByte(line, ':')+1:]))
+					_, err = strconv.ParseInt(strings.TrimSpace(line[strings.IndexByte(line, ':')+1:]), 10, 32)
 					if err == nil {
 						ret++
 					}
@@ -464,11 +464,11 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 		}
 		fields[0] = strings.TrimSpace(fields[0])
 		if fields[0] == "physical id" || fields[0] == "cpu cores" {
-			val, err := strconv.Atoi(strings.TrimSpace(fields[1]))
+			val, err := strconv.ParseInt(strings.TrimSpace(fields[1]), 10, 32)
 			if err != nil {
 				continue
 			}
-			currentInfo[fields[0]] = val
+			currentInfo[fields[0]] = int(val)
 		}
 	}
 	ret := 0

--- a/cpu/cpu_netbsd.go
+++ b/cpu/cpu_netbsd.go
@@ -9,9 +9,10 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"github.com/tklauser/go-sysconf"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 const (

--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -136,7 +136,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 					return nil, err
 				}
 			case `%Used`:
-				val, err := strconv.Atoi(strings.Replace(fs[i], "%", "", -1))
+				val, err := strconv.ParseInt(strings.Replace(fs[i], "%", "", -1), 10, 32)
 				if err != nil {
 					return nil, err
 				}
@@ -152,7 +152,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 					return nil, err
 				}
 			case `%Iused`:
-				val, err := strconv.Atoi(strings.Replace(fs[i], "%", "", -1))
+				val, err := strconv.ParseInt(strings.Replace(fs[i], "%", "", -1), 10, 32)
 				if err != nil {
 					return nil, err
 				}

--- a/disk/disk_netbsd.go
+++ b/disk/disk_netbsd.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 const (

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"unsafe"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/shirou/gopsutil/v4/internal/common"
 	"github.com/shirou/gopsutil/v4/process"
-	"golang.org/x/sys/unix"
 )
 
 const (

--- a/host/host_netbsd.go
+++ b/host/host_netbsd.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func HostIDWithContext(ctx context.Context) (string, error) {

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -181,7 +181,7 @@ func platformInformation(ctx context.Context) (platform, family, version, displa
 			err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`CurrentBuildNumber`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
 			if err == nil {
 				buildNumberStr := windows.UTF16ToString(regBuf[:])
-				if buildNumber, err := strconv.Atoi(buildNumberStr); err == nil && buildNumber >= 22000 {
+				if buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 32); err == nil && buildNumber >= 22000 {
 					platform = strings.Replace(platform, "Windows 10", "Windows 11", 1)
 				}
 			}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -154,7 +154,7 @@ func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 	var ret []string
 
 	r := bufio.NewReader(f)
-	for i := 0; i < n+int(offset) || n < 0; i++ {
+	for i := uint(0); i < uint(n)+offset || n < 0; i++ {
 		line, err := r.ReadString('\n')
 		if err != nil {
 			if err == io.EOF && len(line) > 0 {
@@ -162,7 +162,7 @@ func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 			}
 			break
 		}
-		if i < int(offset) {
+		if i < offset {
 			continue
 		}
 		ret = append(ret, strings.Trim(line, "\n"))

--- a/mem/mem_freebsd.go
+++ b/mem/mem_freebsd.go
@@ -8,8 +8,9 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func VirtualMemory() (*VirtualMemoryStat, error) {
@@ -85,7 +86,6 @@ func SwapMemory() (*SwapMemoryStat, error) {
 }
 
 // Constants from vm/vm_param.h
-// nolint: golint
 const (
 	XSWDEV_VERSION11 = 1
 	XSWDEV_VERSION   = 2

--- a/net/net_aix.go
+++ b/net/net_aix.go
@@ -117,7 +117,7 @@ func parseNetstatAddr(local string, remote string, family uint32) (laddr Addr, r
 				return Addr{}, fmt.Errorf("unknown family, %d", family)
 			}
 		}
-		lport, err := strconv.Atoi(port)
+		lport, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			return Addr{}, err
 		}

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -143,8 +143,8 @@ func newMapInterfaceNameUsage(ifaces []netstatInterface) mapInterfaceNameUsage {
 	return output
 }
 
-func (min mapInterfaceNameUsage) isTruncated() bool {
-	for _, usage := range min {
+func (mapi mapInterfaceNameUsage) isTruncated() bool {
+	for _, usage := range mapi {
 		if usage > 1 {
 			return true
 		}
@@ -152,9 +152,9 @@ func (min mapInterfaceNameUsage) isTruncated() bool {
 	return false
 }
 
-func (min mapInterfaceNameUsage) notTruncated() []string {
+func (mapi mapInterfaceNameUsage) notTruncated() []string {
 	output := make([]string, 0)
-	for ifaceName, usage := range min {
+	for ifaceName, usage := range mapi {
 		if usage == 1 {
 			output = append(output, ifaceName)
 		}
@@ -247,7 +247,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		}
 	}
 
-	if pernic == false {
+	if !pernic {
 		return getIOCountersAll(ret)
 	}
 	return ret, nil

--- a/net/net_freebsd.go
+++ b/net/net_freebsd.go
@@ -83,7 +83,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		ret = append(ret, n)
 	}
 
-	if pernic == false {
+	if !pernic {
 		return getIOCountersAll(ret)
 	}
 
@@ -96,7 +96,7 @@ func IOCountersByFile(pernic bool, filename string) ([]IOCountersStat, error) {
 }
 
 func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename string) ([]IOCountersStat, error) {
-	return IOCounters(pernic)
+	return IOCountersWithContext(ctx, pernic)
 }
 
 func FilterCounters() ([]FilterStat, error) {

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -573,7 +573,7 @@ func getProcInodes(root string, pid int32, maxConn int) (map[string][]inodeMap, 
 		if !ok {
 			ret[inode] = make([]inodeMap, 0)
 		}
-		fd, err := strconv.Atoi(dirEntry.Name())
+		fd, err := strconv.ParseInt(dirEntry.Name(), 10, 32)
 		if err != nil {
 			continue
 		}
@@ -858,7 +858,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 		if len(tokens) < 6 {
 			continue
 		}
-		st, err := strconv.Atoi(tokens[4])
+		st, err := strconv.ParseInt(tokens[4], 10, 32)
 		if err != nil {
 			return nil, err
 		}

--- a/net/net_linux_test.go
+++ b/net/net_linux_test.go
@@ -52,27 +52,27 @@ func TestIOCountersByFileParsing(t *testing.T) {
 		assert.NotEmpty(t, counters)
 		assert.Equal(t, 2, len(counters))
 		assert.Equal(t, interface0, counters[0].Name)
-		assert.Equal(t, 1, int(counters[0].BytesRecv))
-		assert.Equal(t, 2, int(counters[0].PacketsRecv))
-		assert.Equal(t, 3, int(counters[0].Errin))
-		assert.Equal(t, 4, int(counters[0].Dropin))
-		assert.Equal(t, 5, int(counters[0].Fifoin))
-		assert.Equal(t, 9, int(counters[0].BytesSent))
-		assert.Equal(t, 10, int(counters[0].PacketsSent))
-		assert.Equal(t, 11, int(counters[0].Errout))
-		assert.Equal(t, 12, int(counters[0].Dropout))
-		assert.Equal(t, 13, int(counters[0].Fifoout))
+		assert.Equal(t, uint64(1), counters[0].BytesRecv)
+		assert.Equal(t, uint64(2), counters[0].PacketsRecv)
+		assert.Equal(t, uint64(3), counters[0].Errin)
+		assert.Equal(t, uint64(4), counters[0].Dropin)
+		assert.Equal(t, uint64(5), counters[0].Fifoin)
+		assert.Equal(t, uint64(9), counters[0].BytesSent)
+		assert.Equal(t, uint64(10), counters[0].PacketsSent)
+		assert.Equal(t, uint64(11), counters[0].Errout)
+		assert.Equal(t, uint64(12), counters[0].Dropout)
+		assert.Equal(t, uint64(13), counters[0].Fifoout)
 		assert.Equal(t, interface1, counters[1].Name)
-		assert.Equal(t, 100, int(counters[1].BytesRecv))
-		assert.Equal(t, 200, int(counters[1].PacketsRecv))
-		assert.Equal(t, 300, int(counters[1].Errin))
-		assert.Equal(t, 400, int(counters[1].Dropin))
-		assert.Equal(t, 500, int(counters[1].Fifoin))
-		assert.Equal(t, 900, int(counters[1].BytesSent))
-		assert.Equal(t, 1000, int(counters[1].PacketsSent))
-		assert.Equal(t, 1100, int(counters[1].Errout))
-		assert.Equal(t, 1200, int(counters[1].Dropout))
-		assert.Equal(t, 1300, int(counters[1].Fifoout))
+		assert.Equal(t, uint64(100), counters[1].BytesRecv)
+		assert.Equal(t, uint64(200), counters[1].PacketsRecv)
+		assert.Equal(t, uint64(300), counters[1].Errin)
+		assert.Equal(t, uint64(400), counters[1].Dropin)
+		assert.Equal(t, uint64(500), counters[1].Fifoin)
+		assert.Equal(t, uint64(900), counters[1].BytesSent)
+		assert.Equal(t, uint64(1000), counters[1].PacketsSent)
+		assert.Equal(t, uint64(1100), counters[1].Errout)
+		assert.Equal(t, uint64(1200), counters[1].Dropout)
+		assert.Equal(t, uint64(1300), counters[1].Fifoout)
 	}
 
 	err = tmpfile.Close()
@@ -81,7 +81,7 @@ func TestIOCountersByFileParsing(t *testing.T) {
 
 func TestGetProcInodesAll(t *testing.T) {
 	waitForServer := make(chan bool)
-	go func() { // TCP listening goroutine to have some opened inodes even in CI
+	go func(t *testing.T) { // TCP listening goroutine to have some opened inodes even in CI
 		addr, err := net.ResolveTCPAddr("tcp", "localhost:0") // dynamically get a random open port from OS
 		if err != nil {
 			t.Skipf("unable to resolve localhost: %v", err)
@@ -99,7 +99,7 @@ func TestGetProcInodesAll(t *testing.T) {
 			}
 			defer conn.Close()
 		}
-	}()
+	}(t)
 	<-waitForServer
 
 	root := common.HostProcWithContext(context.Background(), "")

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -97,7 +97,7 @@ func ParseNetstat(output string, mode string,
 			n.PacketsSent = parsed[2]
 			n.Dropout = parsed[3]
 		case "ine":
-		        n.Errin = parsed[0]
+			n.Errin = parsed[0]
 			n.Errout = parsed[1]
 		}
 
@@ -255,7 +255,7 @@ func parseNetstatAddr(local string, remote string, family uint32) (laddr Addr, r
 				return Addr{}, fmt.Errorf("unknown family, %d", family)
 			}
 		}
-		lport, err := strconv.Atoi(port)
+		lport, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			return Addr{}, err
 		}

--- a/net/net_unix.go
+++ b/net/net_unix.go
@@ -109,11 +109,11 @@ func parseNetLine(line string) (ConnectionStat, error) {
 		f[7] = "unix"
 	}
 
-	pid, err := strconv.Atoi(f[1])
+	pid, err := strconv.ParseInt(f[1], 10, 32)
 	if err != nil {
 		return ConnectionStat{}, err
 	}
-	fd, err := strconv.Atoi(strings.Trim(f[3], "u"))
+	fd, err := strconv.ParseInt(strings.Trim(f[3], "u"), 10, 32)
 	if err != nil {
 		return ConnectionStat{}, fmt.Errorf("unknown fd, %s", f[3])
 	}
@@ -157,7 +157,7 @@ func parseNetAddr(line string) (laddr Addr, raddr Addr, err error) {
 		if err != nil {
 			return Addr{}, fmt.Errorf("wrong addr, %s", l)
 		}
-		lport, err := strconv.Atoi(port)
+		lport, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			return Addr{}, err
 		}

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -193,24 +193,24 @@ func convertCPUTimes(s string) (ret float64, err error) {
 		_t := strings.Split(s, ":")
 		switch len(_t) {
 		case 3:
-			hour, err := strconv.Atoi(_t[0])
+			hour, err := strconv.ParseInt(_t[0], 10, 32)
 			if err != nil {
 				return ret, err
 			}
-			t += hour * 60 * 60 * clockTicks
+			t += int(hour) * 60 * 60 * clockTicks
 
-			mins, err := strconv.Atoi(_t[1])
+			mins, err := strconv.ParseInt(_t[1], 10, 32)
 			if err != nil {
 				return ret, err
 			}
-			t += mins * 60 * clockTicks
+			t += int(mins) * 60 * clockTicks
 			_tmp = _t[2]
 		case 2:
-			mins, err := strconv.Atoi(_t[0])
+			mins, err := strconv.ParseInt(_t[0], 10, 32)
 			if err != nil {
 				return ret, err
 			}
-			t += mins * 60 * clockTicks
+			t += int(mins) * 60 * clockTicks
 			_tmp = _t[1]
 		case 1, 0:
 			_tmp = s
@@ -225,10 +225,10 @@ func convertCPUTimes(s string) (ret float64, err error) {
 	if err != nil {
 		return ret, err
 	}
-	h, err := strconv.Atoi(_t[0])
-	t += h * clockTicks
-	h, err = strconv.Atoi(_t[1])
-	t += h
+	h, err := strconv.ParseInt(_t[0], 10, 32)
+	t += int(h) * clockTicks
+	h, err = strconv.ParseInt(_t[1], 10, 32)
+	t += int(h)
 	return float64(t) / float64(clockTicks), nil
 }
 

--- a/process/process_darwin_nocgo.go
+++ b/process/process_darwin_nocgo.go
@@ -20,7 +20,7 @@ func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 	out, err := invoke.CommandWithContext(ctx, "lsof", "-p", strconv.Itoa(int(p.Pid)), "-Fpfn")
 	if err != nil {
-		return "", fmt.Errorf("bad call to lsof: %s", err)
+		return "", fmt.Errorf("bad call to lsof: %w", err)
 	}
 	txtFound := 0
 	lines := strings.Split(string(out), "\n")
@@ -111,15 +111,15 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 	if err != nil {
 		return nil, err
 	}
-	rss, err := strconv.Atoi(r[0][0])
+	rss, err := strconv.ParseInt(r[0][0], 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	vms, err := strconv.Atoi(r[0][1])
+	vms, err := strconv.ParseInt(r[0][1], 10, 64)
 	if err != nil {
 		return nil, err
 	}
-	pagein, err := strconv.Atoi(r[0][2])
+	pagein, err := strconv.ParseInt(r[0][2], 10, 64)
 	if err != nil {
 		return nil, err
 	}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -307,6 +307,7 @@ func TestName(t *testing.T) {
 	}
 }
 
+// #nosec G204
 func TestLong_Name_With_Spaces(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -353,6 +354,7 @@ func TestLong_Name_With_Spaces(t *testing.T) {
 	cmd.Process.Kill()
 }
 
+// #nosec G204
 func TestLong_Name(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -779,6 +781,7 @@ func TestIsRunning(t *testing.T) {
 	}
 }
 
+// #nosec G204
 func TestEnviron(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {

--- a/sensors/sensors_openbsd.go
+++ b/sensors/sensors_openbsd.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //go:build openbsd
 
-package openbsd
+package sensors
 
 import (
 	"context"


### PR DESCRIPTION
golangci-lint is failing because of gosec G115, `G115: integer overflow conversion`. I have take a look and I think it is hard to solve all of the errors, so I just ignore it.

This PR 

- Remove gosec G204 exclude rule
  - Add `#nosec` comment for a few functions
- Use `ParseInt` instead of `Atoi` in order to avoid overflow panic
- fix package name in `sensors/sensors_openbsd.go`