### PR TITLE
[cpu][mem][linux]: throw error on Readline failed

### DIFF
--- a/cpu/cpu_dragonfly.go
+++ b/cpu/cpu_dragonfly.go
@@ -128,7 +128,11 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 
 func parseDmesgBoot(fileName string) (InfoStat, error) {
 	c := InfoStat{}
-	lines, _ := common.ReadLines(fileName)
+	lines, err := common.ReadLines(fileName)
+	if err != nil {
+		return c, fmt.Errorf("could not read %s: %w", fileName, err)
+	}
+
 	for _, line := range lines {
 		if matches := cpuEnd.FindStringSubmatch(line); matches != nil {
 			break

--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -126,7 +126,11 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 
 func parseDmesgBoot(fileName string) (InfoStat, int, error) {
 	c := InfoStat{}
-	lines, _ := common.ReadLines(fileName)
+	lines, err := common.ReadLines(fileName)
+	if err != nil {
+		return c, 0, fmt.Errorf("could not read %s: %w", fileName, err)
+	}
+
 	cpuNum := 1 // default cpu num is 1
 	for _, line := range lines {
 		if matches := cpuEnd.FindStringSubmatch(line); matches != nil {

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -105,6 +105,7 @@ func Times(percpu bool) ([]TimesStat, error) {
 func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 	filename := common.HostProcWithContext(ctx, "stat")
 	lines := []string{}
+	var err error
 	if percpu {
 		statlines, err := common.ReadLines(filename)
 		if err != nil || len(statlines) < 2 {
@@ -117,7 +118,10 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 			lines = append(lines, line)
 		}
 	} else {
-		lines, _ = common.ReadLinesOffsetN(filename, 0, 1)
+		lines, err = common.ReadLinesOffsetN(filename, 0, 1)
+		if err != nil || len(lines) == 0 {
+			return []TimesStat{}, nil
+		}
 	}
 
 	ret := make([]TimesStat, 0, len(lines))
@@ -181,7 +185,10 @@ func Info() ([]InfoStat, error) {
 
 func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 	filename := common.HostProcWithContext(ctx, "cpuinfo")
-	lines, _ := common.ReadLines(filename)
+	lines, err := common.ReadLines(filename)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %s: %w", filename, err)
+	}
 
 	var ret []InfoStat
 	var processorName string

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -39,7 +39,10 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 
 func fillFromMeminfoWithContext(ctx context.Context) (*VirtualMemoryStat, *ExVirtualMemory, error) {
 	filename := common.HostProcWithContext(ctx, "meminfo")
-	lines, _ := common.ReadLines(filename)
+	lines, err := common.ReadLines(filename)
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't read %s: %w", filename, err)
+	}
 
 	// flag if MemAvailable is in /proc/meminfo (kernel 3.14+)
 	memavail := false
@@ -348,7 +351,10 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 		ret.UsedPercent = 0
 	}
 	filename := common.HostProcWithContext(ctx, "vmstat")
-	lines, _ := common.ReadLines(filename)
+	lines, err := common.ReadLines(filename)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read %s: %w", filename, err)
+	}
 	for _, l := range lines {
 		fields := strings.Fields(l)
 		if len(fields) < 2 {


### PR DESCRIPTION
fix #1896

`common.ReadLines` can potentially fail. This PR adds proper error handling for it.