### PR TITLE
[host][process]: fix type missmatch test.

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -50,7 +50,7 @@ func TestBootTime(t *testing.T) {
 	common.SkipIfNotImplementedErr(t, err)
 	require.NoError(t, err)
 	assert.NotZerof(t, v, "Could not get boot time %v", v)
-	assert.GreaterOrEqualf(t, v, 946652400, "Invalid Boottime, older than 2000-01-01")
+	assert.GreaterOrEqualf(t, v, uint64(946652400), "Invalid Boottime, older than 2000-01-01")
 	t.Logf("first boot time: %d", v)
 
 	v2, err := BootTime()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -384,7 +384,7 @@ func TestCreateTime(t *testing.T) {
 	common.SkipIfNotImplementedErr(t, err)
 	require.NoError(t, err)
 
-	assert.GreaterOrEqualf(t, c, 1420000000, "process created time is wrong.")
+	assert.GreaterOrEqualf(t, c, int64(1420000000), "process created time is wrong.")
 
 	gotElapsed := time.Since(time.Unix(int64(c/1000), 0))
 	maxElapsed := time.Duration(20 * time.Second)


### PR DESCRIPTION
This PR fixes tests which there are skipped on CI.

The errors are like this.
```
--- FAIL: TestCreateTime (0.00s)
    process_test.go:387:
                Error Trace:    /home/foo/bar/github.com/shirou/gopsutil/process/process_test.go:387
                Error:          Elements should be the same type
                Test:           TestCreateTime
                Messages:       process created time is wrong.
FAIL
```