### PR TITLE
[cpu][darwin]: release pCoreRef in each iteration

### DIFF
--- a/cpu/cpu_darwin_arm64.go
+++ b/cpu/cpu_darwin_arm64.go
@@ -69,6 +69,7 @@ func getFrequency() (float64, error) {
 			// combine the bytes into a uint32 value
 			b := buf[length-8 : length-4]
 			pCoreHz = binary.LittleEndian.Uint32(b)
+			cfRelease(uintptr(pCoreRef))
 			ioObjectRelease(service)
 			break
 		}


### PR DESCRIPTION
Release `pCoreRef` in each IOService iteration to fix a potential memory leak.
`cpu.Info` is probably not frequently called so it's a subtle issue, but still worth fixing.