### PR TITLE
Use the context provide to UsageWithContext public function

### DIFF
--- a/disk/disk_aix_cgo.go
+++ b/disk/disk_aix_cgo.go
@@ -44,7 +44,7 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	return ret, err
 }
 
-func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	f, err := perfstat.FileSystemStat()
 	if err != nil {
 		return nil, err

--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -84,7 +84,7 @@ func getFsType(stat unix.Statfs_t) string {
 	return FSType[int(stat.Vfstype)]
 }
 
-func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
+func getUsage(ctx context.Context, path string) (*UsageStat, error) {
 	out, err := invoke.CommandWithContext(ctx, "df", "-v")
 	if err != nil {
 		return nil, err

--- a/disk/disk_fallback.go
+++ b/disk/disk_fallback.go
@@ -17,7 +17,7 @@ func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 	return []PartitionStat{}, common.ErrNotImplementedError
 }
 
-func UsageWithContext(_ context.Context, _ string) (*UsageStat, error) {
+func getUsage(_ context.Context, _ string) (*UsageStat, error) {
 	return nil, common.ErrNotImplementedError
 }
 

--- a/disk/disk_netbsd.go
+++ b/disk/disk_netbsd.go
@@ -102,7 +102,7 @@ func IOCountersWithContext(_ context.Context, _ ...string) (map[string]IOCounter
 	return ret, common.ErrNotImplementedError
 }
 
-func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	stat := Statvfs{}
 	flag := uint64(1) // ST_WAIT/MNT_WAIT, see sys/fstypes.h
 

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -122,7 +122,7 @@ func parseDiskstats(buf []byte) (Diskstats, error) {
 	return ds, nil
 }
 
-func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	stat := unix.Statfs_t{}
 	err := unix.Statfs(path, &stat)
 	if err != nil {

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -199,7 +199,7 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 	return ret, nil
 }
 
-func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	statvfs := unix.Statvfs_t{}
 	if err := unix.Statvfs(path, &statvfs); err != nil {
 		return nil, fmt.Errorf("unable to call statvfs(2) on %q: %w", path, err)

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	stat := unix.Statfs_t{}
 	err := unix.Statfs(path, &stat)
 	if err != nil {

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -55,7 +55,7 @@ func init() {
 	}
 }
 
-func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
+func getUsage(_ context.Context, path string) (*UsageStat, error) {
 	lpFreeBytesAvailable := int64(0)
 	lpTotalNumberOfBytes := int64(0)
 	lpTotalNumberOfFreeBytes := int64(0)


### PR DESCRIPTION
Currently, at work, we use gopsutil. We wanted to use the `disk.UsageWithContext` to allow setting some timeout when calling the Usage function. 

We realized that the function UsageWithContext does not use the ctx provided. 

It would be a good addition to this great package. 

Before adding a test or even applying this pattern to other functions `*WithContext,` I wanted to know if this is something that we would be ok with having in the package. If so, I can add tests and extend the pattern to the rest of the  `*WithContext` functions. 

Looking forward for your feedback.