### PR TITLE
since Go 1.18 'interface{}' can be replaced by 'any'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,9 @@ linters-settings:
             recommandations:
               - io
               - os
+  revive:
+    rules:
+      - name: use-any
   testifylint:
     disable:
       - expected-actual

--- a/internal/common/binary.go
+++ b/internal/common/binary.go
@@ -137,7 +137,7 @@ func (bigEndian) GoString() string { return "binary.BigEndian" }
 // blank (_) field names is skipped; i.e., blank field names
 // may be used for padding.
 // When reading into a struct, all non-blank fields must be exported.
-func Read(r io.Reader, order ByteOrder, data interface{}) error {
+func Read(r io.Reader, order ByteOrder, data any) error {
 	// Fast path for basic types and slices.
 	if n := intDataSize(data); n != 0 {
 		var b [8]byte
@@ -229,7 +229,7 @@ func Read(r io.Reader, order ByteOrder, data interface{}) error {
 // and read from successive fields of the data.
 // When writing structs, zero values are written for fields
 // with blank (_) field names.
-func Write(w io.Writer, order ByteOrder, data interface{}) error {
+func Write(w io.Writer, order ByteOrder, data any) error {
 	// Fast path for basic types and slices.
 	if n := intDataSize(data); n != 0 {
 		var b [8]byte
@@ -339,7 +339,7 @@ func Write(w io.Writer, order ByteOrder, data interface{}) error {
 // Size returns how many bytes Write would generate to encode the value v, which
 // must be a fixed-size value or a slice of fixed-size values, or a pointer to such data.
 // If v is neither of these, Size returns -1.
-func Size(v interface{}) int {
+func Size(v any) int {
 	return dataSize(reflect.Indirect(reflect.ValueOf(v)))
 }
 
@@ -607,7 +607,7 @@ func (e *encoder) skip(v reflect.Value) {
 
 // intDataSize returns the size of the data required to represent the data when encoded.
 // It returns zero if the type cannot be implemented by the fast path in Read or Write.
-func intDataSize(data interface{}) int {
+func intDataSize(data any) int {
 	switch data := data.(type) {
 	case int8, *int8, *uint8:
 		return 1

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -311,7 +311,7 @@ func IntContains(target []int, src int) bool {
 
 // get struct attributes.
 // This method is used only for debugging platform dependent code.
-func attributes(m interface{}) map[string]reflect.Type {
+func attributes(m any) map[string]reflect.Type {
 	typ := reflect.TypeOf(m)
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -197,7 +197,7 @@ func ProcessorQueueLengthCounter() (*Win32PerformanceCounter, error) {
 }
 
 // WMIQueryWithContext - wraps wmi.Query with a timed-out context to avoid hanging
-func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, connectServerArgs ...interface{}) error {
+func WMIQueryWithContext(ctx context.Context, query string, dst any, connectServerArgs ...any) error {
 	if _, ok := ctx.Deadline(); !ok {
 		ctxTimeout, cancel := context.WithTimeout(ctx, Timeout)
 		defer cancel()

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -376,7 +376,7 @@ func getTableUintptr(family uint32, buf []byte) uintptr {
 	return p
 }
 
-func getTableInfo(filename string, table interface{}) (index, step, length int) {
+func getTableInfo(filename string, table any) (index, step, length int) {
 	switch filename {
 	case kindTCP4.filename:
 		index = int(unsafe.Sizeof(table.(pmibTCPTableOwnerPidAll).DwNumEntries))


### PR DESCRIPTION
#### Description

Use revive rule 'use-any' to ensure that 'any' is used instead of 'interface{}'