### PR TITLE
Use registry to remove wmi from cpu package

### DIFF
--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -104,7 +104,7 @@ func TestInfo(t *testing.T) {
 		assert.NotEmptyf(t, vv.ModelName, "could not get CPU Info: %v", vv)
 		if runtime.GOOS == "windows" {
 			assert.NotEmptyf(t, vv.VendorID, "could not get Vendor ID: %v", vv)
-			assert.NotEmptyf(t, vv.VendorID, "could not get CPU Family: %v", vv)
+			assert.NotEmptyf(t, vv.Family, "could not get CPU Family: %v", vv)
 			assert.Positivef(t, vv.Mhz, "could not get CPU Mhz: %v", vv)
 			assert.Positivef(t, vv.Cores, "could not get CPU Cores: %v", vv)
 		}

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -220,9 +220,9 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 				registryKeyPath := filepath.Join(centralProcessorRegistryKey, strconv.Itoa(globalLpl))
 				key, err := registry.OpenKey(registry.LOCAL_MACHINE, registryKeyPath, registry.QUERY_VALUE|registry.READ)
 				if err == nil {
-					defer key.Close()
 					model = getRegistryStringValueIfUnset(key, "ProcessorNameString", model)
 					vendorId = getRegistryStringValueIfUnset(key, "VendorIdentifier", vendorId)
+					_ = key.Close()
 				}
 			})
 		}


### PR DESCRIPTION
Implemented registry to get model name and vendorId.
Removed wmi from cpu package
