### PR TITLE
process: Fix data race on darwin

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -668,13 +668,11 @@ func TestConcurrent(t *testing.T) {
 				return
 			}
 
-			times, err := p.Times()
+			_, err = p.Times()
 			if err != nil {
 				t.Errorf("process.Times failed: %v", err)
 				return
 			}
-
-			fmt.Println(times)
 		}()
 	}
 	wg.Wait()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -663,10 +663,16 @@ func TestConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			p, err := NewProcess(int32(os.Getpid()))
-			require.NoError(t, err)
+			if err != nil {
+				t.Errorf("NewProcess failed: %v", err)
+				return
+			}
 
 			times, err := p.Times()
-			require.NoError(t, err)
+			if err != nil {
+				t.Errorf("process.Times failed: %v", err)
+				return
+			}
 
 			fmt.Println(times)
 		}()

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -655,6 +655,25 @@ func TestCwd(t *testing.T) {
 	t.Log(pidCwd)
 }
 
+func TestConcurrent(t *testing.T) {
+	const goroutines int = 5
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p, err := NewProcess(int32(os.Getpid()))
+			require.NoError(t, err)
+
+			times, err := p.Times()
+			require.NoError(t, err)
+
+			fmt.Println(times)
+		}()
+	}
+	wg.Wait()
+}
+
 func BenchmarkNewProcess(b *testing.B) {
 	checkPid := os.Getpid()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Fixes #1900

`registerFuncs` mutates globals, and is called when any process instance methods to access CPU time or memory are used.

If 2 separate process instances are used concurrently to read CPU/memory this results in a data race.

Avoid globals completely by storing the loaded functions on a struct alongside the `*common.Library`, which avoids the race.