### PR TITLE
process: Cache dlOpen lib for faster lib calls

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -41,6 +41,7 @@ type Process struct {
 	lastCPUTimes *cpu.TimesStat
 	lastCPUTime  time.Time
 
+	os   osProcess
 	tgid int32
 }
 

--- a/process/process_state_none.go
+++ b/process/process_state_none.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build !darwin
+
+package process
+
+type osProcess struct{}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -799,3 +799,10 @@ func BenchmarkProcesses(b *testing.B) {
 		require.NotEmpty(b, ps)
 	}
 }
+
+func BenchmarkProcessCPUTime(b *testing.B) {
+	p := testGetProcess()
+	for i := 0; i < b.N; i++ {
+		p.Times()
+	}
+}


### PR DESCRIPTION
On darwin, calls that rely on purego functions such as process times or memory info will open/close the library, which dlOpen/dlCloses the same library repeatedly. This causes them to be significantly slower when they're used for periodic metrics emission.

Cache the library on the process to avoid the repeated dlOpen/dlClose.

The added benchmark shows significant improvements:
```
# old
BenchmarkProcessCPUTime-10        211495              5682 ns/op            2776 B/op         64 allocs/op
# new
BenchmarkProcessCPUTime-10       1159842              1021 ns/op             760 B/op         15 allocs/op
```