### PR TITLE
chore: enable use-any from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,6 @@ linters-settings:
       - name: unused-parameter
         disabled: true
       - name: use-any
-        disabled: true
       - name: var-declaration
       - name: var-naming
         disabled: true

--- a/internal/common/binary.go
+++ b/internal/common/binary.go
@@ -137,7 +137,7 @@ func (bigEndian) GoString() string { return "binary.BigEndian" }
 // blank (_) field names is skipped; i.e., blank field names
 // may be used for padding.
 // When reading into a struct, all non-blank fields must be exported.
-func Read(r io.Reader, order ByteOrder, data interface{}) error {
+func Read(r io.Reader, order ByteOrder, data any) error {
 	// Fast path for basic types and slices.
 	if n := intDataSize(data); n != 0 {
 		var b [8]byte
@@ -229,7 +229,7 @@ func Read(r io.Reader, order ByteOrder, data interface{}) error {
 // and read from successive fields of the data.
 // When writing structs, zero values are written for fields
 // with blank (_) field names.
-func Write(w io.Writer, order ByteOrder, data interface{}) error {
+func Write(w io.Writer, order ByteOrder, data any) error {
 	// Fast path for basic types and slices.
 	if n := intDataSize(data); n != 0 {
 		var b [8]byte
@@ -339,7 +339,7 @@ func Write(w io.Writer, order ByteOrder, data interface{}) error {
 // Size returns how many bytes Write would generate to encode the value v, which
 // must be a fixed-size value or a slice of fixed-size values, or a pointer to such data.
 // If v is neither of these, Size returns -1.
-func Size(v interface{}) int {
+func Size(v any) int {
 	return dataSize(reflect.Indirect(reflect.ValueOf(v)))
 }
 
@@ -607,7 +607,7 @@ func (e *encoder) skip(v reflect.Value) {
 
 // intDataSize returns the size of the data required to represent the data when encoded.
 // It returns zero if the type cannot be implemented by the fast path in Read or Write.
-func intDataSize(data interface{}) int {
+func intDataSize(data any) int {
 	switch data := data.(type) {
 	case int8, *int8, *uint8:
 		return 1

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -311,7 +311,7 @@ func IntContains(target []int, src int) bool {
 
 // get struct attributes.
 // This method is used only for debugging platform dependent code.
-func attributes(m interface{}) map[string]reflect.Type {
+func attributes(m any) map[string]reflect.Type {
 	typ := reflect.TypeOf(m)
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()


### PR DESCRIPTION
#### Description 

[use-any](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any): Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.