### PR TITLE
add support for get disk serial number on darwin

### DIFF
--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -118,7 +118,7 @@ type spnvmeDataWrapper struct {
 	} `json:"SPNVMeDataType"`
 }
 
-func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
+func SerialNumberWithContext(ctx context.Context, _ string) (string, error) {
 	output, err := invoke.CommandWithContext(ctx, "system_profiler", "SPNVMeDataType", "-json")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Hello! This is my first PR on this project, so let me know if I got anything wrong and should change it.

This fixes #801 and adds support for getting (NVMe) drives' serial number. It does this by executing [system_profiler](https://ss64.com/mac/system_profiler.html) and unmarshalling.

