### PR TITLE
chore: enable govet linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - gocritic
     - gomodguard
     - gosec
+    - govet
     - importas
     - misspell
     - nakedret
@@ -33,7 +34,6 @@ linters:
     - usetesting
   disable:
     - errcheck
-    - govet
     - ineffassign
     - staticcheck
     - unused
@@ -51,6 +51,13 @@ linters:
     gosec:
       excludes:
         - G115
+    govet:
+      disable:
+        - copylocks
+        - fieldalignment
+        - shadow
+        - testinggoroutine
+      enable-all: true
     perfsprint:
       # Optimizes even if it requires an int or uint type cast.
       int-conversion: true


### PR DESCRIPTION
#### Description

- Adding `govet` to the list of enabled linters in the Golang CI configuration 