### PR TITLE
feat(exwindows): expose phys and pagefile memory

### DIFF
--- a/mem/ex_windows.go
+++ b/mem/ex_windows.go
@@ -11,14 +11,14 @@ import (
 // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-memorystatusex
 // https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-performance_information
 type ExVirtualMemory struct {
-	CommitLimit  uint64 `json:"commitLimit"`
-	CommitTotal  uint64 `json:"commitTotal"`
-	VirtualTotal uint64 `json:"virtualTotal"`
-	VirtualAvail uint64 `json:"virtualAvail"`
-	PhysTotal    uint64 `json:"physTotal"`
-	PhysAvail    uint64 `json:"physAvail"`
-	SwapTotal    uint64 `json:"swapTotal"`
-	SwapAvail    uint64 `json:"swapAvail"`
+	CommitLimit   uint64 `json:"commitLimit"`
+	CommitTotal   uint64 `json:"commitTotal"`
+	VirtualTotal  uint64 `json:"virtualTotal"`
+	VirtualAvail  uint64 `json:"virtualAvail"`
+	PhysTotal     uint64 `json:"physTotal"`
+	PhysAvail     uint64 `json:"physAvail"`
+	PageFileTotal uint64 `json:"pageFileTotal"`
+	PageFileAvail uint64 `json:"pageFileAvail"`
 }
 
 type ExWindows struct{}
@@ -48,14 +48,14 @@ func (e *ExWindows) VirtualMemory() (*ExVirtualMemory, error) {
 	}
 
 	ret := &ExVirtualMemory{
-		CommitLimit:  perfInfo.commitLimit * perfInfo.pageSize,
-		CommitTotal:  perfInfo.commitTotal * perfInfo.pageSize,
-		VirtualTotal: memInfo.ullTotalVirtual,
-		VirtualAvail: memInfo.ullAvailVirtual,
-		PhysTotal:    memInfo.ullTotalPhys,
-		PhysAvail:    memInfo.ullAvailPhys,
-		SwapTotal:    memInfo.ullTotalPageFile,
-		SwapAvail:    memInfo.ullAvailPageFile,
+		CommitLimit:   perfInfo.commitLimit * perfInfo.pageSize,
+		CommitTotal:   perfInfo.commitTotal * perfInfo.pageSize,
+		VirtualTotal:  memInfo.ullTotalVirtual,
+		VirtualAvail:  memInfo.ullAvailVirtual,
+		PhysTotal:     memInfo.ullTotalPhys,
+		PhysAvail:     memInfo.ullAvailPhys,
+		PageFileTotal: memInfo.ullTotalPageFile,
+		PageFileAvail: memInfo.ullAvailPageFile,
 	}
 
 	return ret, nil


### PR DESCRIPTION
add a way to retrieve pagefile info from memorystatusex
add phys memory for usability