### PR TITLE
Fixes #1932

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -341,6 +341,7 @@ func parseFieldsOnMountinfo(ctx context.Context, lines []string, all bool, fs []
 		blockDeviceID := fields[2]
 		mountPoint := fields[4]
 		mountOpts := strings.Split(fields[5], ",")
+		device := fields[3]
 
 		if rootDir := fields[3]; rootDir != "" && rootDir != "/" {
 			mountOpts = append(mountOpts, "bind")
@@ -348,7 +349,9 @@ func parseFieldsOnMountinfo(ctx context.Context, lines []string, all bool, fs []
 
 		fields = strings.Fields(parts[1])
 		fstype := fields[0]
-		device := fields[1]
+		if (fields[0] != fields[1]) || (fields[0] == fields[1] && device == "/") {
+			device = fields[1]
+		}
 
 		d := PartitionStat{
 			Device:     device,


### PR DESCRIPTION
Certain virtual filesystems (e.g. nsfs, SOME tmpfs, overlayfs, etc.) should NOT duplicate the fstype as the source, as they have a *real* source.

This PR applies logic to determine whether to use mountinfo field 10 as the device ('source') or to use the mouninfo field 3 ('root') as the device.