### PR TITLE
feat(mem): Add windows commit stats

### DIFF
--- a/mem/ex_windows.go
+++ b/mem/ex_windows.go
@@ -11,7 +11,10 @@ import (
 
 // ExVirtualMemory represents Windows specific information
 // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
+// https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-performance_information
 type ExVirtualMemory struct {
+	CommitLimit  uint64 `json:"commitLimit"`
+	CommitTotal  uint64 `json:"commitTotal"`
 	VirtualTotal uint64 `json:"virtualTotal"`
 	VirtualAvail uint64 `json:"virtualAvail"`
 }
@@ -30,7 +33,16 @@ func (e *ExWindows) VirtualMemory() (*ExVirtualMemory, error) {
 		return nil, windows.GetLastError()
 	}
 
+	var perfInfo performanceInformation
+	perfInfo.cb = uint32(unsafe.Sizeof(perfInfo))
+	perf, _, _ := procGetPerformanceInfo.Call(uintptr(unsafe.Pointer(&perfInfo)), uintptr(perfInfo.cb))
+	if perf == 0 {
+		return nil, windows.GetLastError()
+	}
+
 	ret := &ExVirtualMemory{
+		CommitLimit:  perfInfo.commitLimit * perfInfo.pageSize,
+		CommitTotal:  perfInfo.commitTotal * perfInfo.pageSize,
 		VirtualTotal: memInfo.ullTotalVirtual,
 		VirtualAvail: memInfo.ullAvailVirtual,
 	}


### PR DESCRIPTION
I'm kinda puzzled if I should avoid calling `procGetPerformanceInfo` and stick to computing commit stats from `memoryStatusEx.ullTotalPageFile` and `memoryStatusEx.ullAvailPageFile` or expose pagefile stats and compute it in final application.

However, I chose this implementation because it is more aligned with the terminology used by Windows Task Manager and Powershell's `Get-Counter`, both of which refer to "commit" rather than "pagefile."

Closes #1719