### PR TITLE
[process][darwin][freebsd][linux][openbsd] Make process.Children not reliant on pgrep

### DIFF
--- a/internal/common/common_unix.go
+++ b/internal/common/common_unix.go
@@ -40,23 +40,3 @@ func CallLsofWithContext(ctx context.Context, invoke Invoker, pid int32, args ..
 	}
 	return ret, nil
 }
-
-func CallPgrepWithContext(ctx context.Context, invoke Invoker, pid int32) ([]int32, error) {
-	out, err := invoke.CommandWithContext(ctx, "pgrep", "-P", strconv.Itoa(int(pid)))
-	if err != nil {
-		return []int32{}, err
-	}
-	lines := strings.Split(string(out), "\n")
-	ret := make([]int32, 0, len(lines))
-	for _, l := range lines {
-		if len(l) == 0 {
-			continue
-		}
-		i, err := strconv.ParseInt(l, 10, 32)
-		if err != nil {
-			continue
-		}
-		ret = append(ret, int32(i))
-	}
-	return ret, nil
-}

--- a/process/process.go
+++ b/process/process.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	invoke                 common.Invoker = common.Invoke{}
-	ErrorNoChildren                       = errors.New("process does not have children")
+	ErrorNoChildren                       = errors.New("process does not have children") // Deprecated: ErrorNoChildren is never returned by process.Children(), check its returned []*Process slice length instead
 	ErrorProcessNotRunning                = errors.New("process does not exist")
 	ErrorNotPermitted                     = errors.New("operation not permitted")
 )

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -286,18 +287,21 @@ func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, e
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
-	pids, err := common.CallPgrepWithContext(ctx, invoke, p.Pid)
+	procs, err := ProcessesWithContext(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
-	ret := make([]*Process, 0, len(pids))
-	for _, pid := range pids {
-		np, err := NewProcessWithContext(ctx, pid)
+	ret := make([]*Process, 0, len(procs))
+	for _, proc := range procs {
+		ppid, err := proc.PpidWithContext(ctx)
 		if err != nil {
-			return nil, err
+			continue
 		}
-		ret = append(ret, np)
+		if ppid == p.Pid {
+			ret = append(ret, proc)
+		}
 	}
+	sort.Slice(ret, func(i, j int) bool { return ret[i].Pid < ret[j].Pid })
 	return ret, nil
 }
 


### PR DESCRIPTION
pgrep -P $PID exits with status of 1 (and nothing in stdout nor stderr) both if a process doesn't exist or it doesn't have child processes, so we don't use it anymore on these OSes. We sort PIDs as pgrep did.

Also remove the ErrorNoChildren error when there are no child processes, this is erroneous (simply check for the length of the returned slice, plus this is not an error per se), this was only returned on linux anyway.

Fixes #1698