### PR TITLE
[cpu][linux]: fix ":" in CPU ModelName

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -195,7 +195,7 @@ func InfoWithContext(ctx context.Context) ([]InfoStat, error) {
 
 	c := InfoStat{CPU: -1, Cores: 1}
 	for _, line := range lines {
-		fields := strings.Split(line, ":")
+		fields := strings.SplitN(line, ":", 2)
 		if len(fields) < 2 {
 			continue
 		}
@@ -476,7 +476,7 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 			currentInfo = make(map[string]int)
 			continue
 		}
-		fields := strings.Split(line, ":")
+		fields := strings.SplitN(line, ":", 2)
 		if len(fields) < 2 {
 			continue
 		}

--- a/cpu/cpu_linux_test.go
+++ b/cpu/cpu_linux_test.go
@@ -100,3 +100,14 @@ func TestCountsLogicalAndroid_1037(t *testing.T) { // https://github.com/shirou/
 	expected := 8
 	assert.Equalf(t, expected, count, "expected %v, got %v", expected, count)
 }
+
+func TestCPUInfoModelNameWithColon_1958(t *testing.T) { // https://github.com/shirou/gopsutil/issues/1958
+	t.Setenv("HOST_PROC", "testdata/linux/1958/proc")
+
+	info, err := Info()
+	require.NoError(t, err)
+	require.Len(t, info, 1)
+
+	expected := "Hygon C86-4G (OPN:5435)"
+	assert.Equalf(t, expected, info[0].ModelName, "expected %v, got %v", expected, info[0].ModelName)
+}

--- a/cpu/testdata/linux/1958/proc/cpuinfo
+++ b/cpu/testdata/linux/1958/proc/cpuinfo
@@ -1,0 +1,21 @@
+processor	: 0
+vendor_id	: HygonGenuine
+cpu family	: 24
+model		: 6
+model name	: Hygon C86-4G (OPN:5435)
+stepping	: 1
+microcode	: 0x90610009
+cpu MHz		: 2799.751
+cache size	: 512 KB
+physical id	: 0
+siblings	: 32
+core id		: 0
+cpu cores	: 16
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 16
+wp		: yes
+flags		: fpu vme de pse
+bogomips	: 5599.50


### PR DESCRIPTION
Correctly parse even if ":" is included in the CPU ModelName.

fix #1958

