### PR TITLE
Fix potential edge case on procfs and alike

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"runtime"
 	"sort"
 	"sync"
@@ -18,6 +19,7 @@ import (
 
 var (
 	invoke                 common.Invoker = common.Invoke{}
+	strictIntPtrn			      = regexp.MustCompile(`^[0-9]+$`)
 	ErrorNoChildren                       = errors.New("process does not have children") // Deprecated: ErrorNoChildren is never returned by process.Children(), check its returned []*Process slice length instead
 	ErrorProcessNotRunning                = errors.New("process does not exist")
 	ErrorNotPermitted                     = errors.New("operation not permitted")

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1173,6 +1173,9 @@ func readPidsFromDir(path string) ([]int32, error) {
 		return nil, err
 	}
 	for _, fname := range fnames {
+		if !strictIntPtrn.MatchString(fname) {
+			continue
+		}
 		pid, err := strconv.ParseInt(fname, 10, 32)
 		if err != nil {
 			// if not numeric name, just skip

--- a/process/process_solaris.go
+++ b/process/process_solaris.go
@@ -289,6 +289,9 @@ func readPidsFromDir(path string) ([]int32, error) {
 		return nil, err
 	}
 	for _, fname := range fnames {
+		if !strictIntPtrn.MatchString(fname) {
+			continue
+		}
 		pid, err := strconv.ParseInt(fname, 10, 32)
 		if err != nil {
 			// if not numeric name, just skip


### PR DESCRIPTION
On systems that use procfs or equivalent (Linux, Solaris), parsing the PID directory name (e.g. `/proc/<pid>`) is done strictly with `strconv.ParseInt`.

Per https://pkg.go.dev/strconv#ParseInt :

>The string may begin with a leading sign: "+" or "-".

Thus these cases would be interpreted erronously as PIDs:

* `/proc/+253/`
* `/proc/-253/`
  * This would even be interpreted as PID -253, since you use ParseInt and not ParseUint

This PR prevents this from occurring (and can avoid issues in the future were you not using an explicit base 10 -- e.g.:
`strconv.ParseInt(fname, 0, 32)` -- and it erroneously parsing e.g. `/proc/0xfd/`).