### PR TITLE
chore: enable fatcontext linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - contextcheck
     - durationcheck
     - errorlint
+    - fatcontext
     - gocritic
     - gomodguard
     - gosec


### PR DESCRIPTION
#### Description

Enable [fatcontext](https://golangci-lint.run/usage/linters/#fatcontext) .  It detects nested contexts in loops and function literals.