### PR TITLE
chore: enable var-naming from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,7 +99,10 @@ linters-settings:
       - name: use-any
       - name: var-declaration
       - name: var-naming
-        disabled: true
+        arguments:
+          - ["ID"] # AllowList
+          - ["VM"] # DenyList
+          - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
   testifylint:
     enable-all: true
   thelper:

--- a/cpu/cpu_aix_nocgo.go
+++ b/cpu/cpu_aix_nocgo.go
@@ -14,11 +14,11 @@ import (
 func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 	var ret []TimesStat
 	if percpu {
-		per_out, err := invoke.CommandWithContext(ctx, "sar", "-u", "-P", "ALL", "10", "1")
+		perOut, err := invoke.CommandWithContext(ctx, "sar", "-u", "-P", "ALL", "10", "1")
 		if err != nil {
 			return nil, err
 		}
-		lines := strings.Split(string(per_out), "\n")
+		lines := strings.Split(string(perOut), "\n")
 		if len(lines) < 6 {
 			return []TimesStat{}, common.ErrNotImplementedError
 		}

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -37,10 +37,10 @@ const (
 
 // mach/processor_info.h
 const (
-	processorCpuLoadInfo = 2
+	processorCpuLoadInfo = 2 //nolint:revive //FIXME
 )
 
-type hostCpuLoadInfoData struct {
+type hostCpuLoadInfoData struct { //nolint:revive //FIXME
 	cpuTicks [cpuStateMax]uint32
 }
 

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -17,7 +17,7 @@ import (
 
 var procGetNativeSystemInfo = common.Modkernel32.NewProc("GetNativeSystemInfo")
 
-type win32_Processor struct {
+type win32_Processor struct { //nolint:revive //FIXME
 	Family                    uint16
 	Manufacturer              string
 	Name                      string
@@ -33,7 +33,7 @@ type win32_Processor struct {
 // https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation#system_processor_performance_information
 // additional fields documented here
 // https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/processor_performance.htm
-type win32_SystemProcessorPerformanceInformation struct {
+type win32_SystemProcessorPerformanceInformation struct { //nolint:revive //FIXME
 	IdleTime       int64 // idle time in 100ns (this is not a filetime).
 	KernelTime     int64 // kernel time in 100ns.  kernel time includes idle time. (this is not a filetime).
 	UserTime       int64 // usertime in 100ns (this is not a filetime).
@@ -47,10 +47,10 @@ const (
 
 	// systemProcessorPerformanceInformationClass information class to query with NTQuerySystemInformation
 	// https://processhacker.sourceforge.io/doc/ntexapi_8h.html#ad5d815b48e8f4da1ef2eb7a2f18a54e0
-	win32_SystemProcessorPerformanceInformationClass = 8
+	win32_SystemProcessorPerformanceInformationClass = 8 //nolint:revive //FIXME
 
 	// size of systemProcessorPerformanceInfoSize in memory
-	win32_SystemProcessorPerformanceInfoSize = uint32(unsafe.Sizeof(win32_SystemProcessorPerformanceInformation{}))
+	win32_SystemProcessorPerformanceInfoSize = uint32(unsafe.Sizeof(win32_SystemProcessorPerformanceInformation{})) //nolint:revive //FIXME
 )
 
 // Times returns times stat per cpu and combined for all CPUs

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -144,8 +144,8 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 }
 
 func (b bintime) Compute() float64 {
-	BINTIME_SCALE := 5.42101086242752217003726400434970855712890625e-20
-	return float64(b.Sec) + float64(b.Frac)*BINTIME_SCALE
+	bintimeScale := 5.42101086242752217003726400434970855712890625e-20
+	return float64(b.Sec) + float64(b.Frac)*bintimeScale
 }
 
 // BT2LD(time)     ((long double)(time).sec + (time).frac * BINTIME_SCALE)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -528,10 +528,10 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 
 func LabelWithContext(ctx context.Context, name string) (string, error) {
 	// Try label based on devicemapper name
-	dmname_filename := common.HostSysWithContext(ctx, fmt.Sprintf("block/%s/dm/name", name))
+	dmnameFilename := common.HostSysWithContext(ctx, fmt.Sprintf("block/%s/dm/name", name))
 	// Could errors.Join errs with Go >= 1.20
-	if common.PathExists(dmname_filename) {
-		dmname, err := os.ReadFile(dmname_filename)
+	if common.PathExists(dmnameFilename) {
+		dmname, err := os.ReadFile(dmnameFilename)
 		if err == nil {
 			return strings.TrimSpace(string(dmname)), nil
 		}

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -14,7 +14,7 @@ import (
 
 // from https://www.ibm.com/docs/en/aix/7.2?topic=files-utmph-file
 const (
-	user_PROCESS = 7
+	user_PROCESS = 7 //nolint:revive //FIXME
 )
 
 func HostIDWithContext(ctx context.Context) (string, error) {

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -20,7 +20,7 @@ import (
 )
 
 // from utmpx.h
-const user_PROCESS = 7
+const user_PROCESS = 7 //nolint:revive //FIXME
 
 func HostIDWithContext(ctx context.Context) (string, error) {
 	out, err := invoke.CommandWithContext(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice")

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -27,7 +27,7 @@ type lsbStruct struct {
 
 // from utmp.h
 const (
-	user_PROCESS = 7
+	user_PROCESS = 7 //nolint:revive //FIXME
 )
 
 func HostIDWithContext(ctx context.Context) (string, error) {

--- a/host/host_linux_386.go
+++ b/host/host_linux_386.go
@@ -16,15 +16,15 @@ const (
 )
 
 type (
-	_C_short     int16
-	_C_int       int32
-	_C_long      int32
-	_C_long_long int64
+	_C_short     int16 //nolint:revive //FIXME
+	_C_int       int32 //nolint:revive //FIXME
+	_C_long      int32 //nolint:revive //FIXME
+	_C_long_long int64 //nolint:revive //FIXME
 )
 
 type utmp struct {
 	Type      int16
-	Pad_cgo_0 [2]byte
+	Pad_cgo_0 [2]byte //nolint:revive //FIXME
 	Pid       int32
 	Line      [32]int8
 	ID        [4]int8
@@ -33,11 +33,11 @@ type utmp struct {
 	Exit      exit_status
 	Session   int32
 	Tv        UtTv
-	Addr_v6   [4]int32
-	X__unused [20]int8
+	Addr_v6   [4]int32 //nolint:revive //FIXME
+	X__unused [20]int8 //nolint:revive //FIXME
 }
 
-type exit_status struct {
+type exit_status struct { //nolint:revive //FIXME
 	Termination int16
 	Exit        int16
 }

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -17,19 +17,19 @@ import (
 )
 
 // for double values
-type PDH_FMT_COUNTERVALUE_DOUBLE struct {
+type PDH_FMT_COUNTERVALUE_DOUBLE struct { //nolint:revive //FIXME
 	CStatus     uint32
 	DoubleValue float64
 }
 
 // for 64 bit integer values
-type PDH_FMT_COUNTERVALUE_LARGE struct {
+type PDH_FMT_COUNTERVALUE_LARGE struct { //nolint:revive //FIXME
 	CStatus    uint32
 	LargeValue int64
 }
 
 // for long values
-type PDH_FMT_COUNTERVALUE_LONG struct {
+type PDH_FMT_COUNTERVALUE_LONG struct { //nolint:revive //FIXME
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte

--- a/load/load_bsd.go
+++ b/load/load_bsd.go
@@ -40,7 +40,7 @@ func AvgWithContext(ctx context.Context) (*AvgStat, error) {
 type forkstat struct {
 	forks    int
 	vforks   int
-	__tforks int
+	__tforks int //nolint:revive //FIXME
 }
 
 // Misc returns miscellaneous host-wide statistics.

--- a/load/load_linux.go
+++ b/load/load_linux.go
@@ -32,11 +32,11 @@ func sysinfoAvgWithContext() (*AvgStat, error) {
 		return nil, err
 	}
 
-	const si_load_shift = 16
+	const siLoadShift = 16
 	return &AvgStat{
-		Load1:  float64(info.Loads[0]) / float64(1<<si_load_shift),
-		Load5:  float64(info.Loads[1]) / float64(1<<si_load_shift),
-		Load15: float64(info.Loads[2]) / float64(1<<si_load_shift),
+		Load1:  float64(info.Loads[0]) / float64(1<<siLoadShift),
+		Load5:  float64(info.Loads[1]) / float64(1<<siLoadShift),
+		Load15: float64(info.Loads[2]) / float64(1<<siLoadShift),
 	}, nil
 }
 

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -27,16 +27,16 @@ const ( // Conntrack Column numbers
 	ctINVALID
 	ctIGNORE
 	ctDELETE
-	ctDELETE_LIST
+	ctDELETE_LIST //nolint:revive //FIXME
 	ctINSERT
-	ctINSERT_FAILED
+	ctINSERT_FAILED //nolint:revive //FIXME
 	ctDROP
-	ctEARLY_DROP
-	ctICMP_ERROR
-	CT_EXPEctNEW
-	ctEXPECT_CREATE
-	CT_EXPEctDELETE
-	ctSEARCH_RESTART
+	ctEARLY_DROP     //nolint:revive //FIXME
+	ctICMP_ERROR     //nolint:revive //FIXME
+	CT_EXPEctNEW     //nolint:revive //FIXME
+	ctEXPECT_CREATE  //nolint:revive //FIXME
+	CT_EXPEctDELETE  //nolint:revive //FIXME
+	ctSEARCH_RESTART //nolint:revive //FIXME
 )
 
 func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, error) {

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -96,7 +96,7 @@ const (
 type mibIfRow2 struct {
 	InterfaceLuid               uint64
 	InterfaceIndex              uint32
-	InterfaceGuid               guid
+	InterfaceGuid               guid //nolint:revive //FIXME
 	Alias                       [maxStringSize + 1]uint16
 	Description                 [maxStringSize + 1]uint16
 	PhysicalAddressLength       uint32
@@ -113,7 +113,7 @@ type mibIfRow2 struct {
 	OperStatus                  uint32
 	AdminStatus                 uint32
 	MediaConnectState           uint32
-	NetworkGuid                 guid
+	NetworkGuid                 guid //nolint:revive //FIXME
 	ConnectionType              uint32
 	padding1                    [pad0for64_4for32]byte
 	TransmitLinkSpeed           uint64
@@ -383,7 +383,7 @@ func getTCPConnections(family uint32) ([]ConnectionStat, error) {
 			}
 		}
 
-		err := getExtendedTcpTable(p,
+		err := getExtendedTCPTable(p,
 			&size,
 			true,
 			family,
@@ -464,7 +464,7 @@ func getUDPConnections(family uint32) ([]ConnectionStat, error) {
 			}
 		}
 
-		err := getExtendedUdpTable(
+		err := getExtendedUDPTable(
 			p,
 			&size,
 			true,
@@ -528,16 +528,16 @@ var tcpStatuses = map[mibTCPState]string{
 	12: "DELETE",
 }
 
-func getExtendedTcpTable(pTcpTable uintptr, pdwSize *uint32, bOrder bool, ulAf uint32, tableClass tcpTableClass, reserved uint32) (errcode error) {
-	r1, _, _ := syscall.Syscall6(procGetExtendedTCPTable.Addr(), 6, pTcpTable, uintptr(unsafe.Pointer(pdwSize)), getUintptrFromBool(bOrder), uintptr(ulAf), uintptr(tableClass), uintptr(reserved))
+func getExtendedTCPTable(pTCPTable uintptr, pdwSize *uint32, bOrder bool, ulAf uint32, tableClass tcpTableClass, reserved uint32) (errcode error) {
+	r1, _, _ := syscall.Syscall6(procGetExtendedTCPTable.Addr(), 6, pTCPTable, uintptr(unsafe.Pointer(pdwSize)), getUintptrFromBool(bOrder), uintptr(ulAf), uintptr(tableClass), uintptr(reserved))
 	if r1 != 0 {
 		errcode = syscall.Errno(r1)
 	}
 	return
 }
 
-func getExtendedUdpTable(pUdpTable uintptr, pdwSize *uint32, bOrder bool, ulAf uint32, tableClass udpTableClass, reserved uint32) (errcode error) {
-	r1, _, _ := syscall.Syscall6(procGetExtendedUDPTable.Addr(), 6, pUdpTable, uintptr(unsafe.Pointer(pdwSize)), getUintptrFromBool(bOrder), uintptr(ulAf), uintptr(tableClass), uintptr(reserved))
+func getExtendedUDPTable(pUDPTable uintptr, pdwSize *uint32, bOrder bool, ulAf uint32, tableClass udpTableClass, reserved uint32) (errcode error) {
+	r1, _, _ := syscall.Syscall6(procGetExtendedUDPTable.Addr(), 6, pUDPTable, uintptr(unsafe.Pointer(pdwSize)), getUintptrFromBool(bOrder), uintptr(ulAf), uintptr(tableClass), uintptr(reserved))
 	if r1 != 0 {
 		errcode = syscall.Errno(r1)
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -326,12 +326,12 @@ func calculatePercent(t1, t2 *cpu.TimesStat, delta float64, numcpu int) float64 
 		return 0
 	}
 	// https://github.com/giampaolo/psutil/blob/c034e6692cf736b5e87d14418a8153bb03f6cf42/psutil/__init__.py#L1064
-	delta_proc := (t2.User - t1.User) + (t2.System - t1.System)
-	if delta_proc <= 0 {
+	deltaProc := (t2.User - t1.User) + (t2.System - t1.System)
+	if deltaProc <= 0 {
 		return 0
 	}
-	overall_percent := ((delta_proc / delta) * 100) * float64(numcpu)
-	return overall_percent
+	overallPercent := ((deltaProc / delta) * 100) * float64(numcpu)
+	return overallPercent
 }
 
 // MemoryPercent returns how many percent of the total RAM this process uses
@@ -361,7 +361,7 @@ func (p *Process) CPUPercent() (float64, error) {
 }
 
 func (p *Process) CPUPercentWithContext(ctx context.Context) (float64, error) {
-	crt_time, err := p.createTimeWithContext(ctx)
+	createTime, err := p.createTimeWithContext(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -371,7 +371,7 @@ func (p *Process) CPUPercentWithContext(ctx context.Context) (float64, error) {
 		return 0, err
 	}
 
-	created := time.Unix(0, crt_time*int64(time.Millisecond))
+	created := time.Unix(0, createTime*int64(time.Millisecond))
 	totalTime := time.Since(created).Seconds()
 	if totalTime <= 0 {
 		return 0, nil

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -33,7 +33,7 @@ const (
 	KernProcPathname = 12 // path to executable
 )
 
-type _Ctype_struct___0 struct {
+type _Ctype_struct___0 struct { //nolint:revive //FIXME
 	Pad uint64
 }
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -958,7 +958,7 @@ func getProcessMemoryInfo(h windows.Handle, mem *PROCESS_MEMORY_COUNTERS) (err e
 	return
 }
 
-type SYSTEM_TIMES struct {
+type SYSTEM_TIMES struct { //nolint:revive //FIXME
 	CreateTime syscall.Filetime
 	ExitTime   syscall.Filetime
 	KernelTime syscall.Filetime

--- a/process/process_windows_32bit.go
+++ b/process/process_windows_32bit.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
-type PROCESS_MEMORY_COUNTERS struct {
+type PROCESS_MEMORY_COUNTERS struct { //nolint:revive //FIXME
 	CB                         uint32
 	PageFaultCount             uint32
 	PeakWorkingSetSize         uint32

--- a/process/process_windows_64bit.go
+++ b/process/process_windows_64bit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
-type PROCESS_MEMORY_COUNTERS struct {
+type PROCESS_MEMORY_COUNTERS struct { //nolint:revive //FIXME
 	CB                         uint32
 	PageFaultCount             uint32
 	PeakWorkingSetSize         uint64

--- a/sensors/sensors_windows.go
+++ b/sensors/sensors_windows.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
-type msAcpi_ThermalZoneTemperature struct {
+type msAcpi_ThermalZoneTemperature struct { //nolint:revive //FIXME
 	Active             bool
 	CriticalTripPoint  uint32
 	CurrentTemperature uint32


### PR DESCRIPTION
#### Description

Enable [var-naming](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming) from revive 

Only fixes private variable or functions naming and add `nolint:revive //FIXME` to the rest of cases.