### PR TITLE
fix 404 link to centos.org

### DIFF
--- a/mem/mem.go
+++ b/mem/mem.go
@@ -48,7 +48,7 @@ type VirtualMemoryStat struct {
 	Laundry uint64 `json:"laundry"`
 
 	// Linux specific numbers
-	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
+	// https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo
 	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 	// https://www.kernel.org/doc/Documentation/vm/overcommit-accounting
 	// https://www.kernel.org/doc/Documentation/vm/transhuge.txt


### PR DESCRIPTION
This fixes a link to `centos.org` that doesn't exists anymore. I found the corresponding page on `redhat.com`.