### PR TITLE
sensors: avoid passing nil pointer to CFArrayGetCount

### DIFF
--- a/sensors/sensors_darwin_arm64.go
+++ b/sensors/sensors_darwin_arm64.go
@@ -96,6 +96,10 @@ func (ta *temperatureArm) getProductNames() []string {
 	ta.ioHIDEventSystemClientSetMatching(uintptr(system), uintptr(ta.sensors))
 	matchingsrvs := ta.ioHIDEventSystemClientCopyServices(uintptr(system))
 
+	if matchingsrvs == nil {
+		return nil
+	}
+
 	count := ta.cfArrayGetCount(uintptr(matchingsrvs))
 
 	var i int32
@@ -129,6 +133,10 @@ func (ta *temperatureArm) getThermalValues() []float64 {
 
 	ta.ioHIDEventSystemClientSetMatching(uintptr(system), uintptr(ta.sensors))
 	matchingsrvs := ta.ioHIDEventSystemClientCopyServices(uintptr(system))
+
+	if matchingsrvs == nil {
+		return nil
+	}
 
 	count := ta.cfArrayGetCount(uintptr(matchingsrvs))
 


### PR DESCRIPTION
Add nil check for `matchingsrvs` before calling `CFArrayGetCount`, as some virtual environments (e.g., Github's action runners) lack sensor data.

Fix https://github.com/shirou/gopsutil/issues/1726