### PR TITLE
enable all rules of testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,8 +58,4 @@ linters-settings:
               - io
               - os
   testifylint:
-    disable:
-      - expected-actual
-      - float-compare
-      - require-error
-    enabel-all: true
+    enable-all: true

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -172,7 +172,7 @@ func TestFillFromTIDStatWithContext_lx_brandz(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		assert.Equal(t, float64(0), cpuTimes.Iowait)
+		assert.Zero(t, cpuTimes.Iowait)
 	}
 }
 


### PR DESCRIPTION
Related to #1743

@shirou , I realised that there is a misspell in the configuration.

And all the excluded rules are already applied so they can be enabled

Only one Equal was left.