### PR TITLE
fix: relace golangcilint on var-naming for package name

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,7 @@ linters:
             - ["ID"] # AllowList
             - ["VM"] # DenyList
             - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
+                skipPackageNameChecks: true
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
Avoid package name check on `common` package name. 
failed lint: https://github.com/shirou/gopsutil/actions/runs/15974770970/job/45054250924

We can not change the package name because it already public.