### PR TITLE
remove wmi to get number of physical cores

### DIFF
--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -79,24 +79,27 @@ func TestTimes(t *testing.T) {
 }
 
 func TestCounts(t *testing.T) {
-	v, err := Counts(true)
+	logicalCount, err := Counts(true)
 	skipIfNotImplementedErr(t, err)
 	if err != nil {
 		t.Errorf("error %v", err)
 	}
-	if v == 0 {
-		t.Errorf("could not get logical CPU counts: %v", v)
+	if logicalCount == 0 {
+		t.Errorf("could not get logical CPU counts: %v", logicalCount)
 	}
-	t.Logf("logical cores: %d", v)
-	v, err = Counts(false)
+	t.Logf("logical cores: %d", logicalCount)
+	physicalCount, err := Counts(false)
 	skipIfNotImplementedErr(t, err)
 	if err != nil {
 		t.Errorf("error %v", err)
 	}
-	if v == 0 {
-		t.Errorf("could not get physical CPU counts: %v", v)
+	if physicalCount == 0 {
+		t.Errorf("could not get physical CPU counts: %v", physicalCount)
 	}
-	t.Logf("physical cores: %d", v)
+	t.Logf("physical cores: %d", physicalCount)
+	if physicalCount > logicalCount {
+		t.Errorf("physical cpu cannot be more than logical cpu: %v > %v", physicalCount, logicalCount)
+	}
 }
 
 func TestTimeStat_String(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
+github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This is first attempt to remove the slow and unreliable wmi from gopsutil.

cpuid get information directly from the cpu where the code is running, so it's very easy and fast to get the number of physical cores.

The only issue could be in a system with more than one processor, I don't have one to test it, I assume that if you have more than one processor they are all of same model.
I am not aware of a frankestein system with more cpu of different models, Intel recommends to use cpu of same model and and in any case says to use only 2 cpu with same number of cores:
https://www.intel.com/content/www/us/en/support/articles/000055408/server-products/server-boards.html

So the code should work in all situations, and probably even more reliable than wmi.

Anyway if someone has a multi cpu system to test it would be nice.
 