### PR TITLE
Fix: use compatible perfstat version to fix aix cgo builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ebitengine/purego v0.8.4
 	github.com/google/go-cmp v0.7.0
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0
-	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55
 	github.com/stretchr/testify v1.11.1
 	github.com/tklauser/go-sysconf v0.3.15
 	github.com/yusufpapurcu/wmi v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
-github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=


### PR DESCRIPTION
The initial version of cpu_aix.go (now split into cpu_aix_cgo.go) already used perfstat.CpuUtilTotalStat() which was not available in the pinned perfstat version in go.mod (then and now) but only in a more recent commit on perfstat (actually, the very next one, compare [1]).
This commit bumps perfstat to the latest state, picking up f38a28bc for the required CpuUtilTotalStat() and also a couple of more recent changes like Power10 support.

[1] https://github.com/power-devops/perfstat/commits/main/