### PR TITLE
enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
     - nolintlint
     - predeclared
     - revive
+    - testifylint
     - typecheck
     - unparam
   disable:
@@ -56,3 +57,9 @@ linters-settings:
             recommandations:
               - io
               - os
+  testifylint:
+    disable:
+      - expected-actual
+      - float-compare
+      - require-error
+    enabel-all: true

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExVirtualMemory(t *testing.T) {
@@ -152,19 +153,19 @@ const invalidFile = `INVALID				Type		Size		Used		Priority
 func TestParseSwapsFile_ValidFile(t *testing.T) {
 	assert := assert.New(t)
 	stats, err := parseSwapsFile(context.Background(), strings.NewReader(validFile))
-	assert.NoError(err)
+	require.NoError(t, err)
 
-	assert.Equal(*stats[0], SwapDevice{
+	assert.Equal(SwapDevice{
 		Name:      "/dev/dm-2",
 		UsedBytes: 502566912,
 		FreeBytes: 68128825344,
-	})
+	}, *stats[0])
 
-	assert.Equal(*stats[1], SwapDevice{
+	assert.Equal(SwapDevice{
 		Name:      "/swapfile",
 		UsedBytes: 1024,
 		FreeBytes: 1024,
-	})
+	}, *stats[1])
 }
 
 func TestParseSwapsFile_InvalidFile(t *testing.T) {

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -34,9 +34,9 @@ func TestVirtualMemory(t *testing.T) {
 	}
 	t.Log(v)
 
-	assert.True(t, v.Total > 0)
-	assert.True(t, v.Available > 0)
-	assert.True(t, v.Used > 0)
+	assert.Positive(t, v.Total)
+	assert.Positive(t, v.Available)
+	assert.Positive(t, v.Used)
 
 	total := v.Used + v.Free + v.Buffers + v.Cached
 	totalStr := "used + free + buffers + cached"

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -73,23 +73,23 @@ func TestSplitProcStat_fromFile(t *testing.T) {
 			continue
 		}
 		contents, err := os.ReadFile(statFile)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		pidStr := strconv.Itoa(int(pid))
 
 		ppid := "68044" // TODO: how to pass ppid to test?
 
 		fields := splitProcStat(contents)
-		assert.Equal(t, fields[1], pidStr)
-		assert.Equal(t, fields[2], "test(cmd).sh")
-		assert.Equal(t, fields[3], "S")
-		assert.Equal(t, fields[4], ppid)
-		assert.Equal(t, fields[5], pidStr) // pgrp
-		assert.Equal(t, fields[6], ppid)   // session
-		assert.Equal(t, fields[8], pidStr) // tpgrp
-		assert.Equal(t, fields[18], "20")  // priority
-		assert.Equal(t, fields[20], "1")   // num threads
-		assert.Equal(t, fields[52], "0")   // exit code
+		assert.Equal(t, pidStr, fields[1])
+		assert.Equal(t, "test(cmd).sh", fields[2])
+		assert.Equal(t, "S", fields[3])
+		assert.Equal(t, ppid, fields[4])
+		assert.Equal(t, pidStr, fields[5]) // pgrp
+		assert.Equal(t, ppid, fields[6])   // session
+		assert.Equal(t, pidStr, fields[8]) // tpgrp
+		assert.Equal(t, "20", fields[18])  // priority
+		assert.Equal(t, "1", fields[20])   // num threads
+		assert.Equal(t, "0", fields[52])   // exit code
 	}
 }
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -336,11 +336,11 @@ func TestLong_Name_With_Spaces(t *testing.T) {
 
 	cmd := exec.Command(tmpfile.Name() + ".exe")
 
-	assert.Nil(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	time.Sleep(100 * time.Millisecond)
 	p, err := NewProcess(int32(cmd.Process.Pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	n, err := p.Name()
 	skipIfNotImplementedErr(t, err)
@@ -383,11 +383,11 @@ func TestLong_Name(t *testing.T) {
 
 	cmd := exec.Command(tmpfile.Name() + ".exe")
 
-	assert.Nil(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	time.Sleep(100 * time.Millisecond)
 	p, err := NewProcess(int32(cmd.Process.Pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	n, err := p.Name()
 	skipIfNotImplementedErr(t, err)
@@ -642,7 +642,7 @@ func TestChildren(t *testing.T) {
 	} else {
 		cmd = exec.Command("sleep", "3")
 	}
-	assert.Nil(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	time.Sleep(100 * time.Millisecond)
 
 	c, err := p.Children()
@@ -682,23 +682,23 @@ func TestCPUTimes(t *testing.T) {
 	pid := os.Getpid()
 	process, err := NewProcess(int32(pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	spinSeconds := 0.2
 	cpuTimes0, err := process.Times()
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	// Spin for a duration of spinSeconds
 	t0 := time.Now()
 	tGoal := t0.Add(time.Duration(spinSeconds*1000) * time.Millisecond)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	for time.Now().Before(tGoal) {
 		// This block intentionally left blank
 	}
 
 	cpuTimes1, err := process.Times()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	if cpuTimes0 == nil || cpuTimes1 == nil {
 		t.FailNow()
@@ -706,26 +706,25 @@ func TestCPUTimes(t *testing.T) {
 	measuredElapsed := cpuTimes1.Total() - cpuTimes0.Total()
 	message := fmt.Sprintf("Measured %fs != spun time of %fs\ncpuTimes0=%v\ncpuTimes1=%v",
 		measuredElapsed, spinSeconds, cpuTimes0, cpuTimes1)
-	assert.True(t, measuredElapsed > float64(spinSeconds)/5, message)
-	assert.True(t, measuredElapsed < float64(spinSeconds)*5, message)
+	assert.Greater(t, measuredElapsed, float64(spinSeconds)/5, message)
+	assert.Less(t, measuredElapsed, float64(spinSeconds)*5, message)
 }
 
 func TestOpenFiles(t *testing.T) {
 	fp, err := os.Open("process_test.go")
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
-		err := fp.Close()
-		assert.Nil(t, err)
+		assert.NoError(t, fp.Close())
 	}()
 
 	pid := os.Getpid()
 	p, err := NewProcess(int32(pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	v, err := p.OpenFiles()
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, v) // test always open files.
 
 	for _, vv := range v {
@@ -740,14 +739,14 @@ func TestKill(t *testing.T) {
 	} else {
 		cmd = exec.Command("sleep", "3")
 	}
-	assert.Nil(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	time.Sleep(100 * time.Millisecond)
 	p, err := NewProcess(int32(cmd.Process.Pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = p.Kill()
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	cmd.Wait()
 }
 
@@ -761,7 +760,7 @@ func TestIsRunning(t *testing.T) {
 	cmd.Start()
 	p, err := NewProcess(int32(cmd.Process.Pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	running, err := p.IsRunning()
 	skipIfNotImplementedErr(t, err)
 	if err != nil {
@@ -812,12 +811,12 @@ func TestEnviron(t *testing.T) {
 
 	cmd.Env = []string{"testkey=envvalue"}
 
-	assert.Nil(t, cmd.Start())
+	require.NoError(t, cmd.Start())
 	defer cmd.Process.Kill()
 	time.Sleep(100 * time.Millisecond)
 	p, err := NewProcess(int32(cmd.Process.Pid))
 	skipIfNotImplementedErr(t, err)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	envs, err := p.Environ()
 	skipIfNotImplementedErr(t, err)
@@ -877,6 +876,6 @@ func BenchmarkProcesses(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ps, err := Processes()
 		require.NoError(b, err)
-		require.Greater(b, len(ps), 0)
+		require.NotEmpty(b, ps)
 	}
 }


### PR DESCRIPTION
This enables [testifylint](https://github.com/Antonboom/testifylint) which is a linter that checks for usage of github.com/stretchr/testify.

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->