### PR TITLE
fix(process): add missing CloseHandle to OpenFilesWithContext for Windows

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -699,6 +699,7 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 	if err != nil {
 		return nil, err
 	}
+	defer windows.CloseHandle(process)
 
 	buffer := make([]byte, 1024)
 	var size uint32


### PR DESCRIPTION
Kudos to @moshe-m-orchid for pinpointing the issue.

Fixes https://github.com/shirou/gopsutil/issues/1949.