### PR TITLE
fix disk.Partition cut off after first disk

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"syscall"
 	"unicode/utf16"
 	"unsafe"
@@ -239,8 +238,7 @@ func getLogicalDrives(ctx context.Context) ([]string, error) {
 		return nil, err // The call failed with an unexpected error
 	}
 
-	drivesString := windows.UTF16ToString(lpBuffer)
-	drives := strings.Split(drivesString, "\x00")
+	drives := split0(lpBuffer, int(bufferLen))
 	return drives, nil
 }
 


### PR DESCRIPTION
using windows.UTF16ToString() converts a []uint16 to a string but ends after the first NUL. There is already a split0() function which does the right thing in this file, so simply use that one.

before:

    getLogicalDrives() -> ['C:\']

after:

    getLogicalDrives() -> ['C:\', 'D:\', 'Z:\']