### PR TITLE
chore: enable ineffassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - gosec
     - govet
     - importas
+    - ineffassign
     - misspell
     - nakedret
     - nolintlint
@@ -34,7 +35,6 @@ linters:
     - usetesting
   disable:
     - errcheck
-    - ineffassign
     - staticcheck
     - unused
   settings:

--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -63,7 +63,7 @@ func PartitionsWithContext(ctx context.Context, _ bool) ([]PartitionStat, error)
 		if startBlank.MatchString(line) {
 			line = "localhost" + line
 		}
-		p := strings.Fields(lines[idx])
+		p := strings.Fields(line)
 		if len(p) < 5 || ignoreFSType[p[colidx["vfs"]]] {
 			continue
 		}


### PR DESCRIPTION
#### Description

- Adding `ineffassign` to the list of enabled linters in the Golang CI configuration 
- Fix identified issue