### PR TITLE
[cpu][windows]: add logical processor count error handling

### DIFF
--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -103,6 +103,7 @@ func TestInfo(t *testing.T) {
 	for _, vv := range v {
 		assert.NotEmptyf(t, vv.ModelName, "could not get CPU Info: %v", vv)
 	}
+	t.Log(v)
 }
 
 func testPercent(t *testing.T, percpu bool) {

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -149,6 +149,9 @@ func getProcessorPowerInformation(ctx context.Context) ([]processorPowerInformat
 	if countErr != nil {
 		return nil, fmt.Errorf("failed to get logical processor count: %w", countErr)
 	}
+	if numLP <= 0 {
+		return nil, fmt.Errorf("invalid logical processor count: %d", numLP)
+	}
 
 	ppiSize := uintptr(numLP) * unsafe.Sizeof(processorPowerInformation{})
 	buf := make([]byte, ppiSize)


### PR DESCRIPTION
related to #1919 

Add error handling for an invalid logical processor count. This should not happen, but I think it’s better to make it safer, especially when using unsafe.

Also add `t.Log` on `TestInfo()` to easy check.