### PR TITLE
chore: update go version in module

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,3 +122,5 @@ linters-settings:
   usetesting:
       os-create-temp: false
       os-mkdir-temp: false
+run:
+  timeout: 5m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shirou/gopsutil/v4
 
-go 1.18
+go 1.23
 
 require (
 	github.com/ebitengine/purego v0.8.2


### PR DESCRIPTION
#### Description

[Go 1.24.0](https://go.dev/blog/go1.24) has been released on since 11 February 2025

This updates Go version from 1.18 to 1.23

Notice that loong64 arch is only available since Go1.19 so it's surprising to see that gopsutil supports it (at least partially) with a Go1.18 module.