### PR TITLE
enable all rules of perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - misspell
     - nakedret
     - nolintlint
+    - perfsprint
     - predeclared
     - revive
     - testifylint
@@ -57,6 +58,17 @@ linters-settings:
             recommandations:
               - io
               - os
+  perfsprint:
+    # Optimizes even if it requires an int or uint type cast.
+    int-conversion: true
+    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+    err-error: true
+    # Optimizes `fmt.Errorf`.
+    errorf: true
+    # Optimizes `fmt.Sprintf` with only one argument.
+    sprintf1: true
+    # Optimizes into strings concatenation.
+    strconcat: true
   testifylint:
     disable:
       - expected-actual

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -4,6 +4,7 @@ package cpu
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"runtime"
@@ -195,7 +196,7 @@ func percentUsedFromLastCallWithContext(ctx context.Context, percpu bool) ([]flo
 	}
 
 	if lastTimes == nil {
-		return nil, fmt.Errorf("error getting times for cpu percent. lastTimes was nil")
+		return nil, errors.New("error getting times for cpu percent. lastTimes was nil")
 	}
 	return calculateAllBusy(lastTimes, cpuTimes)
 }

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -5,7 +5,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,7 +102,7 @@ func BootTimeWithContext(ctx context.Context, enableCache bool) (uint64, error) 
 	currentTime := float64(time.Now().UnixNano()) / float64(time.Second)
 
 	if len(lines) != 1 {
-		return 0, fmt.Errorf("wrong uptime format")
+		return 0, errors.New("wrong uptime format")
 	}
 	f := strings.Fields(lines[0])
 	b, err := strconv.ParseFloat(f[0], 64)
@@ -142,7 +142,7 @@ func readBootTimeStat(ctx context.Context) (uint64, error) {
 	if strings.HasPrefix(line, "btime") {
 		f := strings.Fields(line)
 		if len(f) != 2 {
-			return 0, fmt.Errorf("wrong btime format")
+			return 0, errors.New("wrong btime format")
 		}
 		b, err := strconv.ParseInt(f[1], 10, 64)
 		if err != nil {
@@ -151,7 +151,7 @@ func readBootTimeStat(ctx context.Context) (uint64, error) {
 		t := uint64(b)
 		return t, nil
 	}
-	return 0, fmt.Errorf("could not find btime")
+	return 0, errors.New("could not find btime")
 }
 
 func Virtualization() (string, string, error) {

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -758,7 +758,7 @@ func parseIPv6HexString(src []byte) (net.IP, error) {
 
 func parseIPv6HexStringWithContext(ctx context.Context, src []byte) (net.IP, error) {
 	if len(src) != 16 {
-		return nil, fmt.Errorf("invalid IPv6 string")
+		return nil, errors.New("invalid IPv6 string")
 	}
 
 	buf := make([]byte, 0, 16)

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -41,7 +41,7 @@ func TestSplitProcStat(t *testing.T) {
 	for _, expectedName := range cases {
 		statLineContent[commandNameIndex-1] = "(" + expectedName + ")"
 		statLine := strings.Join(statLineContent, " ")
-		t.Run(fmt.Sprintf("name: %s", expectedName), func(t *testing.T) {
+		t.Run("name: "+expectedName, func(t *testing.T) {
 			parsedStatLine := splitProcStat([]byte(statLine))
 			assert.Equal(t, expectedName, parsedStatLine[commandNameIndex])
 			for _, idx := range consideredFields {


### PR DESCRIPTION
#### Description


[perfsprint](https://golangci-lint.run/usage/linters/#perfsprint) checks that fmt.Sprintf can be replaced with a faster alternative.