### PR TITLE
fix: windows-2019 runner image has been deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
-        os: [ubuntu-22.04, ubuntu-24.04, windows-2019, windows-2022, windows-2025, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
see https://github.com/actions/runner-images/issues/12045