### PR TITLE
[common]: remove unused DoSysctrl

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -442,7 +442,7 @@ func HostRootWithContext(ctx context.Context, combineWith ...string) string {
 }
 
 // getSysctrlEnv sets LC_ALL=C in a list of env vars for use when running
-// sysctl commands (see DoSysctrl).
+// sysctl commands.
 func getSysctrlEnv(env []string) []string {
 	foundLC := false
 	for i, line := range env {

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -4,31 +4,13 @@
 package common
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
 	"golang.org/x/sys/unix"
 )
-
-func DoSysctrlWithContext(ctx context.Context, mib string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "sysctl", "-n", mib)
-	cmd.Env = getSysctrlEnv(os.Environ())
-	out, err := cmd.Output()
-	if err != nil {
-		return []string{}, err
-	}
-	v := strings.Replace(string(out), "{ ", "", 1)
-	v = strings.Replace(string(v), " }", "", 1)
-	values := strings.Fields(string(v))
-
-	return values, nil
-}
 
 func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	miblen := uint64(len(mib))

--- a/internal/common/common_freebsd.go
+++ b/internal/common/common_freebsd.go
@@ -5,9 +5,6 @@ package common
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -26,20 +23,6 @@ func SysctlUint(mib string) (uint64, error) {
 		return uint64(t), nil
 	}
 	return 0, fmt.Errorf("unexpected size: %s, %d", mib, len(buf))
-}
-
-func DoSysctrl(mib string) ([]string, error) {
-	cmd := exec.Command("sysctl", "-n", mib)
-	cmd.Env = getSysctrlEnv(os.Environ())
-	out, err := cmd.Output()
-	if err != nil {
-		return []string{}, err
-	}
-	v := strings.Replace(string(out), "{ ", "", 1)
-	v = strings.Replace(string(v), " }", "", 1)
-	values := strings.Fields(string(v))
-
-	return values, nil
 }
 
 func CallSyscall(mib []int32) ([]byte, uint64, error) {

--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,20 +18,6 @@ import (
 
 // cachedBootTime must be accessed via atomic.Load/StoreUint64
 var cachedBootTime uint64
-
-func DoSysctrl(mib string) ([]string, error) {
-	cmd := exec.Command("sysctl", "-n", mib)
-	cmd.Env = getSysctrlEnv(os.Environ())
-	out, err := cmd.Output()
-	if err != nil {
-		return []string{}, err
-	}
-	v := strings.Replace(string(out), "{ ", "", 1)
-	v = strings.Replace(string(v), " }", "", 1)
-	values := strings.Fields(string(v))
-
-	return values, nil
-}
 
 func NumProcs() (uint64, error) {
 	return NumProcsWithContext(context.Background())

--- a/internal/common/common_netbsd.go
+++ b/internal/common/common_netbsd.go
@@ -4,27 +4,10 @@
 package common
 
 import (
-	"os"
-	"os/exec"
-	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
-
-func DoSysctrl(mib string) ([]string, error) {
-	cmd := exec.Command("sysctl", "-n", mib)
-	cmd.Env = getSysctrlEnv(os.Environ())
-	out, err := cmd.Output()
-	if err != nil {
-		return []string{}, err
-	}
-	v := strings.Replace(string(out), "{ ", "", 1)
-	v = strings.Replace(string(v), " }", "", 1)
-	values := strings.Fields(string(v))
-
-	return values, nil
-}
 
 func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	mibptr := unsafe.Pointer(&mib[0])

--- a/internal/common/common_openbsd.go
+++ b/internal/common/common_openbsd.go
@@ -4,27 +4,10 @@
 package common
 
 import (
-	"os"
-	"os/exec"
-	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
-
-func DoSysctrl(mib string) ([]string, error) {
-	cmd := exec.Command("sysctl", "-n", mib)
-	cmd.Env = getSysctrlEnv(os.Environ())
-	out, err := cmd.Output()
-	if err != nil {
-		return []string{}, err
-	}
-	v := strings.Replace(string(out), "{ ", "", 1)
-	v = strings.Replace(string(v), " }", "", 1)
-	values := strings.Fields(string(v))
-
-	return values, nil
-}
 
 func CallSyscall(mib []int32) ([]byte, uint64, error) {
 	mibptr := unsafe.Pointer(&mib[0])


### PR DESCRIPTION
`internal/common/DoSysctrl` now unused. This PR delete those functions among platforms.