### PR TITLE
fix: memory leak and string corruption in ARM Mac temperature sensors

### DIFF
--- a/sensors/sensors_darwin_arm64.go
+++ b/sensors/sensors_darwin_arm64.go
@@ -41,11 +41,16 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	}
 
 	ta.matching(0xff00, 5)
-	thermalNames := ta.getProductNames()
-	thermalValues := ta.getThermalValues()
+	defer ta.cfRelease(uintptr(ta.sensors))
+
+	// Create HID system client
+	system := ta.ioHIDEventSystemClientCreate(common.KCFAllocatorDefault)
+	defer ta.cfRelease(uintptr(system))
+
+	thermalNames := ta.getProductNames(system)
+	thermalValues := ta.getThermalValues(system)
 	result := dumpNameValues(thermalNames, thermalValues)
 
-	ta.cfRelease(uintptr(ta.sensors))
 	return result, nil
 }
 
@@ -84,14 +89,12 @@ type temperatureArm struct {
 	sensors unsafe.Pointer
 }
 
-func (ta *temperatureArm) getProductNames() []string {
+func (ta *temperatureArm) getProductNames(system unsafe.Pointer) []string {
 	ioHIDServiceClientCopyProperty := common.GetFunc[common.IOHIDServiceClientCopyPropertyFunc](ta.ioKit, common.IOHIDServiceClientCopyPropertySym)
-
 	cfStringGetLength := common.GetFunc[common.CFStringGetLengthFunc](ta.cf, common.CFStringGetLengthSym)
 	cfStringGetCString := common.GetFunc[common.CFStringGetCStringFunc](ta.cf, common.CFStringGetCStringSym)
 
 	var names []string
-	system := ta.ioHIDEventSystemClientCreate(common.KCFAllocatorDefault)
 
 	ta.ioHIDEventSystemClientSetMatching(uintptr(system), uintptr(ta.sensors))
 	matchingsrvs := ta.ioHIDEventSystemClientCopyServices(uintptr(system))
@@ -99,37 +102,36 @@ func (ta *temperatureArm) getProductNames() []string {
 	if matchingsrvs == nil {
 		return nil
 	}
+	defer ta.cfRelease(uintptr(matchingsrvs))
 
 	count := ta.cfArrayGetCount(uintptr(matchingsrvs))
 
 	var i int32
 	str := ta.cfStr("Product")
+	defer ta.cfRelease(uintptr(str))
+
 	for i = 0; i < count; i++ {
 		sc := ta.cfArrayGetValueAtIndex(uintptr(matchingsrvs), i)
 		name := ioHIDServiceClientCopyProperty(uintptr(sc), uintptr(str))
 
 		if name != nil {
-			length := cfStringGetLength(uintptr(name)) + 1 // null terminator
-			buf := make([]byte, length-1)
+			length := cfStringGetLength(uintptr(name)) + 1 // include null terminator
+			buf := make([]byte, length)                    // allocate buffer with full length
 			cfStringGetCString(uintptr(name), &buf[0], length, common.KCFStringEncodingUTF8)
 
-			names = append(names, string(buf))
+			names = append(names, string(buf[:length-1])) // remove null terminator
 			ta.cfRelease(uintptr(name))
 		} else {
 			names = append(names, "noname")
 		}
 	}
 
-	ta.cfRelease(uintptr(matchingsrvs))
-	ta.cfRelease(uintptr(str))
 	return names
 }
 
-func (ta *temperatureArm) getThermalValues() []float64 {
+func (ta *temperatureArm) getThermalValues(system unsafe.Pointer) []float64 {
 	ioHIDServiceClientCopyEvent := common.GetFunc[common.IOHIDServiceClientCopyEventFunc](ta.ioKit, common.IOHIDServiceClientCopyEventSym)
 	ioHIDEventGetFloatValue := common.GetFunc[common.IOHIDEventGetFloatValueFunc](ta.ioKit, common.IOHIDEventGetFloatValueSym)
-
-	system := ta.ioHIDEventSystemClientCreate(common.KCFAllocatorDefault)
 
 	ta.ioHIDEventSystemClientSetMatching(uintptr(system), uintptr(ta.sensors))
 	matchingsrvs := ta.ioHIDEventSystemClientCopyServices(uintptr(system))
@@ -137,6 +139,7 @@ func (ta *temperatureArm) getThermalValues() []float64 {
 	if matchingsrvs == nil {
 		return nil
 	}
+	defer ta.cfRelease(uintptr(matchingsrvs))
 
 	count := ta.cfArrayGetCount(uintptr(matchingsrvs))
 
@@ -155,7 +158,6 @@ func (ta *temperatureArm) getThermalValues() []float64 {
 		values = append(values, temp)
 	}
 
-	ta.cfRelease(uintptr(matchingsrvs))
 	return values
 }
 


### PR DESCRIPTION
This PR addresses several issues in the temperature sensor implementation for ARM Mac:
1. Memory leak caused by unreleased system resources
2. Increasing port counts in Activity Monitor
3. String corruption where the first character becomes "\x00"

## Changes

1. Resource Management:
   - Added proper resource cleanup using `defer` statements
   - Refactored code to share the HID system client instead of creating new ones
   - Fixed memory leaks by ensuring all CoreFoundation objects are properly released

2. String Handling:
   - Fixed buffer allocation for string conversion
   - Properly handle null terminators in C string to Go string conversion
   - Added correct string length calculations

3. Code Structure:
   - Reduced resource allocation by sharing system client between functions
   - Enhanced code readability with better comments
   
## Testing
Tested on Apple Silicon Mac with the following improvements:
- Memory usage remains stable over time
- Port count in Activity Monitor stays constant
- No more string corruption issues

## How to Reproduce
You can reproduce these issues using the following code:

```go
package main

import (
	"context"
	"time"

	"log/slog"

	"github.com/shirou/gopsutil/v4/sensors"
)

func main() {
	slog.SetLogLoggerLevel(slog.LevelDebug)
	ticker := time.NewTicker(10 * time.Millisecond)

	for range ticker.C {
		temps, err := sensors.TemperaturesWithContext(context.Background())
		if err != nil {
			slog.Debug("Sensor error", "err", err)
		}
		slog.Debug("Temperature", "sensors", temps)
	}
}
```

go run demo.go | grep "x00"


Memory leaks screen recordings: https://github.com/user-attachments/assets/0168feba-5637-4f3f-8a45-a56a3b5cbfdb

String corruption screenshot:
![String corruption](https://github.com/user-attachments/assets/e6100ee9-4abe-4ec1-aaef-3fd31c7df0a7)

@uubulb would you mind taking a look? Many thanks!