### PR TITLE
refactor(darwin): optimize string allocation

### DIFF
--- a/cpu/cpu_darwin_arm64.go
+++ b/cpu/cpu_darwin_arm64.go
@@ -55,10 +55,10 @@ func getFrequency() (float64, error) {
 			break
 		}
 
-		buf := make([]byte, 512)
-		ioRegistryEntryGetName(service, &buf[0])
+		buf := common.NewCStr(512)
+		ioRegistryEntryGetName(service, buf)
 
-		if common.GoString(&buf[0]) == "pmgr" {
+		if buf.GoString() == "pmgr" {
 			pCoreRef := ioRegistryEntryCreateCFProperty(service, uintptr(pCorekey), common.KCFAllocatorDefault, common.KNilOptions)
 			length := cfDataGetLength(uintptr(pCoreRef))
 			data := cfDataGetBytePtr(uintptr(pCoreRef))

--- a/sensors/sensors_darwin.go
+++ b/sensors/sensors_darwin.go
@@ -24,7 +24,7 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	}
 	defer smc.Close()
 
-	var temperatures []TemperatureStat
+	temperatures := make([]TemperatureStat, 0, len(temperatureKeys))
 	for _, key := range temperatureKeys {
 		temperatures = append(temperatures, TemperatureStat{
 			SensorKey:   key,

--- a/sensors/sensors_test.go
+++ b/sensors/sensors_test.go
@@ -3,8 +3,12 @@
 package sensors
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"testing"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func TestTemperatureStat_String(t *testing.T) {
@@ -18,4 +22,25 @@ func TestTemperatureStat_String(t *testing.T) {
 	if s != fmt.Sprintf("%v", v) {
 		t.Errorf("TemperatureStat string is invalid, %v", fmt.Sprintf("%v", v))
 	}
+}
+
+func skipIfNotImplementedErr(t *testing.T, err error) {
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+}
+
+func TestTemperatures(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skip CI")
+	}
+	v, err := SensorsTemperatures()
+	skipIfNotImplementedErr(t, err)
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+	if len(v) == 0 {
+		t.Errorf("Could not get temperature %v", v)
+	}
+	t.Log(v)
 }


### PR DESCRIPTION
Introduce a new CStr type to simplify string conversion, making it less error-prone.
Also added some comments to improve readability and unit test for sensors package.

Supersedes https://github.com/shirou/gopsutil/pull/1725 