### PR TITLE
add anolis family with anolis platform in host/host_linux.go

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -315,6 +315,8 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		family = "solus"
 	case "neokylin":
 		family = "neokylin"
+	case "anolis":
+		family = "anolis"
 	}
 
 	return platform, family, version, nil


### PR DESCRIPTION
I add anolis family in the host/host_linux.go file.

Anolis OS is one of the linux distributions. This is the Anolis OS website link. https://openanolis.cn/news/334391213648953345