### PR TITLE
Add missing mount flags (local, protect)

### DIFF
--- a/disk/disk_darwin.go
+++ b/disk/disk_darwin.go
@@ -74,6 +74,12 @@ func PartitionsWithContext(_ context.Context, _ bool) ([]PartitionStat, error) {
 		if stat.Flags&unix.MNT_NODEV != 0 {
 			opts = append(opts, "nodev")
 		}
+		if stat.Flags&unix.MNT_LOCAL != 0 {
+			opts = append(opts, "local")
+		}
+		if stat.Flags&unix.MNT_CPROTECT != 0 {
+			opts = append(opts, "protect")
+		}
 		d := PartitionStat{
 			Device:     common.ByteToString(stat.Mntfromname[:]),
 			Mountpoint: common.ByteToString(stat.Mntonname[:]),


### PR DESCRIPTION
## Summary
Add support for `local` and `protect` mount flags on Darwin.

## Motivation
While comparing `mount` command output with gopsutil results on macOS, I noticed two commonly used flags were missing:
```
$ mount
/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
/dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled, nobrowse, protect)
/dev/disk3s7 on /nix (apfs, local, nosuid, journaled, noatime, nobrowse, protect)
```

The `local` and `protect` flags were not being parsed.

## Changes
Added checks for two mount flags in `PartitionsWithContext()`:
- `MNT_LOCAL` - indicates local (non-network) filesystem
- `MNT_CPROTECT` - indicates Data Protection is enabled (FileVault)

## Testing
Manually tested on macOS by comparing output with the native `mount` command. The flags now appear correctly in partition options.