### PR TITLE
feat(mem): Add support for Percpu

### DIFF
--- a/mem/ex_linux.go
+++ b/mem/ex_linux.go
@@ -14,6 +14,7 @@ type ExVirtualMemory struct {
 	ActiveAnon   uint64 `json:"activeanon"`
 	InactiveAnon uint64 `json:"inactiveanon"`
 	Unevictable  uint64 `json:"unevictable"`
+	Percpu       uint64 `json:"percpu"`
 }
 
 func (v ExVirtualMemory) String() string {

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -82,7 +82,6 @@ type VirtualMemoryStat struct {
 	HugePagesSurp  uint64 `json:"hugePagesSurp"`
 	HugePageSize   uint64 `json:"hugePageSize"`
 	AnonHugePages  uint64 `json:"anonHugePages"`
-	Percpu         uint64 `json:"percpu"`
 }
 
 type SwapMemoryStat struct {

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -138,6 +138,12 @@ func fillFromMeminfoWithContext(ctx context.Context) (*VirtualMemoryStat, *ExVir
 				return ret, retEx, err
 			}
 			retEx.Unevictable = t * 1024
+		case "Percpu":
+			t, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return ret, retEx, err
+			}
+			retEx.Percpu = t * 1024
 		case "Writeback":
 			t, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
@@ -301,12 +307,6 @@ func fillFromMeminfoWithContext(ctx context.Context) (*VirtualMemoryStat, *ExVir
 				return ret, retEx, err
 			}
 			ret.AnonHugePages = t * 1024
-		case "Percpu":
-			t, err := strconv.ParseUint(value, 10, 64)
-			if err != nil {
-				return ret, retEx, err
-			}
-			ret.Percpu = t * 1024
 		}
 	}
 

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -29,6 +29,7 @@ func TestExVirtualMemory(t *testing.T) {
 var virtualMemoryTests = []struct {
 	mockedRootFS string
 	stat         *VirtualMemoryStat
+	exStat       *ExVirtualMemory
 }{
 	{
 		"intelcorei5", &VirtualMemoryStat{
@@ -69,7 +70,14 @@ var virtualMemoryTests = []struct {
 			HugePagesRsvd:  0,
 			HugePagesSurp:  0,
 			HugePageSize:   2097152,
-			Percpu:         19595264,
+		},
+		&ExVirtualMemory{
+			ActiveFile:   1121992 * 1024,
+			InactiveFile: 1683344 * 1024,
+			ActiveAnon:   3123508 * 1024,
+			InactiveAnon: 1186612 * 1024,
+			Unevictable:  32 * 1024,
+			Percpu:       19136 * 1024,
 		},
 	},
 	{
@@ -112,6 +120,14 @@ var virtualMemoryTests = []struct {
 			HugePagesSurp:  0,
 			HugePageSize:   0,
 		},
+		&ExVirtualMemory{
+			ActiveFile:   88280 * 1024,
+			InactiveFile: 8380 * 1024,
+			ActiveAnon:   17956 * 1024,
+			InactiveAnon: 0,
+			Unevictable:  0,
+			Percpu:       0,
+		},
 	},
 	{
 		"anonhugepages", &VirtualMemoryStat{
@@ -121,6 +137,14 @@ var virtualMemoryTests = []struct {
 			AnonHugePages: 50409472 * 1024,
 			Used:          136109264896,
 			UsedPercent:   50.96606579876596,
+		},
+		&ExVirtualMemory{
+			ActiveFile:   0,
+			InactiveFile: 0,
+			ActiveAnon:   0,
+			InactiveAnon: 0,
+			Unevictable:  0,
+			Percpu:       0,
 		},
 	},
 }
@@ -136,6 +160,22 @@ func TestVirtualMemoryLinux(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Truef(t, reflect.DeepEqual(stat, tt.stat), "got: %+v\nwant: %+v", stat, tt.stat)
+		})
+	}
+}
+
+func TestExVirtualMemoryLinux(t *testing.T) {
+	for _, tt := range virtualMemoryTests {
+		t.Run(tt.mockedRootFS, func(t *testing.T) {
+			t.Setenv("HOST_PROC", filepath.Join("testdata", "linux", "virtualmemory", tt.mockedRootFS, "proc"))
+
+			ex := NewExLinux()
+			exStat, err := ex.VirtualMemory()
+			if errors.Is(err, common.ErrNotImplementedError) {
+				t.Skip("not implemented")
+			}
+			require.NoError(t, err)
+			assert.Truef(t, reflect.DeepEqual(exStat, tt.exStat), "got: %+v\nwant: %+v", exStat, tt.exStat)
 		})
 	}
 }

--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -83,7 +83,7 @@ func TestVirtualMemoryStat_String(t *testing.T) {
 		Free:        40,
 	}
 	t.Log(v)
-	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeBack":0,"dirty":0,"writeBackTmp":0,"shared":0,"slab":0,"sreclaimable":0,"sunreclaim":0,"pageTables":0,"swapCached":0,"commitLimit":0,"committedAS":0,"highTotal":0,"highFree":0,"lowTotal":0,"lowFree":0,"swapTotal":0,"swapFree":0,"mapped":0,"vmallocTotal":0,"vmallocUsed":0,"vmallocChunk":0,"hugePagesTotal":0,"hugePagesFree":0,"hugePagesRsvd":0,"hugePagesSurp":0,"hugePageSize":0,"anonHugePages":0, "percpu":0}`
+	e := `{"total":10,"available":20,"used":30,"usedPercent":30.1,"free":40,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeBack":0,"dirty":0,"writeBackTmp":0,"shared":0,"slab":0,"sreclaimable":0,"sunreclaim":0,"pageTables":0,"swapCached":0,"commitLimit":0,"committedAS":0,"highTotal":0,"highFree":0,"lowTotal":0,"lowFree":0,"swapTotal":0,"swapFree":0,"mapped":0,"vmallocTotal":0,"vmallocUsed":0,"vmallocChunk":0,"hugePagesTotal":0,"hugePagesFree":0,"hugePagesRsvd":0,"hugePagesSurp":0,"hugePageSize":0,"anonHugePages":0}`
 	assert.JSONEqf(t, e, v.String(), "VirtualMemoryStat string is invalid: %v", v)
 }
 


### PR DESCRIPTION
Hi!

Please take a look at the PR, it add support for the `Percpu` field from /`proc/meminfo` which is available on modern linux based OS. 

Closes #1203 
  