### PR TITLE
Expose oom_kill as part of SwapMemory

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -97,6 +97,7 @@ type SwapMemoryStat struct {
 	// Linux specific numbers
 	// https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 	PgMajFault uint64 `json:"pgMajFault"`
+	OomKill    uint64 `json:"oomKill"`
 }
 
 func (m VirtualMemoryStat) String() string {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -375,6 +375,12 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 				continue
 			}
 			ret.PgMajFault = value * 4 * 1024
+		case "oom_kill":
+			value, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			ret.OomKill = value
 		}
 	}
 	return ret, nil

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -108,8 +108,9 @@ func TestSwapMemoryStat_String(t *testing.T) {
 		PgOut:       4,
 		PgFault:     5,
 		PgMajFault:  6,
+		OomKill:     7,
 	}
-	e := `{"total":10,"used":30,"free":40,"usedPercent":30.1,"sin":1,"sout":2,"pgIn":3,"pgOut":4,"pgFault":5,"pgMajFault":6}`
+	e := `{"total":10,"used":30,"free":40,"usedPercent":30.1,"sin":1,"sout":2,"pgIn":3,"pgOut":4,"pgFault":5,"pgMajFault":6,"oomKill":7}`
 	if e != fmt.Sprintf("%v", v) {
 		t.Errorf("SwapMemoryStat string is invalid: %v", v)
 	}

--- a/mem/testdata/linux/swapmemory/oomkill/proc/vmstat
+++ b/mem/testdata/linux/swapmemory/oomkill/proc/vmstat
@@ -1,0 +1,15 @@
+pgpgin 1
+pgpgout 2
+pswpin 3
+pswpout 4
+pgalloc_dma 5
+pgalloc_dma32 6
+pgalloc_normal 7
+pgalloc_movable 8
+pgfree 9
+pgactivate 10
+pgdeactivate 1
+pglazyfree 2
+pgfault 3
+pgmajfault 4
+oom_kill 5


### PR DESCRIPTION
`oom_kill` from `/proc/vmstat` represents the number of times OOM Killer killed a process. 

This PR proposes a simplistic approach to exposing it. Specifically, it includes the value of the counter in `SwapMemoryStat` (for linux only).

Alternatively, we could expose it in the `VirtualMemoryStat` object, where it seems to fit better. However, this will require opening `/proc/vmstat` for `VirtualMemory` call. Currently, `VirtualMemory` opens only `/proc/meminfo`, so that will be some overhead.

Another approach would be to expose memory events as another struct and create a specific call for it.

Please advice.