### PR TITLE
fix: enable loong64 architecture in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: amd64}
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: arm64}
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: arm}
-#          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: loong64} # FIXME
+          - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: loong64}
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips64}
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips64le}
           - {os: ubuntu-latest, CGO_ENABLED: "0", GOOS: linux, GOARCH: mips}


### PR DESCRIPTION
#### Description

This pull request includes a small change to the `.github/workflows/lint.yml` file. The change re-enables the previously commented-out configuration for the `loong64` architecture.