### PR TITLE
fix: `Process.CmdlineSliceWithContext` incorrect on Windows

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -408,6 +408,11 @@ func (p *Process) Cmdline() (string, error) {
 
 // CmdlineSlice returns the command line arguments of the process as a slice with each
 // element being an argument.
+//
+// On Windows, this assumes the command line is encoded according to the convention accepted by
+// [golang.org/x/sys/windows.CmdlineToArgv] (the most common convention). If this is not suitable,
+// you should instead use [Process.Cmdline] and parse the command line according to your specific
+// requirements.
 func (p *Process) CmdlineSlice() ([]string, error) {
 	return p.CmdlineSliceWithContext(context.Background())
 }


### PR DESCRIPTION
On Windows, command line arguments are carried over as a space-separated string. As a result, there are complex quoting rules to encode individual arguments that contain spaces.

The implementation of `Process.CmdlineSliceWithContext` on Windows turns the command line string into a slice of strings by simply doing `strings.Split(cmdline, " ")`, which produces incorrect result in many situations.

This PR proposes to instead use the Windows standard library API `windows.CommandLineToArgv` to appropriately parse the most commonly used quoting convention in use, so that the returned slice contains the expected values, and Windows behaves a little bit more like Linux.

I've also added documentation to the `Process.CmdlineSlice` function mentioning this behavior so that users know to sue `Process.Cmdline` instead if they cannot assume arguments are passed according to the expected convention.

---

Note that an alternate approach I have seen used a bit on Go programs using `windows.CommandLineToArgv` is to fall back to alternate parsing methods if it returns an error... In this case, we could imagine falling back to space-splitting the string as is currently done, although I am personally not very fond of this way...