### PR TITLE
chore: enable noinlineerr linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - noinlineerr
     - nolintlint
     - perfsprint
     - predeclared

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -162,7 +162,8 @@ func PercentWithContext(ctx context.Context, interval time.Duration, percpu bool
 		return nil, err
 	}
 
-	if err := common.Sleep(ctx, interval); err != nil {
+	err = common.Sleep(ctx, interval)
+	if err != nil {
 		return nil, err
 	}
 

--- a/cpu/cpu_aix_nocgo.go
+++ b/cpu/cpu_aix_nocgo.go
@@ -45,7 +45,8 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 					continue
 				}
 
-				if t, err := strconv.ParseFloat(v[pos], 64); err == nil {
+				t, err := strconv.ParseFloat(v[pos], 64)
+				if err == nil {
 					switch header {
 					case `cpu`:
 						ct.CPU = strconv.FormatFloat(t, 'f', -1, 64)
@@ -77,7 +78,8 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 		h := strings.Fields(lines[len(lines)-3]) // headers
 		v := strings.Fields(lines[len(lines)-2]) // values
 		for i, header := range h {
-			if t, err := strconv.ParseFloat(v[i], 64); err == nil {
+			t, err := strconv.ParseFloat(v[i], 64)
+			if err == nil {
 				switch header {
 				case `%usr`:
 					ct.User = t
@@ -109,14 +111,16 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 		case strings.HasPrefix(line, "Number Of Processors:"):
 			p := strings.Fields(line)
 			if len(p) > 3 {
-				if t, err := strconv.ParseUint(p[3], 10, 64); err == nil {
+				t, err := strconv.ParseUint(p[3], 10, 64)
+				if err == nil {
 					ret.Cores = int32(t)
 				}
 			}
 		case strings.HasPrefix(line, "Processor Clock Speed:"):
 			p := strings.Fields(line)
 			if len(p) > 4 {
-				if t, err := strconv.ParseFloat(p[3], 64); err == nil {
+				t, err := strconv.ParseFloat(p[3], 64)
+				if err == nil {
 					switch strings.ToUpper(p[4]) {
 					case "MHZ":
 						ret.Mhz = t

--- a/cpu/cpu_dragonfly.go
+++ b/cpu/cpu_dragonfly.go
@@ -101,20 +101,22 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 	}
 
 	var u32 uint32
-	if u32, err = unix.SysctlUint32("hw.clockrate"); err != nil {
+	u32, err = unix.SysctlUint32("hw.clockrate")
+	if err != nil {
 		return nil, err
 	}
 	c.Mhz = float64(u32)
 
 	var num int
 	var buf string
-	if buf, err = unix.Sysctl("hw.cpu_topology.tree"); err != nil {
+	buf, err = unix.Sysctl("hw.cpu_topology.tree")
+	if err != nil {
 		return nil, err
 	}
 	num = strings.Count(buf, "CHIP")
 	c.Cores = int32(strings.Count(string(buf), "CORE") / num)
-
-	if c.ModelName, err = unix.Sysctl("hw.model"); err != nil {
+	c.ModelName, err = unix.Sysctl("hw.model")
+	if err != nil {
 		return nil, err
 	}
 

--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -102,17 +102,18 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 	}
 
 	var u32 uint32
-	if u32, err = unix.SysctlUint32("hw.clockrate"); err != nil {
+	u32, err = unix.SysctlUint32("hw.clockrate")
+	if err != nil {
 		return nil, err
 	}
 	c.Mhz = float64(u32)
-
-	if u32, err = unix.SysctlUint32("hw.ncpu"); err != nil {
+	u32, err = unix.SysctlUint32("hw.ncpu")
+	if err != nil {
 		return nil, err
 	}
 	c.Cores = int32(u32)
-
-	if c.ModelName, err = unix.Sysctl("hw.model"); err != nil {
+	c.ModelName, err = unix.Sysctl("hw.model")
+	if err != nil {
 		return nil, err
 	}
 

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -222,7 +222,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 				processorName = "S390"
 			}
 		case "CPU implementer":
-			if v, err := strconv.ParseUint(value, 0, 8); err == nil {
+			v, err := strconv.ParseUint(value, 0, 8)
+			if err == nil {
 				switch v {
 				case 0x41:
 					c.VendorID = "ARM"
@@ -262,7 +263,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Model = value
 			// if CPU is arm based, model name is found via model number. refer to: arch/arm64/kernel/cpuinfo.c
 			if c.VendorID == "ARM" {
-				if v, err := strconv.ParseUint(c.Model, 0, 16); err == nil {
+				v, err := strconv.ParseUint(c.Model, 0, 16)
+				if err == nil {
 					modelName, exist := armModelToModelName[v]
 					if exist {
 						c.ModelName = modelName
@@ -296,7 +298,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 			c.Stepping = int32(t)
 		case "cpu MHz", "clock", "cpu MHz dynamic":
 			// treat this as the fallback value, thus we ignore error
-			if t, err := strconv.ParseFloat(strings.Replace(value, "MHz", "", 1), 64); err == nil {
+			t, err := strconv.ParseFloat(strings.Replace(value, "MHz", "", 1), 64)
+			if err == nil {
 				c.Mhz = t
 			}
 		case "cache size":
@@ -442,7 +445,8 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 	// https://github.com/giampaolo/psutil/pull/1727#issuecomment-707624964
 	// https://lkml.org/lkml/2019/2/26/41
 	for _, glob := range []string{"devices/system/cpu/cpu[0-9]*/topology/core_cpus_list", "devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list"} {
-		if files, err := filepath.Glob(common.HostSysWithContext(ctx, glob)); err == nil {
+		files, err := filepath.Glob(common.HostSysWithContext(ctx, glob))
+		if err == nil {
 			for _, file := range files {
 				lines, err := common.ReadLines(file)
 				if err != nil || len(lines) != 1 {

--- a/cpu/cpu_netbsd.go
+++ b/cpu/cpu_netbsd.go
@@ -108,8 +108,8 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 		return nil, err
 	}
 	c.Cores = int32(ncpu)
-
-	if c.ModelName, err = unix.Sysctl("machdep.dmi.processor-version"); err != nil {
+	c.ModelName, err = unix.Sysctl("machdep.dmi.processor-version")
+	if err != nil {
 		return nil, err
 	}
 

--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -126,8 +126,8 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 		return nil, err
 	}
 	c.Cores = int32(ncpu)
-
-	if c.ModelName, err = unix.Sysctl("hw.model"); err != nil {
+	c.ModelName, err = unix.Sysctl("hw.model")
+	if err != nil {
 		return nil, err
 	}
 

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -135,7 +135,8 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	var ret []InfoStat
 	var dst []win32_Processor
 	q := wmi.CreateQuery(&dst, "")
-	if err := common.WMIQueryWithContext(ctx, q, &dst); err != nil {
+	err := common.WMIQueryWithContext(ctx, q, &dst)
+	if err != nil {
 		return ret, err
 	}
 

--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -126,7 +126,8 @@ func SerialNumberWithContext(ctx context.Context, _ string) (string, error) {
 	}
 
 	var data spnvmeDataWrapper
-	if err := json.Unmarshal(output, &data); err != nil {
+	err = json.Unmarshal(output, &data)
+	if err != nil {
 		return "", fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -29,7 +29,8 @@ func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 	}
 
 	fs := make([]unix.Statfs_t, count)
-	if _, err = unix.Getfsstat(fs, unix.MNT_WAIT); err != nil {
+	_, err = unix.Getfsstat(fs, unix.MNT_WAIT)
+	if err != nil {
 		return ret, err
 	}
 
@@ -154,7 +155,8 @@ func (b bintime) Compute() float64 {
 func parsedevstat(buf []byte) (devstat, error) {
 	var ds devstat
 	br := bytes.NewReader(buf)
-	if err := binary.Read(br, binary.LittleEndian, &ds); err != nil {
+	err := binary.Read(br, binary.LittleEndian, &ds)
+	if err != nil {
 		return ds, err
 	}
 

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -509,7 +509,8 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 
 func udevData(ctx context.Context, major, minor uint32, name string) (string, error) {
 	udevDataPath := common.HostRunWithContext(ctx, fmt.Sprintf("udev/data/b%d:%d", major, minor))
-	if f, err := os.Open(udevDataPath); err == nil {
+	f, err := os.Open(udevDataPath)
+	if err == nil {
 		defer f.Close()
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
@@ -527,7 +528,8 @@ func udevData(ctx context.Context, major, minor uint32, name string) (string, er
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	var stat unix.Stat_t
-	if err := unix.Stat(name, &stat); err != nil {
+	err := unix.Stat(name, &stat)
+	if err != nil {
 		return "", err
 	}
 	major := unix.Major(uint64(stat.Rdev))
@@ -561,7 +563,8 @@ func LabelWithContext(ctx context.Context, name string) (string, error) {
 	}
 	// Try udev data
 	var stat unix.Stat_t
-	if err := unix.Stat(common.HostDevWithContext(ctx, name), &stat); err != nil {
+	err := unix.Stat(common.HostDevWithContext(ctx, name), &stat)
+	if err != nil {
 		return "", err
 	}
 	major := unix.Major(uint64(stat.Rdev))

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -23,7 +23,8 @@ func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 	}
 
 	fs := make([]unix.Statfs_t, count)
-	if _, err = unix.Getfsstat(fs, unix.MNT_WAIT); err != nil {
+	_, err = unix.Getfsstat(fs, unix.MNT_WAIT)
+	if err != nil {
 		return ret, err
 	}
 
@@ -114,7 +115,8 @@ func IOCountersWithContext(_ context.Context, names ...string) (map[string]IOCou
 func parseDiskstats(buf []byte) (Diskstats, error) {
 	var ds Diskstats
 	br := bytes.NewReader(buf)
-	if err := binary.Read(br, binary.LittleEndian, &ds); err != nil {
+	err := binary.Read(br, binary.LittleEndian, &ds)
+	if err != nil {
 		return ds, err
 	}
 

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -78,7 +78,8 @@ func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 			Opts:       strings.Split(fields[3], ","),
 		})
 	}
-	if err := scanner.Err(); err != nil {
+	err = scanner.Err()
+	if err != nil {
 		return nil, fmt.Errorf("unable to scan %q: %w", _MNTTAB, err)
 	}
 
@@ -201,7 +202,8 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 
 func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 	statvfs := unix.Statvfs_t{}
-	if err := unix.Statvfs(path, &statvfs); err != nil {
+	err := unix.Statvfs(path, &statvfs)
+	if err != nil {
 		return nil, fmt.Errorf("unable to call statvfs(2) on %q: %w", path, err)
 	}
 
@@ -252,7 +254,8 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 			return "", nil
 		}
 	}
-	if err := s.Err(); err != nil {
+	err = s.Err()
+	if err != nil {
 		return "", err
 	}
 	return "", nil

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -281,7 +281,8 @@ func getCgroupFilePath(ctx context.Context, containerID, base, target, file stri
 	}
 	statfile := path.Join(base, containerID, file)
 
-	if _, err := os.Stat(statfile); os.IsNotExist(err) {
+	_, err := os.Stat(statfile)
+	if os.IsNotExist(err) {
 		statfile = path.Join(
 			common.HostSysWithContext(ctx, fmt.Sprintf("fs/cgroup/%s/system.slice", target)), "docker-"+containerID+".scope", file)
 	}

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -142,7 +142,8 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 				break
 			}
 
-			if t, err := strconv.ParseFloat(v[i], 64); err == nil {
+			t, err := strconv.ParseFloat(v[i], 64)
+			if err == nil {
 				switch header {
 				case `User`:
 					us.User = strconv.FormatFloat(t, 'f', 1, 64)

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -72,7 +72,8 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 
 func UptimeWithContext(_ context.Context) (uint64, error) {
 	sysinfo := &unix.Sysinfo_t{}
-	if err := unix.Sysinfo(sysinfo); err != nil {
+	err := unix.Sysinfo(sysinfo)
+	if err != nil {
 		return 0, err
 	}
 	return uint64(sysinfo.Uptime), nil

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -182,7 +182,8 @@ func platformInformation() (platform, family, version, displayVersion string, er
 			err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`CurrentBuildNumber`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
 			if err == nil {
 				buildNumberStr := windows.UTF16ToString(regBuf)
-				if buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 32); err == nil && buildNumber >= 22000 {
+				buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 32)
+				if err == nil && buildNumber >= 22000 {
 					platform = strings.Replace(platform, "Windows 10", "Windows 11", 1)
 				}
 			}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -57,11 +57,13 @@ func (Invoke) CommandWithContext(ctx context.Context, name string, arg ...string
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 
-	if err := cmd.Start(); err != nil {
+	err := cmd.Start()
+	if err != nil {
 		return buf.Bytes(), err
 	}
 
-	if err := cmd.Wait(); err != nil {
+	err = cmd.Wait()
+	if err != nil {
 		return buf.Bytes(), err
 	}
 
@@ -325,10 +327,8 @@ func attributes(m any) map[string]reflect.Type {
 }
 
 func PathExists(filename string) bool {
-	if _, err := os.Stat(filename); err == nil {
-		return true
-	}
-	return false
+	_, err := os.Stat(filename)
+	return err == nil
 }
 
 // PathExistsWithContents returns the filename exists and it is not empty

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -52,7 +52,8 @@ func NumProcsWithContext(ctx context.Context) (uint64, error) {
 	var cnt uint64
 
 	for _, v := range list {
-		if _, err = strconv.ParseUint(v, 10, 64); err == nil {
+		_, err = strconv.ParseUint(v, 10, 64)
+		if err == nil {
 			cnt++
 		}
 	}

--- a/load/load_aix_nocgo.go
+++ b/load/load_aix_nocgo.go
@@ -29,13 +29,16 @@ func AvgWithContext(ctx context.Context) (*AvgStat, error) {
 
 	p := separator.Split(string(line[idx:]), 5)
 	if 4 < len(p) && p[0] == "load" && p[1] == "average:" {
-		if t, err := strconv.ParseFloat(p[2], 64); err == nil {
+		t, err := strconv.ParseFloat(p[2], 64)
+		if err == nil {
 			ret.Load1 = t
 		}
-		if t, err := strconv.ParseFloat(p[3], 64); err == nil {
+		t, err = strconv.ParseFloat(p[3], 64)
+		if err == nil {
 			ret.Load5 = t
 		}
-		if t, err := strconv.ParseFloat(p[4], 64); err == nil {
+		t, err = strconv.ParseFloat(p[4], 64)
+		if err == nil {
 			ret.Load15 = t
 		}
 		return ret, nil

--- a/mem/mem_aix_nocgo.go
+++ b/mem/mem_aix_nocgo.go
@@ -48,26 +48,31 @@ func callSVMon(ctx context.Context, virt bool) (*VirtualMemoryStat, *SwapMemoryS
 		if virt && strings.HasPrefix(line, "memory") {
 			p := strings.Fields(line)
 			if len(p) > 2 {
-				if t, err := strconv.ParseUint(p[1], 10, 64); err == nil {
+				t, err := strconv.ParseUint(p[1], 10, 64)
+				if err == nil {
 					vmem.Total = t * pagesize
 				}
-				if t, err := strconv.ParseUint(p[2], 10, 64); err == nil {
+				t, err = strconv.ParseUint(p[2], 10, 64)
+				if err == nil {
 					vmem.Used = t * pagesize
 					if vmem.Total > 0 {
 						vmem.UsedPercent = 100 * float64(vmem.Used) / float64(vmem.Total)
 					}
 				}
-				if t, err := strconv.ParseUint(p[3], 10, 64); err == nil {
+				t, err = strconv.ParseUint(p[3], 10, 64)
+				if err == nil {
 					vmem.Free = t * pagesize
 				}
 			}
 		} else if strings.HasPrefix(line, "pg space") {
 			p := strings.Fields(line)
 			if len(p) > 3 {
-				if t, err := strconv.ParseUint(p[2], 10, 64); err == nil {
+				t, err := strconv.ParseUint(p[2], 10, 64)
+				if err == nil {
 					swap.Total = t * pagesize
 				}
-				if t, err := strconv.ParseUint(p[3], 10, 64); err == nil {
+				t, err = strconv.ParseUint(p[3], 10, 64)
+				if err == nil {
 					swap.Free = swap.Total - t*pagesize
 				}
 			}

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -335,8 +335,8 @@ func SwapMemory() (*SwapMemoryStat, error) {
 
 func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 	sysinfo := &unix.Sysinfo_t{}
-
-	if err := unix.Sysinfo(sysinfo); err != nil {
+	err := unix.Sysinfo(sysinfo)
+	if err != nil {
 		return nil, err
 	}
 	ret := &SwapMemoryStat{
@@ -474,7 +474,8 @@ func parseSwapsFile(ctx context.Context, r io.Reader) ([]*SwapDevice, error) {
 	swapsFilePath := common.HostProcWithContext(ctx, swapsFilename)
 	scanner := bufio.NewScanner(r)
 	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
+		err := scanner.Err()
+		if err != nil {
 			return nil, fmt.Errorf("couldn't read file %q: %w", swapsFilePath, err)
 		}
 		return nil, fmt.Errorf("unexpected end-of-file in %q", swapsFilePath)
@@ -520,7 +521,8 @@ func parseSwapsFile(ctx context.Context, r io.Reader) ([]*SwapDevice, error) {
 		})
 	}
 
-	if err := scanner.Err(); err != nil {
+	err := scanner.Err()
+	if err != nil {
 		return nil, fmt.Errorf("couldn't read file %q: %w", swapsFilePath, err)
 	}
 

--- a/mem/mem_openbsd.go
+++ b/mem/mem_openbsd.go
@@ -61,7 +61,8 @@ func VirtualMemoryWithContext(_ context.Context) (*VirtualMemoryStat, error) {
 	}
 	var bcs Bcachestats
 	br := bytes.NewReader(buf)
-	if err := binary.Read(br, binary.LittleEndian, &bcs); err != nil {
+	err = binary.Read(br, binary.LittleEndian, &bcs)
+	if err != nil {
 		return nil, err
 	}
 	ret.Buffers = uint64(bcs.Numbufpages) * p

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -71,7 +71,8 @@ func parseNetstatLine(line string) (stat *IOCountersStat, linkID *uint, err erro
 			continue
 		}
 
-		if numericValue, err = strconv.ParseUint(target, 10, 64); err != nil {
+		numericValue, err = strconv.ParseUint(target, 10, 64)
+		if err != nil {
 			return nil, nil, err
 		}
 		parsed = append(parsed, numericValue)
@@ -114,7 +115,8 @@ func parseNetstatOutput(output string) ([]netstatInterface, error) {
 
 	for index := 0; index < numberInterfaces; index++ {
 		nsIface := netstatInterface{}
-		if nsIface.stat, nsIface.linkID, err = parseNetstatLine(lines[index+1]); err != nil {
+		nsIface.stat, nsIface.linkID, err = parseNetstatLine(lines[index+1])
+		if err != nil {
 			return nil, err
 		}
 		interfaces[index] = nsIface
@@ -206,7 +208,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		}
 	} else {
 		// duplicated interface, list all interfaces
-		if out, err = invoke.CommandWithContext(ctx, "ifconfig", "-l"); err != nil {
+		out, err = invoke.CommandWithContext(ctx, "ifconfig", "-l")
+		if err != nil {
 			return nil, err
 		}
 		interfaceNames := strings.Fields(strings.TrimRight(string(out), endOfLine))
@@ -225,7 +228,8 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 			}
 			if truncated {
 				// run netstat with -I$ifacename
-				if out, err = invoke.CommandWithContext(ctx, netstat, "-ibdnWI"+interfaceName); err != nil {
+				out, err = invoke.CommandWithContext(ctx, netstat, "-ibdnWI"+interfaceName)
+				if err != nil {
 					return nil, err
 				}
 				parsedIfaces, err := parseNetstatOutput(string(out))

--- a/process/process.go
+++ b/process/process.go
@@ -261,7 +261,8 @@ func (p *Process) PercentWithContext(ctx context.Context, interval time.Duration
 	if interval > 0 {
 		p.lastCPUTimes = cpuTimes
 		p.lastCPUTime = now
-		if err := common.Sleep(ctx, interval); err != nil {
+		err := common.Sleep(ctx, interval)
+		if err != nil {
 			return 0, err
 		}
 		cpuTimes, err = p.TimesWithContext(ctx)

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -79,7 +79,8 @@ func (p *Process) CwdWithContext(_ context.Context) (string, error) {
 
 	var k kinfoFile
 	br := bytes.NewReader(buf)
-	if err := binary.Read(br, binary.LittleEndian, &k); err != nil {
+	err = binary.Read(br, binary.LittleEndian, &k)
+	if err != nil {
 		return "", err
 	}
 	cwd := common.IntToString(k.Path[:])

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -84,7 +84,8 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 	if p.name == "" {
-		if err := p.fillNameWithContext(ctx); err != nil {
+		err := p.fillNameWithContext(ctx)
+		if err != nil {
 			return "", err
 		}
 	}
@@ -93,7 +94,8 @@ func (p *Process) NameWithContext(ctx context.Context) (string, error) {
 
 func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
 	if p.tgid == 0 {
-		if err := p.fillFromStatusWithContext(ctx); err != nil {
+		err := p.fillFromStatusWithContext(ctx)
+		if err != nil {
 			return 0, err
 		}
 	}
@@ -212,7 +214,8 @@ func (p *Process) RlimitUsageWithContext(ctx context.Context, gatherUsed bool) (
 	if err != nil {
 		return nil, err
 	}
-	if err := p.fillFromStatusWithContext(ctx); err != nil {
+	err = p.fillFromStatusWithContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -392,7 +395,8 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 		// If smaps_rollup exists (require kernel >= 4.15), then we will use it
 		// for pre-summed memory information for a process.
 		smapsRollupPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "smaps_rollup")
-		if _, err := os.Stat(smapsRollupPath); !os.IsNotExist(err) {
+		_, err := os.Stat(smapsRollupPath)
+		if !os.IsNotExist(err) {
 			smapsPath = smapsRollupPath
 		}
 	}
@@ -600,7 +604,8 @@ func (p *Process) fillFromLimitsWithContext(ctx context.Context) ([]RlimitStat, 
 		limitStats = append(limitStats, statItem)
 	}
 
-	if err := limitsScanner.Err(); err != nil {
+	err = limitsScanner.Err()
+	if err != nil {
 		return nil, err
 	}
 

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -122,7 +122,8 @@ func TestSplitProcStat_fromFile(t *testing.T) {
 			continue
 		}
 		statFile := fmt.Sprintf("testdata/linux/%d/stat", pid)
-		if _, err := os.Stat(statFile); err != nil {
+		_, err = os.Stat(statFile)
+		if err != nil {
 			continue
 		}
 		contents, err := os.ReadFile(statFile)
@@ -155,7 +156,8 @@ func TestFillFromCommWithContext(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if _, err := os.Stat(fmt.Sprintf("testdata/linux/%d/status", pid)); err != nil {
+		_, err = os.Stat(fmt.Sprintf("testdata/linux/%d/status", pid))
+		if err != nil {
 			continue
 		}
 		p, _ := NewProcess(int32(pid))
@@ -172,7 +174,8 @@ func TestFillFromStatusWithContext(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if _, err := os.Stat(fmt.Sprintf("testdata/linux/%d/status", pid)); err != nil {
+		_, err = os.Stat(fmt.Sprintf("testdata/linux/%d/status", pid))
+		if err != nil {
 			continue
 		}
 		p, _ := NewProcess(int32(pid))
@@ -207,7 +210,8 @@ func TestFillFromTIDStatWithContext_lx_brandz(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if _, err := os.Stat(fmt.Sprintf("testdata/lx_brandz/%d/stat", pid)); err != nil {
+		_, err = os.Stat(fmt.Sprintf("testdata/lx_brandz/%d/stat", pid))
+		if err != nil {
 			continue
 		}
 		p, _ := NewProcess(int32(pid))

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -119,13 +119,15 @@ func readPtr(r io.Reader) (uintptr, error) {
 	switch sizeofPtr {
 	case 4:
 		var p uint32
-		if err := binary.Read(r, binary.LittleEndian, &p); err != nil {
+		err := binary.Read(r, binary.LittleEndian, &p)
+		if err != nil {
 			return 0, err
 		}
 		return uintptr(p), nil
 	case 8:
 		var p uint64
-		if err := binary.Read(r, binary.LittleEndian, &p); err != nil {
+		err := binary.Read(r, binary.LittleEndian, &p)
+		if err != nil {
 			return 0, err
 		}
 		return uintptr(p), nil

--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -90,12 +90,14 @@ func isMount(path string) bool {
 		return false
 	}
 	var stat1 unix.Stat_t
-	if err := unix.Lstat(path, &stat1); err != nil {
+	err = unix.Lstat(path, &stat1)
+	if err != nil {
 		return false
 	}
 	parent := filepath.Join(path, "..")
 	var stat2 unix.Stat_t
-	if err := unix.Lstat(parent, &stat2); err != nil {
+	err = unix.Lstat(parent, &stat2)
+	if err != nil {
 		return false
 	}
 	return stat1.Dev != stat2.Dev || stat1.Ino == stat2.Ino

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -275,7 +275,8 @@ func TestLong_Name_With_Spaces(t *testing.T) {
 	require.NoErrorf(t, err, "unable to create temp file %v", err)
 
 	tmpfilecontent := []byte("package main\nimport(\n\"time\"\n)\nfunc main(){\nfor range time.Tick(time.Second) {}\n}")
-	if _, err := tmpfile.Write(tmpfilecontent); err != nil {
+	_, err = tmpfile.Write(tmpfilecontent)
+	if err != nil {
 		tmpfile.Close()
 		t.Fatalf("unable to write temp file %v", err)
 	}
@@ -314,7 +315,8 @@ func TestLong_Name(t *testing.T) {
 	require.NoErrorf(t, err, "unable to create temp file %v", err)
 
 	tmpfilecontent := []byte("package main\nimport(\n\"time\"\n)\nfunc main(){\nfor range time.Tick(time.Second) {}\n}")
-	if _, err := tmpfile.Write(tmpfilecontent); err != nil {
+	_, err = tmpfile.Write(tmpfilecontent)
+	if err != nil {
 		tmpfile.Close()
 		t.Fatalf("unable to write temp file %v", err)
 	}
@@ -351,7 +353,8 @@ func TestName_Against_Python(t *testing.T) {
 	if err != nil {
 		t.Skipf("python3 not found: %s", err)
 	}
-	if out, err := exec.Command(py3Path, "-c", "import psutil").CombinedOutput(); err != nil {
+	out, err := exec.Command(py3Path, "-c", "import psutil").CombinedOutput()
+	if err != nil {
 		t.Skipf("psutil not found for %s: %s", py3Path, out)
 	}
 
@@ -362,7 +365,8 @@ func TestName_Against_Python(t *testing.T) {
 	tmpfile, err := os.Create(tmpfilepath)
 	require.NoErrorf(t, err, "unable to create temp file %v", err)
 	tmpfilecontent := []byte("#!" + py3Path + "\nimport psutil, time\nprint(psutil.Process().name(), flush=True)\nwhile True:\n\ttime.sleep(1)")
-	if _, err := tmpfile.Write(tmpfilecontent); err != nil {
+	_, err = tmpfile.Write(tmpfilecontent)
+	if err != nil {
 		tmpfile.Close()
 		t.Fatalf("unable to write temp file %v", err)
 	}
@@ -696,7 +700,8 @@ func TestEnviron(t *testing.T) {
 	require.NoErrorf(t, err, "unable to create temp file %v", err)
 
 	tmpfilecontent := []byte("package main\nimport(\n\"time\"\n)\nfunc main(){\nfor range time.Tick(time.Second) {}\n}")
-	if _, err := tmpfile.Write(tmpfilecontent); err != nil {
+	_, err = tmpfile.Write(tmpfilecontent)
+	if err != nil {
 		tmpfile.Close()
 		t.Fatalf("unable to write temp file %v", err)
 	}

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -251,7 +251,8 @@ func pidsWithContext(_ context.Context) ([]int32, error) {
 
 	for {
 		ps := make([]uint32, psSize)
-		if err := windows.EnumProcesses(ps, &read); err != nil {
+		err := windows.EnumProcesses(ps, &read)
+		if err != nil {
 			return nil, err
 		}
 		if uint32(len(ps)) == read/dwordSize { // ps buffer was too small to host every results, retry with a bigger one
@@ -348,7 +349,8 @@ func (p *Process) ExeWithContext(_ context.Context) (string, error) {
 	defer windows.CloseHandle(c)
 	buf := make([]uint16, syscall.MAX_LONG_PATH)
 	size := uint32(syscall.MAX_LONG_PATH)
-	if err := procQueryFullProcessImageNameW.Find(); err == nil { // Vista+
+	err = procQueryFullProcessImageNameW.Find()
+	if err == nil { // Vista+
 		ret, _, err := procQueryFullProcessImageNameW.Call(
 			uintptr(c),
 			uintptr(0),
@@ -674,7 +676,8 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	defer windows.CloseHandle(snap)
 	var pe32 windows.ProcessEntry32
 	pe32.Size = uint32(unsafe.Sizeof(pe32))
-	if err := windows.Process32First(snap, &pe32); err != nil {
+	err = windows.Process32First(snap, &pe32)
+	if err != nil {
 		return out, err
 	}
 	for {
@@ -684,7 +687,8 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 				out = append(out, p)
 			}
 		}
-		if err = windows.Process32Next(snap, &pe32); err != nil {
+		err = windows.Process32Next(snap, &pe32)
+		if err != nil {
 			break
 		}
 	}
@@ -891,7 +895,8 @@ func getFromSnapProcess(pid int32) (int32, int32, string, error) { //nolint:unpa
 			szexe := windows.UTF16ToString(pe32.ExeFile[:])
 			return int32(pe32.ParentProcessID), int32(pe32.Threads), szexe, nil
 		}
-		if err = windows.Process32Next(snap, &pe32); err != nil {
+		err = windows.Process32Next(snap, &pe32)
+		if err != nil {
 			break
 		}
 	}
@@ -925,8 +930,8 @@ func getRusage(pid int32) (*windows.Rusage, error) {
 		return nil, err
 	}
 	defer windows.CloseHandle(c)
-
-	if err := windows.GetProcessTimes(c, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime); err != nil {
+	err = windows.GetProcessTimes(c, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime)
+	if err != nil {
 		return nil, err
 	}
 
@@ -940,7 +945,8 @@ func getMemoryInfo(pid int32) (PROCESS_MEMORY_COUNTERS, error) {
 		return mem, err
 	}
 	defer windows.CloseHandle(c)
-	if err := getProcessMemoryInfo(c, &mem); err != nil {
+	err = getProcessMemoryInfo(c, &mem)
+	if err != nil {
 		return mem, err
 	}
 
@@ -1131,7 +1137,8 @@ func getProcessEnvironmentVariables(ctx context.Context, pid int32) ([]string, e
 			continue
 		}
 	}
-	if err := envvarScanner.Err(); err != nil {
+	err = envvarScanner.Err()
+	if err != nil {
 		return nil, err
 	}
 	return envVars, nil

--- a/process/process_windows_32bit.go
+++ b/process/process_windows_32bit.go
@@ -38,7 +38,8 @@ func queryPebAddress(procHandle syscall.Handle, is32BitProcess bool) (uint64, er
 			uintptr(unsafe.Sizeof(info)),
 			uintptr(0),
 		)
-		if status := windows.NTStatus(ret); status == windows.STATUS_SUCCESS {
+		status := windows.NTStatus(ret)
+		if status == windows.STATUS_SUCCESS {
 			return uint64(info.PebBaseAddress), nil
 		}
 		return 0, windows.NTStatus(ret)
@@ -57,7 +58,8 @@ func queryPebAddress(procHandle syscall.Handle, is32BitProcess bool) (uint64, er
 		uintptr(unsafe.Sizeof(info)),
 		uintptr(0),
 	)
-	if status := windows.NTStatus(ret); status == windows.STATUS_SUCCESS {
+	status := windows.NTStatus(ret)
+	if status == windows.STATUS_SUCCESS {
 		return info.PebBaseAddress, nil
 	}
 	return 0, windows.NTStatus(ret)

--- a/process/process_windows_64bit.go
+++ b/process/process_windows_64bit.go
@@ -37,7 +37,8 @@ func queryPebAddress(procHandle syscall.Handle, is32BitProcess bool) (uint64, er
 			uintptr(unsafe.Sizeof(wow64)),
 			uintptr(0),
 		)
-		if status := windows.NTStatus(ret); status == windows.STATUS_SUCCESS {
+		status := windows.NTStatus(ret)
+		if status == windows.STATUS_SUCCESS {
 			return uint64(wow64), nil
 		}
 		return 0, windows.NTStatus(ret)
@@ -52,7 +53,8 @@ func queryPebAddress(procHandle syscall.Handle, is32BitProcess bool) (uint64, er
 		uintptr(unsafe.Sizeof(info)),
 		uintptr(0),
 	)
-	if status := windows.NTStatus(ret); status == windows.STATUS_SUCCESS {
+	status := windows.NTStatus(ret)
+	if status == windows.STATUS_SUCCESS {
 		return info.PebBaseAddress, nil
 	}
 	return 0, windows.NTStatus(ret)

--- a/sensors/ex_linux.go
+++ b/sensors/ex_linux.go
@@ -55,7 +55,8 @@ func (*ExLinux) TemperatureWithContext(ctx context.Context) ([]ExTemperature, er
 		}
 
 		// Get the name of the temperature you are reading
-		if raw, err = os.ReadFile(filepath.Join(directory, "name")); err != nil {
+		raw, err = os.ReadFile(filepath.Join(directory, "name"))
+		if err != nil {
 			warns.Add(err)
 			continue
 		}

--- a/sensors/sensors_linux.go
+++ b/sensors/sensors_linux.go
@@ -92,7 +92,8 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 		}
 
 		// Get the name of the temperature you are reading
-		if raw, err = os.ReadFile(filepath.Join(directory, "name")); err != nil {
+		raw, err = os.ReadFile(filepath.Join(directory, "name"))
+		if err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -104,12 +105,14 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 		}
 
 		// Get the temperature reading
-		if raw, err = os.ReadFile(file); err != nil {
+		raw, err = os.ReadFile(file)
+		if err != nil {
 			warns.Add(err)
 			continue
 		}
 
-		if temperature, err = strconv.ParseFloat(strings.TrimSpace(string(raw)), 64); err != nil {
+		temperature, err = strconv.ParseFloat(strings.TrimSpace(string(raw)), 64)
+		if err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -127,20 +130,19 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 }
 
 func getTemperatureFiles(ctx context.Context) ([]string, error) {
-	var files []string
-	var err error
-
 	// Only the temp*_input file provides current temperature
 	// value in millidegree Celsius as reported by the temperature to the device:
 	// https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
-	if files, err = filepath.Glob(common.HostSysWithContext(ctx, "/class/hwmon/hwmon*/temp*_input")); err != nil {
+	files, err := filepath.Glob(common.HostSysWithContext(ctx, "/class/hwmon/hwmon*/temp*_input"))
+	if err != nil {
 		return nil, err
 	}
 
 	if len(files) == 0 {
 		// CentOS has an intermediate /device directory:
 		// https://github.com/giampaolo/psutil/issues/971
-		if files, err = filepath.Glob(common.HostSysWithContext(ctx, "/class/hwmon/hwmon*/device/temp*_input")); err != nil {
+		files, err = filepath.Glob(common.HostSysWithContext(ctx, "/class/hwmon/hwmon*/device/temp*_input"))
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -151,20 +153,19 @@ func getTemperatureFiles(ctx context.Context) ([]string, error) {
 func optionalValueReadFromFile(filename string) float64 {
 	var raw []byte
 
-	var err error
-
 	var value float64
 
 	// Check if file exists
-	if _, err := os.Stat(filename); os.IsNotExist(err) {
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
 		return 0
 	}
-
-	if raw, err = os.ReadFile(filename); err != nil {
+	raw, err = os.ReadFile(filename)
+	if err != nil {
 		return 0
 	}
-
-	if value, err = strconv.ParseFloat(strings.TrimSpace(string(raw)), 64); err != nil {
+	value, err = strconv.ParseFloat(strings.TrimSpace(string(raw)), 64)
+	if err != nil {
 		return 0
 	}
 

--- a/sensors/sensors_windows.go
+++ b/sensors/sensors_windows.go
@@ -23,7 +23,8 @@ func TemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
 	var ret []TemperatureStat
 	var dst []msAcpi_ThermalZoneTemperature
 	q := wmi.CreateQuery(&dst, "")
-	if err := common.WMIQueryWithContext(ctx, q, &dst, nil, "root/wmi"); err != nil {
+	err := common.WMIQueryWithContext(ctx, q, &dst, nil, "root/wmi")
+	if err != nil {
 		return ret, err
 	}
 

--- a/winservices/winservices.go
+++ b/winservices/winservices.go
@@ -87,13 +87,15 @@ func (s *Service) QueryStatusWithContext(_ context.Context) (ServiceStatus, erro
 	var bytesNeeded uint32
 	var buf []byte
 
-	if err := windows.QueryServiceStatusEx(s.srv.Handle, windows.SC_STATUS_PROCESS_INFO, nil, 0, &bytesNeeded); !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
+	err := windows.QueryServiceStatusEx(s.srv.Handle, windows.SC_STATUS_PROCESS_INFO, nil, 0, &bytesNeeded)
+	if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
 		return ServiceStatus{}, err
 	}
 
 	buf = make([]byte, bytesNeeded)
 	p = (*windows.SERVICE_STATUS_PROCESS)(unsafe.Pointer(&buf[0]))
-	if err := windows.QueryServiceStatusEx(s.srv.Handle, windows.SC_STATUS_PROCESS_INFO, &buf[0], uint32(len(buf)), &bytesNeeded); err != nil {
+	err = windows.QueryServiceStatusEx(s.srv.Handle, windows.SC_STATUS_PROCESS_INFO, &buf[0], uint32(len(buf)), &bytesNeeded)
+	if err != nil {
 		return ServiceStatus{}, err
 	}
 


### PR DESCRIPTION
#### Description

This PR proposes enabling the [noinlineerr](https://golangci-lint.run/usage/linters/#noinlineerr) linter.

Based on previous discussions (see #1863), I understand that there is a project preference for aligning error handling style. However, while the current trend is to inline the error variable and handling (which is preferred by @shirou), I am suggesting the opposite: to adopt the noinlineerr linter in order to harmonize error handling by discouraging inlined error declarations.

Enabling this linter would:
- Promote consistency in error handling across the codebase
- Potentially make error management clearer for reviewers and contributors

I understand this proposal goes against the existing preference, but I believe it could be beneficial for maintainability. I’m sharing this for open discussion and feedback.
