### PR TITLE
limit memory usage on warnings list

### DIFF
--- a/internal/common/warnings.go
+++ b/internal/common/warnings.go
@@ -3,12 +3,17 @@ package common
 
 import "fmt"
 
+const maxWarnings = 100 // An arbitrary limit to avoid excessive memory usage, it has no sense to store thousands of errors
+
 type Warnings struct {
 	List    []error
 	Verbose bool
 }
 
 func (w *Warnings) Add(err error) {
+	if len(w.List) >= maxWarnings {
+		return
+	}
 	w.List = append(w.List, err)
 }
 


### PR DESCRIPTION
-  Warning List has no bound limit, there are cases where the list accumulates an infinite amount of errors causing memory exhaustion on the machine.

- I think having more than 100 errors, is not helpful in troubleshooting, it can only cause system instability.

- I propose to limit the amount, this is the most simple solution, the if you think it's necessary a more complex logic can be added, ex: (making configurable, avoid duplicated errors, add error rotations, ..)
