### PR TITLE
Do not return an error on unknown CPU stepping

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -271,6 +271,10 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 				val = strings.Split(value, ".")[0]
 			}
 
+			if strings.EqualFold(val, "unknown") {
+				continue
+			}
+
 			t, err := strconv.ParseInt(val, 10, 64)
 			if err != nil {
 				return ret, err


### PR DESCRIPTION
As mentioned in https://github.com/DataDog/datadog-agent/issues/17935#issuecomment-3141818500, on some platforms the "stepping" entry in `/proc/cpuinfo` is "unknown", which makes `gopsutil` return an error.

I think this should just be ignored in that case, as if the `stepping` key was missing.

There is no test for this function so I didn't add any to cover this change, but if you want to I can add some.