### PR TITLE
chore: explicit revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,6 @@
 issues:
   max-same-issues: 0
-  exclude-rules:
-    - linters:
-        - gosec
-      text: G115
-    - linters:
-        - revive
-      text: var-naming
-    - linters:
-        - revive
-      text: exported
-    - linters:
-        - revive
-      text: empty-block
-    - linters:
-        - revive
-      text: unused-parameter
+  exclude-rules: []
 linters:
   enable:
     - asciicheck
@@ -58,6 +43,9 @@ linters-settings:
             recommandations:
               - io
               - os
+  gosec:
+    excludes:
+      - G115
   perfsprint:
     # Optimizes even if it requires an int or uint type cast.
     int-conversion: true
@@ -69,5 +57,48 @@ linters-settings:
     sprintf1: true
     # Optimizes into strings concatenation.
     strconcat: true
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: duplicated-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: exported
+        disabled: true
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+        arguments:
+          - "preserveScope"
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: redundant-import-alias
+      - name: superfluous-else
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+        disabled: true
+      - name: unreachable-code
+      - name: unused-parameter
+        disabled: true
+      - name: use-any
+        disabled: true
+      - name: var-declaration
+      - name: var-naming
+        disabled: true
   testifylint:
     enable-all: true

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	cpu "github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 


### PR DESCRIPTION
* List explicitly the activated rules of revive.
* fixes redundant-import-alias as there is only one
* moves G115 exclusion to a dedicated configuration of gosec