### PR TITLE
[common] add HOST_PROC_MOUNTINFO to EnvMap

### DIFF
--- a/common/env.go
+++ b/common/env.go
@@ -12,13 +12,14 @@ type EnvKeyType string
 var EnvKey = EnvKeyType("env")
 
 const (
-	HostProcEnvKey EnvKeyType = "HOST_PROC"
-	HostSysEnvKey  EnvKeyType = "HOST_SYS"
-	HostEtcEnvKey  EnvKeyType = "HOST_ETC"
-	HostVarEnvKey  EnvKeyType = "HOST_VAR"
-	HostRunEnvKey  EnvKeyType = "HOST_RUN"
-	HostDevEnvKey  EnvKeyType = "HOST_DEV"
-	HostRootEnvKey EnvKeyType = "HOST_ROOT"
+	HostProcEnvKey    EnvKeyType = "HOST_PROC"
+	HostSysEnvKey     EnvKeyType = "HOST_SYS"
+	HostEtcEnvKey     EnvKeyType = "HOST_ETC"
+	HostVarEnvKey     EnvKeyType = "HOST_VAR"
+	HostRunEnvKey     EnvKeyType = "HOST_RUN"
+	HostDevEnvKey     EnvKeyType = "HOST_DEV"
+	HostRootEnvKey    EnvKeyType = "HOST_ROOT"
+	HostProcMountinfo EnvKeyType = "HOST_PROC_MOUNTINFO"
 )
 
 type EnvMap map[EnvKeyType]string


### PR DESCRIPTION
Add one more key to EnvMap for the environment variable HOST_PROC_MOUNTINFO.