### PR TITLE
use correct path lengths

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -200,7 +200,7 @@ func buildPartitionStat(path string) (PartitionStat, error) {
 			uintptr(unsafe.Pointer(volPath)),
 			uintptr(unsafe.Pointer(&volumeName[0])),
 			uintptr(len(volumeName)),
-			uintptr(0), // serial numbrt
+			uintptr(0), // serial number
 			uintptr(0), // max component length
 			uintptr(unsafe.Pointer(&fsFlags)),
 			uintptr(unsafe.Pointer(&fsName[0])),


### PR DESCRIPTION
Fix to use correct paths/buffer lengths, consider that NTFS supports also paths longer than 256 (windows.MAX_PATH)