### PR TITLE
[mem][linux]: Used calculated from Total and Available

### DIFF
--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -296,15 +296,17 @@ func fillFromMeminfoWithContext(ctx context.Context) (*VirtualMemoryStat, *ExVir
 
 	ret.Cached += ret.Sreclaimable
 
-	if !memavail {
+	if memavail {
+		ret.Used = ret.Total - ret.Available
+	} else {
 		if activeFile && inactiveFile && sReclaimable {
 			ret.Available = calculateAvailVmem(ctx, ret, retEx)
 		} else {
 			ret.Available = ret.Cached + ret.Free
 		}
+		ret.Used = ret.Total - ret.Free - ret.Buffers - ret.Cached
 	}
 
-	ret.Used = ret.Total - ret.Free - ret.Buffers - ret.Cached
 	ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
 
 	return ret, retEx, nil

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -33,8 +33,8 @@ var virtualMemoryTests = []struct {
 		"intelcorei5", &VirtualMemoryStat{
 			Total:          16502300672,
 			Available:      11495358464,
-			Used:           3437277184,
-			UsedPercent:    20.82907863769651,
+			Used:           5006942208,
+			UsedPercent:    30.340873721295385,
 			Free:           8783491072,
 			Active:         4347392000,
 			Inactive:       2938834944,
@@ -74,8 +74,8 @@ var virtualMemoryTests = []struct {
 		"issue1002", &VirtualMemoryStat{
 			Total:          260579328,
 			Available:      215199744,
-			Used:           34328576,
-			UsedPercent:    13.173944481121694,
+			Used:           45379584,
+			UsedPercent:    17.414882580401773,
 			Free:           124506112,
 			Active:         108785664,
 			Inactive:       8581120,
@@ -117,8 +117,8 @@ var virtualMemoryTests = []struct {
 			Available:     127880216 * 1024,
 			Free:          119443248 * 1024,
 			AnonHugePages: 50409472 * 1024,
-			Used:          144748720128,
-			UsedPercent:   54.20110673559013,
+			Used:          136109264896,
+			UsedPercent:   50.96606579876596,
 		},
 	},
 }

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -39,6 +39,9 @@ func TestVirtualMemory(t *testing.T) {
 	case "freebsd":
 		total = v.Used + v.Free + v.Cached + v.Inactive + v.Laundry
 		totalStr = "used + free + cached + inactive + laundry"
+	case "linux":
+		total = v.Available + v.Used
+		totalStr = "used + available"
 	}
 	assert.Equalf(t, v.Total, total,
 		"Total should be computable (%v): %v", totalStr, v)


### PR DESCRIPTION
fix #1873 

`mem.Used` calculated from `Total - Free - Buffers - Cache` even if `MemAvailable` can be used.
