### PR TITLE
[host]: fix potential error on CI test on Windows.

### DIFF
--- a/host/host_test.go
+++ b/host/host_test.go
@@ -115,7 +115,7 @@ func TestVirtualization(t *testing.T) {
 	for i := 0; i < testCount; i++ {
 		go func(j int) {
 			system, role, err := Virtualization()
-			wg.Done()
+			defer wg.Done()
 			common.SkipIfNotImplementedErr(t, err)
 			assert.NoErrorf(t, err, "Virtualization() failed, %v", err)
 


### PR DESCRIPTION
Sometimes test `host/TestVirtualization` on CI [fails](https://github.com/shirou/gopsutil/actions/runs/14142756595/job/39626344426). This PR try to fix the error even if I can not reproduce the error.