### PR TITLE
chore: enable staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,13 +29,13 @@ linters:
     - perfsprint
     - predeclared
     - revive
+    - staticcheck
     - testifylint
     - thelper
     - unparam
     - usetesting
   disable:
     - errcheck
-    - staticcheck
     - unused
   settings:
     gocritic:
@@ -112,6 +112,18 @@ linters:
             - ["ID"] # AllowList
             - ["VM"] # DenyList
             - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
+    staticcheck:
+      checks:
+        - all
+        - -SA1019 # Using a deprecated function, variable, constant or field
+        - -SA2002 # Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed
+        - -SA4003 # Comparing unsigned values against negative values is pointless
+        - -SA4004 # The loop exits unconditionally after one iteration
+        - -SA4008 # The variable in the loop condition never changes, are you incrementing the wrong variable?
+        - -SA5003 # Defers in infinite loops will never execute
+        - -SA9003 # Empty body in an if or else branch
+        - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Incorrectly formatted error string
     testifylint:
       enable-all: true
     usetesting:

--- a/cpu/cpu_darwin_arm64.go
+++ b/cpu/cpu_darwin_arm64.go
@@ -51,7 +51,7 @@ func getFrequency() (float64, error) {
 	var pCoreHz uint32
 	for {
 		service := ioIteratorNext(iterator)
-		if !(service > 0) {
+		if service <= 0 {
 			break
 		}
 

--- a/cpu/cpu_solaris.go
+++ b/cpu/cpu_solaris.go
@@ -159,10 +159,7 @@ func parseISAInfo(cmdOutput string) ([]string, error) {
 		return nil, errors.New("attempted to parse invalid isainfo output")
 	}
 
-	flags := make([]string, len(words)-4)
-	for i, val := range words[4:] { //nolint:gosimple //FIXME
-		flags[i] = val
-	}
+	flags := words[4:]
 	sort.Strings(flags)
 
 	return flags, nil

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -201,7 +201,7 @@ func IOCountersWithContext(_ context.Context, names ...string) (map[string]IOCou
 	stats := make([]IOCountersStat, 0, 16)
 	for {
 		d := ioIteratorNext(drives)
-		if !(d > 0) {
+		if d <= 0 {
 			break
 		}
 

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -67,8 +67,8 @@ func parseUptime(uptime string) uint64 {
 	var days, hours, mins uint64
 	var err error
 
-	switch {
-	case ut[3] == "day," || ut[3] == "days,":
+	switch ut[3] {
+	case "day,", "days,":
 		days, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0
@@ -105,12 +105,12 @@ func parseUptime(uptime string) uint64 {
 				return 0
 			}
 		}
-	case ut[3] == "hr," || ut[3] == "hrs,":
+	case "hr,", "hrs,":
 		hours, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0
 		}
-	case ut[3] == "min," || ut[3] == "mins,":
+	case "min,", "mins,":
 		mins, err = strconv.ParseUint(ut[2], 10, 64)
 		if err != nil {
 			return 0

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -67,8 +67,7 @@ func UsersWithContext(_ context.Context) ([]UserStat, error) {
 	// Skip macOS utmpx header part
 	buf = buf[604:]
 
-	u := Utmpx{}
-	entrySize := int(unsafe.Sizeof(u))
+	entrySize := int(unsafe.Sizeof(Utmpx{}))
 	count := len(buf) / entrySize
 
 	for i := 0; i < count; i++ {

--- a/host/host_freebsd.go
+++ b/host/host_freebsd.go
@@ -117,8 +117,7 @@ func getUsersFromUtmp(utmpfile string) ([]UserStat, error) {
 		return ret, err
 	}
 
-	u := Utmp{}
-	entrySize := int(unsafe.Sizeof(u))
+	entrySize := int(unsafe.Sizeof(Utmp{}))
 	count := len(buf) / entrySize
 
 	for i := 0; i < count; i++ {

--- a/host/host_openbsd.go
+++ b/host/host_openbsd.go
@@ -71,8 +71,7 @@ func UsersWithContext(_ context.Context) ([]UserStat, error) {
 		return ret, err
 	}
 
-	u := Utmp{}
-	entrySize := int(unsafe.Sizeof(u))
+	entrySize := int(unsafe.Sizeof(Utmp{}))
 	count := len(buf) / entrySize
 
 	for i := 0; i < count; i++ {

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -393,10 +393,7 @@ func GoString(cStr *byte) string {
 		return ""
 	}
 	var length int
-	for {
-		if *(*byte)(unsafe.Add(unsafe.Pointer(cStr), uintptr(length))) == '\x00' {
-			break
-		}
+	for *(*byte)(unsafe.Add(unsafe.Pointer(cStr), uintptr(length))) != '\x00' {
 		length++
 	}
 	return string(unsafe.Slice(cStr, length))

--- a/net/net_openbsd.go
+++ b/net/net_openbsd.go
@@ -296,7 +296,7 @@ func ConnectionsWithContext(ctx context.Context, kind string) ([]ConnectionStat,
 	}
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
-		if !(strings.HasPrefix(line, "tcp") || strings.HasPrefix(line, "udp")) {
+		if !strings.HasPrefix(line, "tcp") && !strings.HasPrefix(line, "udp") {
 			continue
 		}
 		n, err := parseNetstatLine(line)

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -594,7 +594,7 @@ func (p *Process) NumThreadsWithContext(_ context.Context) (int32, error) {
 
 	// if no errors and not cached already, cache ppid
 	p.parent = ppid
-	if 0 == p.getPpid() {
+	if p.getPpid() == 0 {
 		p.setPpid(ppid)
 	}
 


### PR DESCRIPTION
#### Description

- Adding `staticcheck` to the list of enabled linters in the Golang CI configuration 
- It excludes all the rules with which the code doesn't comply yet and will be fixed in dedicated PR and fixed the quick fixes.