### PR TITLE
chore(golangci-lint): cover aix and cgo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,38 +19,46 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: macos-latest, GOOS: darwin, GOARCH: amd64}
-          - {os: macos-latest, GOOS: darwin, GOARCH: arm64}
-          - {os: ubuntu-latest, GOOS: dragonfly, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: freebsd, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: freebsd, GOARCH: 386}
-          - {os: ubuntu-latest, GOOS: freebsd, GOARCH: arm}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: 386}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: arm64}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: arm}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: mips64}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: mips64le}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: mips}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: mipsle}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: ppc64le}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: ppc64}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: riscv64}
-          - {os: ubuntu-latest, GOOS: linux, GOARCH: s390x}
-          - {os: ubuntu-latest, GOOS: netbsd, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: openbsd, GOARCH: 386}
-          - {os: ubuntu-latest, GOOS: openbsd, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: plan9, GOARCH: amd64}
-          - {os: ubuntu-latest, GOOS: plan9, GOARCH: 386}
-          - {os: ubuntu-latest, GOOS: solaris, GOARCH: amd64}
-          - {os: windows-latest, GOOS: windows, GOARCH: amd64}
-          - {os: windows-latest, GOOS: windows, GOARCH: 386}
+          - {os: macos-latest, CGO_ENABLED: "0", GOOS: darwin, GOARCH: amd64}
+          - {os: macos-latest, CGO_ENABLED: "1", GOOS: darwin, GOARCH: amd64}
+          - {os: macos-latest, CGO_ENABLED: "0", GOOS: darwin, GOARCH: arm64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: aix, GOARCH: ppc64}
+#          - {os: ubuntu-latest, CGO_ENABLED: "1", GOOS: aix, GOARCH: ppc64} # FIXME
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: dragonfly, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: freebsd, GOARCH: amd64}
+#          - {os: ubuntu-latest, CGO_ENABLED: "1", GOOS: freebsd, GOARCH: amd64} # FIXME
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: freebsd, GOARCH: 386}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: freebsd, GOARCH: arm}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: 386}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: arm64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: arm}
+#          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: loong64} # FIXME
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips64le}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mipsle}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: ppc64le}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: ppc64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: riscv64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: s390x}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: netbsd, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "1", GOOS: netbsd, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: openbsd, GOARCH: 386}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: openbsd, GOARCH: amd64}
+#          - {os: ubuntu-latest, CGO_ENABLED: "1", GOOS: openbsd, GOARCH: amd64} # FIXME
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: plan9, GOARCH: amd64}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: plan9, GOARCH: 386}
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: solaris, GOARCH: amd64}
+          - {os: windows-latest, CGO_ENABLED: "0", GOOS: windows, GOARCH: amd64}
+          - {os: windows-latest, CGO_ENABLED: "0", GOOS: windows, GOARCH: 386}
     permissions:
       contents: read  # for actions/checkout to fetch code
       pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ${{ matrix.os }}
     env:
+      CGO_ENABLED: "${{ matrix.CGO_ENABLED }}"
       GOARCH: ${{ matrix.GOARCH }}
       GOOS: ${{ matrix.GOOS }}
     steps:

--- a/cpu/cpu_aix_nocgo.go
+++ b/cpu/cpu_aix_nocgo.go
@@ -148,7 +148,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	return []InfoStat{ret}, nil
 }
 
-func CountsWithContext(ctx context.Context, logical bool) (int, error) {
+func CountsWithContext(ctx context.Context, _ bool) (int, error) {
 	info, err := InfoWithContext(ctx)
 	if err == nil {
 		return int(info[0].Cores), nil

--- a/disk/disk_aix.go
+++ b/disk/disk_aix.go
@@ -11,11 +11,11 @@ import (
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
-func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOCountersStat, error) {
+func IOCountersWithContext(_ context.Context, _ ...string) (map[string]IOCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func LabelWithContext(ctx context.Context, name string) (string, error) {
+func LabelWithContext(_ context.Context, _ string) (string, error) {
 	return "", common.ErrNotImplementedError
 }
 

--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/v4/internal/common"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 var startBlank = regexp.MustCompile(`^\s+`)
@@ -25,7 +26,7 @@ var (
 	}
 )
 
-func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
+func PartitionsWithContext(ctx context.Context, _ bool) ([]PartitionStat, error) {
 	var ret []PartitionStat
 
 	out, err := invoke.CommandWithContext(ctx, "mount")

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -27,7 +27,7 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 	return strings.Split(string(out[:]), "\n")[0], nil
 }
 
-func numProcs(ctx context.Context) (uint64, error) {
+func numProcs(_ context.Context) (uint64, error) {
 	return 0, common.ErrNotImplementedError
 }
 
@@ -38,7 +38,7 @@ func BootTimeWithContext(ctx context.Context) (btime uint64, err error) {
 	}
 
 	if ut <= 0 {
-		return 0, errors.New("Uptime was not set, so cannot calculate boot time from it.")
+		return 0, errors.New("uptime was not set, so cannot calculate boot time from it")
 	}
 
 	ut = ut * 60
@@ -110,7 +110,7 @@ func parseUptime(uptime string) uint64 {
 		if err != nil {
 			return 0
 		}
-	case ut[3] == "mins,":
+	case ut[3] == "min," || ut[3] == "mins,":
 		mins, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0
@@ -201,6 +201,6 @@ func KernelArch() (arch string, err error) {
 	return arch, nil
 }
 
-func VirtualizationWithContext(ctx context.Context) (string, string, error) {
+func VirtualizationWithContext(_ context.Context) (string, string, error) {
 	return "", "", common.ErrNotImplementedError
 }

--- a/net/net_aix.go
+++ b/net/net_aix.go
@@ -15,23 +15,23 @@ import (
 )
 
 // Deprecated: use process.PidsWithContext instead
-func PidsWithContext(ctx context.Context) ([]int32, error) {
+func PidsWithContext(_ context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func IOCountersByFileWithContext(ctx context.Context, pernic bool, filename string) ([]IOCountersStat, error) {
-	return IOCounters(pernic)
+func IOCountersByFileWithContext(ctx context.Context, pernic bool, _ string) ([]IOCountersStat, error) {
+	return IOCountersWithContext(ctx, pernic)
 }
 
-func FilterCountersWithContext(ctx context.Context) ([]FilterStat, error) {
+func FilterCountersWithContext(_ context.Context) ([]FilterStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func ConntrackStatsWithContext(ctx context.Context, percpu bool) ([]ConntrackStat, error) {
+func ConntrackStatsWithContext(_ context.Context, _ bool) ([]ConntrackStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
-func ProtoCountersWithContext(ctx context.Context, protocols []string) ([]ProtoCountersStat, error) {
+func ProtoCountersWithContext(_ context.Context, _ []string) ([]ProtoCountersStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 
@@ -202,7 +202,7 @@ func parseNetstatA(output string, kind string) ([]ConnectionStat, error) {
 
 			c, err := parseNetstatUnixLine(fields)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse Unix Address (%s): %s", line, err)
+				return nil, fmt.Errorf("failed to parse Unix Address (%s): %w", line, err)
 			}
 
 			ret = append(ret, c)
@@ -221,7 +221,7 @@ func parseNetstatA(output string, kind string) ([]ConnectionStat, error) {
 
 			c, err := parseNetstatNetLine(line)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse Inet Address (%s): %s", line, err)
+				return nil, fmt.Errorf("failed to parse Inet Address (%s): %w", line, err)
 			}
 
 			ret = append(ret, c)
@@ -294,6 +294,6 @@ func ConnectionsPidMaxWithoutUidsWithContext(ctx context.Context, kind string, p
 	return connectionsPidMaxWithoutUidsWithContext(ctx, kind, pid, maxConn, true)
 }
 
-func connectionsPidMaxWithoutUidsWithContext(ctx context.Context, kind string, pid int32, maxConn int, skipUids bool) ([]ConnectionStat, error) {
+func connectionsPidMaxWithoutUidsWithContext(_ context.Context, _ string, _ int32, _ int, _ bool) ([]ConnectionStat, error) {
 	return []ConnectionStat{}, common.ErrNotImplementedError
 }

--- a/net/net_aix_cgo.go
+++ b/net/net_aix_cgo.go
@@ -29,7 +29,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		}
 		iocounters = append(iocounters, n)
 	}
-	if pernic == false {
+	if !pernic {
 		return getIOCountersAll(iocounters), nil
 	}
 	return iocounters, nil

--- a/net/net_aix_nocgo.go
+++ b/net/net_aix_nocgo.go
@@ -5,7 +5,7 @@ package net
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -19,7 +19,7 @@ func parseNetstatI(output string) ([]IOCountersStat, error) {
 
 	// Check first line is header
 	if len(lines) > 0 && strings.Fields(lines[0])[0] != "Name" {
-		return nil, fmt.Errorf("not a 'netstat -i' output")
+		return nil, errors.New("not a 'netstat -i' output")
 	}
 
 	for _, line := range lines[1:] {
@@ -88,7 +88,7 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 	if err != nil {
 		return nil, err
 	}
-	if pernic == false {
+	if !pernic {
 		return getIOCountersAll(iocounters), nil
 	}
 	return iocounters, nil

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -59,7 +59,7 @@ func TestPid_exists(t *testing.T) {
 		t.Errorf("error %v", err)
 	}
 
-	if ret == false {
+	if !ret {
 		t.Errorf("could not get process exists: %v", ret)
 	}
 }

--- a/sensors/sensors_aix.go
+++ b/sensors/sensors_aix.go
@@ -13,10 +13,10 @@ const (
 	hostTemperatureScale = 1000.0 // Not part of the linked file, but kept just in case it becomes relevant
 )
 
-func VirtualizationWithContext(ctx context.Context) (string, string, error) {
+func VirtualizationWithContext(_ context.Context) (string, string, error) {
 	return "", "", common.ErrNotImplementedError
 }
 
-func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
+func TemperaturesWithContext(_ context.Context) ([]TemperatureStat, error) {
 	return []TemperatureStat{}, common.ErrNotImplementedError
 }


### PR DESCRIPTION
#### Description

Extends golangci-lint to cover aix architecture and cgo option