### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -300,12 +301,7 @@ func StringsContains(target []string, src string) bool {
 
 // IntContains checks the src in any int of the target int slice.
 func IntContains(target []int, src int) bool {
-	for _, t := range target {
-		if src == t {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(target, src)
 }
 
 // get struct attributes.

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -723,11 +724,8 @@ func TestEnviron(t *testing.T) {
 	}
 	require.NoErrorf(t, err, "getting environ error %v", err)
 	var envvarFound bool
-	for _, envvar := range envs {
-		if envvar == "testkey=envvalue" {
-			envvarFound = true
-			break
-		}
+	if slices.Contains(envs, "testkey=envvalue") {
+		envvarFound = true
 	}
 	assert.Truef(t, envvarFound, "environment variable not found")
 }


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.