### PR TITLE
[chore]: bump golangci-lint to v2.1.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Setup golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd  # v7.0.0
         with:
           args: --verbose
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,25 @@
+version: "2"
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/shirou)
 issues:
   max-same-issues: 0
-  exclude-rules: []
 linters:
   enable:
     - asciicheck
     - contextcheck
     - durationcheck
     - errorlint
-    - gci
     - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
     - gomodguard
     - gosec
-    - gosimple
     - importas
     - misspell
     - nakedret
@@ -24,7 +29,6 @@ linters:
     - revive
     - testifylint
     - thelper
-    - typecheck
     - unparam
     - usetesting
   disable:
@@ -33,83 +37,88 @@ linters:
     - ineffassign
     - staticcheck
     - unused
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/shirou)
-  gocritic:
-    disabled-checks:
-      - captLocal
-  gomodguard:
-    blocked:
-      modules:
-        - io/ioutil:
-            recommendations:
-              - io
-              - os
-  gosec:
-    excludes:
-      - G115
-  perfsprint:
-    # Optimizes even if it requires an int or uint type cast.
-    int-conversion: true
-    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
-    err-error: true
-    # Optimizes `fmt.Errorf`.
-    errorf: true
-    # Optimizes `fmt.Sprintf` with only one argument.
-    sprintf1: true
-    # Optimizes into strings concatenation.
-    strconcat: true
-  revive:
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
-      - name: context-keys-type
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: early-return
-        arguments:
-          - "preserveScope"
-      - name: empty-block
-        disabled: true
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: exported
-        disabled: true
-      - name: errorf
-      - name: increment-decrement
-      - name: indent-error-flow
-        arguments:
-          - "preserveScope"
-      - name: range
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: redundant-import-alias
-      - name: superfluous-else
-        arguments:
-          - "preserveScope"
-      - name: time-naming
-      - name: unexported-return
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: use-any
-      - name: var-declaration
-      - name: var-naming
-        arguments:
-          - ["ID"] # AllowList
-          - ["VM"] # DenyList
-          - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
-  testifylint:
-    enable-all: true
-  usetesting:
+  settings:
+    gocritic:
+      disabled-checks:
+        - captLocal
+    gomodguard:
+      blocked:
+        modules:
+          - io/ioutil:
+              recommendations:
+                - io
+                - os
+    gosec:
+      excludes:
+        - G115
+    perfsprint:
+      # Optimizes even if it requires an int or uint type cast.
+      int-conversion: true
+      # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+      err-error: true
+      # Optimizes `fmt.Errorf`.
+      errorf: true
+      # Optimizes `fmt.Sprintf` with only one argument.
+      sprintf1: true
+      # Optimizes into strings concatenation.
+      strconcat: true
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
+        - name: context-keys-type
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+          arguments:
+            - "preserveScope"
+        - name: empty-block
+          disabled: true
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: exported
+          disabled: true
+        - name: errorf
+        - name: increment-decrement
+        - name: indent-error-flow
+          arguments:
+            - "preserveScope"
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: redundant-import-alias
+        - name: superfluous-else
+          arguments:
+            - "preserveScope"
+        - name: time-naming
+        - name: unexported-return
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: use-any
+        - name: var-declaration
+        - name: var-naming
+          arguments:
+            - ["ID"] # AllowList
+            - ["VM"] # DenyList
+            - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
+    testifylint:
+      enable-all: true
+    usetesting:
       os-create-temp: false
       os-mkdir-temp: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    warn-unused: true
+output:
+  show-stats: false
 run:
   timeout: 5m

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -554,7 +554,7 @@ func TestOpenFiles(t *testing.T) {
 	assert.NotEmpty(t, v) // test always open files.
 
 	for _, vv := range v {
-		assert.NotEqual(t, "", vv.Path)
+		assert.NotEmpty(t, vv.Path)
 	}
 }
 


### PR DESCRIPTION
#### Description

This updates golangci-lint version to v2 and golangci-lint-action to V7.