### PR TITLE
refactor: using fmt.Errorf in InfoWithContext

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"runtime"
 	"time"
@@ -70,47 +71,47 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 
 	ret.Hostname, err = os.Hostname()
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting hostname: %w", err)
 	}
 
 	ret.Platform, ret.PlatformFamily, ret.PlatformVersion, err = PlatformInformationWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting platform information: %w", err)
 	}
 
 	ret.KernelVersion, err = KernelVersionWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting kernel version: %w", err)
 	}
 
 	ret.KernelArch, err = KernelArch()
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting kernel archictecture: %w", err)
 	}
 
 	ret.VirtualizationSystem, ret.VirtualizationRole, err = VirtualizationWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting virtualization information: %w", err)
 	}
 
 	ret.BootTime, err = BootTimeWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting boot time: %w", err)
 	}
 
 	ret.Uptime, err = UptimeWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting uptime: %w", err)
 	}
 
 	ret.Procs, err = numProcs(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting number of procs: %w", err)
 	}
 
 	ret.HostID, err = HostIDWithContext(ctx)
 	if err != nil && !errors.Is(err, common.ErrNotImplementedError) {
-		return nil, err
+		return nil, fmt.Errorf("getting host ID: %w", err)
 	}
 
 	return ret, nil


### PR DESCRIPTION
The following brings:
- Refactoring of `InfoWithContext` to wrap errors with `fmt.Errorf` in order to add textual context, making error messages more helpful for the end user.

ref: #1836