### PR TITLE
Remove leaking goroutine

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -95,7 +95,7 @@ func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 // PartitionsWithContext returns disk partitions.
 // It uses procGetLogicalDriveStringsW to get drives with drive letters and procFindFirstVolumeW to get volumes without drive letters.
 // Since the api calls don't have a timeout, this method uses context to set deadline by users.
-func PartitionsWithContext(ctx context.Context, _ bool) ([]PartitionStat, error) {
+func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 	warnings := Warnings{Verbose: true}
 	processedPaths := make(map[string]struct{})
 	partitionStats := []PartitionStat{}


### PR DESCRIPTION
This code was using a leaking goroutine to provide context cancellation, this is wrong and extremely dangerous.
Context should be used to provide real cancellation as soon as possible, if there is some code that cannot be interrupted, it's the responsibility of the caller to decide what to do, if blocking the thread or leave it leaking.

This is very important, suppose that you have this code:

```
ctx, cancel := context.WithCancel()
for {
   go leakingRoutine(ctx)
   time.sleep(1 * time.Second)
   cancel()
}
```


You expect that after cancel the routine is canceled, instead is still running and you accumulate memory and CPU indefinitely.

Never leave leaking go routines, and provide always a correct context cancellation.

I suggest to integrate https://github.com/uber-go/goleak In the tests to avoid leaking go routines.

I will make another PR later to provide a correct context cancellation.



Reference: https://github.com/shirou/gopsutil/issues/1911