### PR TITLE
fix nil ptr

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -5,6 +5,7 @@ package cpu
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -153,7 +154,7 @@ func perCPUTimes(machLib *common.Library) ([]TimesStat, error) {
 	}
 
 	if cpuload == nil {
-		return nil, fmt.Errorf("host_processor_info returned nil cpuload")
+		return nil, errors.New("host_processor_info returned nil cpuload")
 	}
 
 	defer vmDeallocate(machTaskSelf(), uintptr(unsafe.Pointer(cpuload)), uintptr(ncpu))

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -152,6 +152,10 @@ func perCPUTimes(machLib *common.Library) ([]TimesStat, error) {
 		return nil, fmt.Errorf("host_processor_info error=%d", status)
 	}
 
+	if cpuload == nil {
+		return nil, fmt.Errorf("host_processor_info returned nil cpuload")
+	}
+
 	defer vmDeallocate(machTaskSelf(), uintptr(unsafe.Pointer(cpuload)), uintptr(ncpu))
 
 	ret := []TimesStat{}


### PR DESCRIPTION
This pull request includes a small but important change to the `perCPUTimes` function in the `cpu/cpu_darwin.go` file. The change adds a check to ensure that the `cpuload` variable is not nil before proceeding, which helps prevent potential runtime errors.

* [`cpu/cpu_darwin.go`](diffhunk://#diff-331b840c2c5c144a66ee5b2729fc9bbfab8987d13bae2d3f8ecf1706199e985aR155-R158): Added a nil check for the `cpuload` variable in the `perCPUTimes` function to handle cases where `host_processor_info` might return a nil value.

Possible fix for: https://github.com/shirou/gopsutil/issues/1834