### PR TITLE
fix(disk): handle NVMe controller notation in IOCounters on Linux

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -498,8 +498,9 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		// Since `name` here is already a basename, re-add the /dev path.
 		// This is not ideal, but we may break the API by changing how SerialNumberWithContext
 		// works.
-		d.SerialNumber, _ = SerialNumberWithContext(ctx, common.HostDevWithContext(ctx, name))
-		d.Label, _ = LabelWithContext(ctx, name)
+		deviceName := getDeviceName(name)
+		d.SerialNumber, _ = SerialNumberWithContext(ctx, common.HostDevWithContext(ctx, deviceName))
+		d.Label, _ = LabelWithContext(ctx, deviceName)
 
 		ret[name] = d
 	}
@@ -580,4 +581,24 @@ func getFsType(stat unix.Statfs_t) string {
 		return ""
 	}
 	return ret
+}
+
+// getDeviceName normalizes NVMe device names by converting controller notation
+// from diskstats format (nvmeXcYnZ) to actual device format (nvmeXnZ).
+// This handles the discrepancy where /proc/diskstats reports nvmeXcYnZ
+// but actual device files exist as /dev/nvmeXnZ.
+func getDeviceName(name string) string {
+	if !strings.HasPrefix(name, "nvme") {
+		return name
+	}
+
+	// Look for controller notation pattern: nvmeXcYnZ
+	if cIdx := strings.Index(name, "c"); cIdx > 4 { // "nvme" is 4 chars
+		if nIdx := strings.Index(name[cIdx:], "n"); nIdx > 0 {
+			// Convert nvmeXcYnZ to nvmeXnZ by removing "cY" part
+			return name[:cIdx] + name[cIdx+nIdx:]
+		}
+	}
+
+	return name
 }

--- a/disk/disk_linux_test.go
+++ b/disk/disk_linux_test.go
@@ -81,3 +81,34 @@ func Test_parseFieldsOnMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDeviceName(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// Controller notation conversion
+		{"nvme0c0n1", "nvme0n1"},
+		{"nvme10c23n1", "nvme10n1"},
+		{"nvme5c5n2", "nvme5n2"},
+
+		// Controller and partition together
+		{"nvme0c0n1p1", "nvme0n1p1"},
+		{"nvme2c2n1p2", "nvme2n1p2"},
+		{"nvme10c23n1p3", "nvme10n1p3"},
+
+		// Should NOT be changed
+		{"nvme0n1", "nvme0n1"},     // standard notation
+		{"nvme0n1p1", "nvme0n1p1"}, // partition
+		{"sda", "sda"},             // non-nvme
+		{"nvme5", "nvme5"},         // incomplete
+		{"nvme0c0", "nvme0c0"},     // no namespace
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			actual := getDeviceName(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes issue where `IOCountersWithContext` fails to get `SerialNumber` and `Label` for NVMe devices reported with controller notation (`nvmeXcYnZ`) in `/proc/diskstats`. The actual device files exist with standard notation (`nvmeXnZ`), causing "no such file or directory" errors.

## Impact

- Eliminates warnings in monitoring tools like Telegraf on systems with multiple NVMe controllers
- Ensures `SerialNumber` and `Label` fields are populated correctly for all NVMe devices
- No breaking changes - maintains backward compatibility

Fixes #1877
Related: influxdata/telegraf#17238