### PR TITLE
fix[github]: deprecate macos-12, add macos-15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04, windows-2022, windows-2019, macos-12, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-24.04, windows-2022, windows-2019, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go


### PR DESCRIPTION
macos-12 GitHub hosted runner is now deprecated. and Add macos-15 instead.