### PR TITLE
[windows]: fix lint error about use-any

### DIFF
--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -197,7 +197,7 @@ func ProcessorQueueLengthCounter() (*Win32PerformanceCounter, error) {
 }
 
 // WMIQueryWithContext - wraps wmi.Query with a timed-out context to avoid hanging
-func WMIQueryWithContext(ctx context.Context, query string, dst interface{}, connectServerArgs ...interface{}) error {
+func WMIQueryWithContext(ctx context.Context, query string, dst any, connectServerArgs ...any) error {
 	if _, ok := ctx.Deadline(); !ok {
 		ctxTimeout, cancel := context.WithTimeout(ctx, Timeout)
 		defer cancel()

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -328,7 +328,7 @@ func getTableUintptr(family uint32, buf []byte) uintptr {
 	return p
 }
 
-func getTableInfo(filename string, table interface{}) (index, step, length int) {
+func getTableInfo(filename string, table any) (index, step, length int) {
 	switch filename {
 	case kindTCP4.filename:
 		index = int(unsafe.Sizeof(table.(pmibTCPTableOwnerPidAll).DwNumEntries))


### PR DESCRIPTION
`use-any` lint check has been introduced by #1784 