### PR TITLE
[darwin]: wrap library functions as struct methods

### DIFF
--- a/cpu/cpu_darwin_arm64.go
+++ b/cpu/cpu_darwin_arm64.go
@@ -13,55 +13,43 @@ import (
 
 // https://github.com/shoenig/go-m1cpu/blob/v0.1.6/cpu.go
 func getFrequency() (float64, error) {
-	ioKit, err := common.NewLibrary(common.IOKit)
+	iokit, err := common.NewIOKitLib()
 	if err != nil {
 		return 0, err
 	}
-	defer ioKit.Close()
+	defer iokit.Close()
 
-	coreFoundation, err := common.NewLibrary(common.CoreFoundation)
+	corefoundation, err := common.NewCoreFoundationLib()
 	if err != nil {
 		return 0, err
 	}
-	defer coreFoundation.Close()
+	defer corefoundation.Close()
 
-	ioServiceMatching := common.GetFunc[common.IOServiceMatchingFunc](ioKit, common.IOServiceMatchingSym)
-	ioServiceGetMatchingServices := common.GetFunc[common.IOServiceGetMatchingServicesFunc](ioKit, common.IOServiceGetMatchingServicesSym)
-	ioIteratorNext := common.GetFunc[common.IOIteratorNextFunc](ioKit, common.IOIteratorNextSym)
-	ioRegistryEntryGetName := common.GetFunc[common.IORegistryEntryGetNameFunc](ioKit, common.IORegistryEntryGetNameSym)
-	ioRegistryEntryCreateCFProperty := common.GetFunc[common.IORegistryEntryCreateCFPropertyFunc](ioKit, common.IORegistryEntryCreateCFPropertySym)
-	ioObjectRelease := common.GetFunc[common.IOObjectReleaseFunc](ioKit, common.IOObjectReleaseSym)
-
-	cfStringCreateWithCString := common.GetFunc[common.CFStringCreateWithCStringFunc](coreFoundation, common.CFStringCreateWithCStringSym)
-	cfDataGetLength := common.GetFunc[common.CFDataGetLengthFunc](coreFoundation, common.CFDataGetLengthSym)
-	cfDataGetBytePtr := common.GetFunc[common.CFDataGetBytePtrFunc](coreFoundation, common.CFDataGetBytePtrSym)
-	cfRelease := common.GetFunc[common.CFReleaseFunc](coreFoundation, common.CFReleaseSym)
-
-	matching := ioServiceMatching("AppleARMIODevice")
+	matching := iokit.IOServiceMatching("AppleARMIODevice")
 
 	var iterator uint32
-	if status := ioServiceGetMatchingServices(common.KIOMainPortDefault, uintptr(matching), &iterator); status != common.KERN_SUCCESS {
+	if status := iokit.IOServiceGetMatchingServices(common.KIOMainPortDefault, uintptr(matching), &iterator); status != common.KERN_SUCCESS {
 		return 0.0, fmt.Errorf("IOServiceGetMatchingServices error=%d", status)
 	}
-	defer ioObjectRelease(iterator)
+	defer iokit.IOObjectRelease(iterator)
 
-	pCorekey := cfStringCreateWithCString(common.KCFAllocatorDefault, "voltage-states5-sram", common.KCFStringEncodingUTF8)
-	defer cfRelease(uintptr(pCorekey))
+	pCorekey := corefoundation.CFStringCreateWithCString(common.KCFAllocatorDefault, "voltage-states5-sram", common.KCFStringEncodingUTF8)
+	defer corefoundation.CFRelease(uintptr(pCorekey))
 
 	var pCoreHz uint32
 	for {
-		service := ioIteratorNext(iterator)
+		service := iokit.IOIteratorNext(iterator)
 		if service <= 0 {
 			break
 		}
 
 		buf := common.NewCStr(512)
-		ioRegistryEntryGetName(service, buf)
+		iokit.IORegistryEntryGetName(service, buf)
 
 		if buf.GoString() == "pmgr" {
-			pCoreRef := ioRegistryEntryCreateCFProperty(service, uintptr(pCorekey), common.KCFAllocatorDefault, common.KNilOptions)
-			length := cfDataGetLength(uintptr(pCoreRef))
-			data := cfDataGetBytePtr(uintptr(pCoreRef))
+			pCoreRef := iokit.IORegistryEntryCreateCFProperty(service, uintptr(pCorekey), common.KCFAllocatorDefault, common.KNilOptions)
+			length := corefoundation.CFDataGetLength(uintptr(pCoreRef))
+			data := corefoundation.CFDataGetBytePtr(uintptr(pCoreRef))
 
 			// composite uint32 from the byte array
 			buf := unsafe.Slice((*byte)(data), length)
@@ -69,12 +57,12 @@ func getFrequency() (float64, error) {
 			// combine the bytes into a uint32 value
 			b := buf[length-8 : length-4]
 			pCoreHz = binary.LittleEndian.Uint32(b)
-			cfRelease(uintptr(pCoreRef))
-			ioObjectRelease(service)
+			corefoundation.CFRelease(uintptr(pCoreRef))
+			iokit.IOObjectRelease(service)
 			break
 		}
 
-		ioObjectRelease(service)
+		iokit.IOObjectRelease(service)
 	}
 
 	return float64(pCoreHz / 1_000_000), nil

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -12,48 +12,311 @@ import (
 )
 
 // Library represents a dynamic library loaded by purego.
-type Library struct {
-	addr  uintptr
-	path  string
-	close func()
+type library struct {
+	handle uintptr
+	fnMap  map[string]any
 }
 
 // library paths
 const (
-	IOKit          = "/System/Library/Frameworks/IOKit.framework/IOKit"
-	CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-	System         = "/usr/lib/libSystem.B.dylib"
+	IOKitLibPath          = "/System/Library/Frameworks/IOKit.framework/IOKit"
+	CoreFoundationLibPath = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+	SystemLibPath         = "/usr/lib/libSystem.B.dylib"
 )
 
-func NewLibrary(path string) (*Library, error) {
+func newLibrary(path string) (*library, error) {
 	lib, err := purego.Dlopen(path, purego.RTLD_LAZY|purego.RTLD_GLOBAL)
 	if err != nil {
 		return nil, err
 	}
 
-	closeFunc := func() {
-		purego.Dlclose(lib)
-	}
-
-	return &Library{
-		addr:  lib,
-		path:  path,
-		close: closeFunc,
+	return &library{
+		handle: lib,
+		fnMap:  make(map[string]any),
 	}, nil
 }
 
-func (lib *Library) Dlsym(symbol string) (uintptr, error) {
-	return purego.Dlsym(lib.addr, symbol)
+func (lib *library) Dlsym(symbol string) (uintptr, error) {
+	return purego.Dlsym(lib.handle, symbol)
 }
 
-func GetFunc[T any](lib *Library, symbol string) T {
-	var fptr T
-	purego.RegisterLibFunc(&fptr, lib.addr, symbol)
-	return fptr
+func getFunc[T any](lib *library, symbol string) T {
+	var dlfun *dlFunc[T]
+	if f, ok := lib.fnMap[symbol].(*dlFunc[T]); ok {
+		dlfun = f
+	} else {
+		dlfun = newDlfunc[T](symbol)
+		dlfun.init(lib.handle)
+		lib.fnMap[symbol] = dlfun
+	}
+	return dlfun.fn
 }
 
-func (lib *Library) Close() {
-	lib.close()
+func (lib *library) Close() {
+	purego.Dlclose(lib.handle)
+}
+
+type dlFunc[T any] struct {
+	sym string
+	fn  T
+}
+
+func (d *dlFunc[T]) init(handle uintptr) {
+	purego.RegisterLibFunc(&d.fn, handle, d.sym)
+}
+
+func newDlfunc[T any](sym string) *dlFunc[T] {
+	return &dlFunc[T]{sym: sym}
+}
+
+type CoreFoundationLib struct {
+	*library
+}
+
+func NewCoreFoundationLib() (*CoreFoundationLib, error) {
+	library, err := newLibrary(CoreFoundationLibPath)
+	if err != nil {
+		return nil, err
+	}
+	return &CoreFoundationLib{library}, nil
+}
+
+func (c *CoreFoundationLib) CFGetTypeID(cf uintptr) int32 {
+	fn := getFunc[CFGetTypeIDFunc](c.library, "CFGetTypeID")
+	return fn(cf)
+}
+
+func (c *CoreFoundationLib) CFNumberCreate(allocator uintptr, theType int32, valuePtr uintptr) unsafe.Pointer {
+	fn := getFunc[CFNumberCreateFunc](c.library, "CFNumberCreate")
+	return fn(allocator, theType, valuePtr)
+}
+
+func (c *CoreFoundationLib) CFNumberGetValue(num uintptr, theType int32, valuePtr uintptr) bool {
+	fn := getFunc[CFNumberGetValueFunc](c.library, "CFNumberGetValue")
+	return fn(num, theType, valuePtr)
+}
+
+func (c *CoreFoundationLib) CFDictionaryCreate(allocator uintptr, keys, values *unsafe.Pointer, numValues int32,
+	keyCallBacks, valueCallBacks uintptr,
+) unsafe.Pointer {
+	fn := getFunc[CFDictionaryCreateFunc](c.library, "CFDictionaryCreate")
+	return fn(allocator, keys, values, numValues, keyCallBacks, valueCallBacks)
+}
+
+func (c *CoreFoundationLib) CFDictionaryAddValue(theDict, key, value uintptr) {
+	fn := getFunc[CFDictionaryAddValueFunc](c.library, "CFDictionaryAddValue")
+	fn(theDict, key, value)
+}
+
+func (c *CoreFoundationLib) CFDictionaryGetValue(theDict, key uintptr) unsafe.Pointer {
+	fn := getFunc[CFDictionaryGetValueFunc](c.library, "CFDictionaryGetValue")
+	return fn(theDict, key)
+}
+
+func (c *CoreFoundationLib) CFArrayGetCount(theArray uintptr) int32 {
+	fn := getFunc[CFArrayGetCountFunc](c.library, "CFArrayGetCount")
+	return fn(theArray)
+}
+
+func (c *CoreFoundationLib) CFArrayGetValueAtIndex(theArray uintptr, index int32) unsafe.Pointer {
+	fn := getFunc[CFArrayGetValueAtIndexFunc](c.library, "CFArrayGetValueAtIndex")
+	return fn(theArray, index)
+}
+
+func (c *CoreFoundationLib) CFStringCreateMutable(alloc uintptr, maxLength int32) unsafe.Pointer {
+	fn := getFunc[CFStringCreateMutableFunc](c.library, "CFStringCreateMutable")
+	return fn(alloc, maxLength)
+}
+
+func (c *CoreFoundationLib) CFStringGetLength(theString uintptr) int32 {
+	fn := getFunc[CFStringGetLengthFunc](c.library, "CFStringGetLength")
+	return fn(theString)
+}
+
+func (c *CoreFoundationLib) CFStringGetCString(theString uintptr, buffer CStr, bufferSize int32, encoding uint32) {
+	fn := getFunc[CFStringGetCStringFunc](c.library, "CFStringGetCString")
+	fn(theString, buffer, bufferSize, encoding)
+}
+
+func (c *CoreFoundationLib) CFStringCreateWithCString(alloc uintptr, cStr string, encoding uint32) unsafe.Pointer {
+	fn := getFunc[CFStringCreateWithCStringFunc](c.library, "CFStringCreateWithCString")
+	return fn(alloc, cStr, encoding)
+}
+
+func (c *CoreFoundationLib) CFDataGetLength(theData uintptr) int32 {
+	fn := getFunc[CFDataGetLengthFunc](c.library, "CFDataGetLength")
+	return fn(theData)
+}
+
+func (c *CoreFoundationLib) CFDataGetBytePtr(theData uintptr) unsafe.Pointer {
+	fn := getFunc[CFDataGetBytePtrFunc](c.library, "CFDataGetBytePtr")
+	return fn(theData)
+}
+
+func (c *CoreFoundationLib) CFRelease(cf uintptr) {
+	fn := getFunc[CFReleaseFunc](c.library, "CFRelease")
+	fn(cf)
+}
+
+type IOKitLib struct {
+	*library
+}
+
+func NewIOKitLib() (*IOKitLib, error) {
+	library, err := newLibrary(IOKitLibPath)
+	if err != nil {
+		return nil, err
+	}
+	return &IOKitLib{library}, nil
+}
+
+func (l *IOKitLib) IOServiceGetMatchingService(mainPort uint32, matching uintptr) uint32 {
+	fn := getFunc[IOServiceGetMatchingServiceFunc](l.library, "IOServiceGetMatchingService")
+	return fn(mainPort, matching)
+}
+
+func (l *IOKitLib) IOServiceGetMatchingServices(mainPort uint32, matching uintptr, existing *uint32) int {
+	fn := getFunc[IOServiceGetMatchingServicesFunc](l.library, "IOServiceGetMatchingServices")
+	return fn(mainPort, matching, existing)
+}
+
+func (l *IOKitLib) IOServiceMatching(name string) unsafe.Pointer {
+	fn := getFunc[IOServiceMatchingFunc](l.library, "IOServiceMatching")
+	return fn(name)
+}
+
+func (l *IOKitLib) IOServiceOpen(service, owningTask, connType uint32, connect *uint32) int {
+	fn := getFunc[IOServiceOpenFunc](l.library, "IOServiceOpen")
+	return fn(service, owningTask, connType, connect)
+}
+
+func (l *IOKitLib) IOServiceClose(connect uint32) int {
+	fn := getFunc[IOServiceCloseFunc](l.library, "IOServiceClose")
+	return fn(connect)
+}
+
+func (l *IOKitLib) IOIteratorNext(iterator uint32) uint32 {
+	fn := getFunc[IOIteratorNextFunc](l.library, "IOIteratorNext")
+	return fn(iterator)
+}
+
+func (l *IOKitLib) IORegistryEntryGetName(entry uint32, name CStr) int {
+	fn := getFunc[IORegistryEntryGetNameFunc](l.library, "IORegistryEntryGetName")
+	return fn(entry, name)
+}
+
+func (l *IOKitLib) IORegistryEntryGetParentEntry(entry uint32, plane string, parent *uint32) int {
+	fn := getFunc[IORegistryEntryGetParentEntryFunc](l.library, "IORegistryEntryGetParentEntry")
+	return fn(entry, plane, parent)
+}
+
+func (l *IOKitLib) IORegistryEntryCreateCFProperty(entry uint32, key, allocator uintptr, options uint32) unsafe.Pointer {
+	fn := getFunc[IORegistryEntryCreateCFPropertyFunc](l.library, "IORegistryEntryCreateCFProperty")
+	return fn(entry, key, allocator, options)
+}
+
+func (l *IOKitLib) IORegistryEntryCreateCFProperties(entry uint32, properties unsafe.Pointer, allocator uintptr, options uint32) int {
+	fn := getFunc[IORegistryEntryCreateCFPropertiesFunc](l.library, "IORegistryEntryCreateCFProperties")
+	return fn(entry, properties, allocator, options)
+}
+
+func (l *IOKitLib) IOObjectConformsTo(object uint32, className string) bool {
+	fn := getFunc[IOObjectConformsToFunc](l.library, "IOObjectConformsTo")
+	return fn(object, className)
+}
+
+func (l *IOKitLib) IOObjectRelease(object uint32) int {
+	fn := getFunc[IOObjectReleaseFunc](l.library, "IOObjectRelease")
+	return fn(object)
+}
+
+func (l *IOKitLib) IOConnectCallStructMethod(connection, selector uint32, inputStruct, inputStructCnt, outputStruct uintptr, outputStructCnt *uintptr) int {
+	fn := getFunc[IOConnectCallStructMethodFunc](l.library, "IOConnectCallStructMethod")
+	return fn(connection, selector, inputStruct, inputStructCnt, outputStruct, outputStructCnt)
+}
+
+func (l *IOKitLib) IOHIDEventSystemClientCreate(allocator uintptr) unsafe.Pointer {
+	fn := getFunc[IOHIDEventSystemClientCreateFunc](l.library, "IOHIDEventSystemClientCreate")
+	return fn(allocator)
+}
+
+func (l *IOKitLib) IOHIDEventSystemClientSetMatching(client, match uintptr) int {
+	fn := getFunc[IOHIDEventSystemClientSetMatchingFunc](l.library, "IOHIDEventSystemClientSetMatching")
+	return fn(client, match)
+}
+
+func (l *IOKitLib) IOHIDServiceClientCopyEvent(service uintptr, eventType int64, options int32, timeout int64) unsafe.Pointer {
+	fn := getFunc[IOHIDServiceClientCopyEventFunc](l.library, "IOHIDServiceClientCopyEvent")
+	return fn(service, eventType, options, timeout)
+}
+
+func (l *IOKitLib) IOHIDServiceClientCopyProperty(service, property uintptr) unsafe.Pointer {
+	fn := getFunc[IOHIDServiceClientCopyPropertyFunc](l.library, "IOHIDServiceClientCopyProperty")
+	return fn(service, property)
+}
+
+func (l *IOKitLib) IOHIDEventGetFloatValue(event uintptr, field int32) float64 {
+	fn := getFunc[IOHIDEventGetFloatValueFunc](l.library, "IOHIDEventGetFloatValue")
+	return fn(event, field)
+}
+
+func (l *IOKitLib) IOHIDEventSystemClientCopyServices(client uintptr) unsafe.Pointer {
+	fn := getFunc[IOHIDEventSystemClientCopyServicesFunc](l.library, "IOHIDEventSystemClientCopyServices")
+	return fn(client)
+}
+
+type SystemLib struct {
+	*library
+}
+
+func NewSystemLib() (*SystemLib, error) {
+	library, err := newLibrary(SystemLibPath)
+	if err != nil {
+		return nil, err
+	}
+	return &SystemLib{library}, nil
+}
+
+func (s *SystemLib) HostProcessorInfo(host uint32, flavor int32, outProcessorCount *uint32, outProcessorInfo uintptr,
+	outProcessorInfoCnt *uint32,
+) int {
+	fn := getFunc[HostProcessorInfoFunc](s.library, "host_processor_info")
+	return fn(host, flavor, outProcessorCount, outProcessorInfo, outProcessorInfoCnt)
+}
+
+func (s *SystemLib) HostStatistics(host uint32, flavor int32, hostInfoOut uintptr, hostInfoOutCnt *uint32) int {
+	fn := getFunc[HostStatisticsFunc](s.library, "host_statistics")
+	return fn(host, flavor, hostInfoOut, hostInfoOutCnt)
+}
+
+func (s *SystemLib) MachHostSelf() uint32 {
+	fn := getFunc[MachHostSelfFunc](s.library, "mach_host_self")
+	return fn()
+}
+
+func (s *SystemLib) MachTaskSelf() uint32 {
+	fn := getFunc[MachTaskSelfFunc](s.library, "mach_task_self")
+	return fn()
+}
+
+func (s *SystemLib) MachTimeBaseInfo(info uintptr) int {
+	fn := getFunc[MachTimeBaseInfoFunc](s.library, "mach_timebase_info")
+	return fn(info)
+}
+
+func (s *SystemLib) VMDeallocate(targetTask uint32, vmAddress, vmSize uintptr) int {
+	fn := getFunc[VMDeallocateFunc](s.library, "vm_deallocate")
+	return fn(targetTask, vmAddress, vmSize)
+}
+
+func (s *SystemLib) ProcPidPath(pid int32, buffer uintptr, bufferSize uint32) int32 {
+	fn := getFunc[ProcPidPathFunc](s.library, "proc_pidpath")
+	return fn(pid, buffer, bufferSize)
+}
+
+func (s *SystemLib) ProcPidInfo(pid, flavor int32, arg uint64, buffer uintptr, bufferSize int32) int32 {
+	fn := getFunc[ProcPidInfoFunc](s.library, "proc_pidinfo")
+	return fn(pid, flavor, arg, buffer, bufferSize)
 }
 
 // status codes
@@ -61,7 +324,7 @@ const (
 	KERN_SUCCESS = 0
 )
 
-// IOKit functions and symbols.
+// IOKit types and constants.
 type (
 	IOServiceGetMatchingServiceFunc       func(mainPort uint32, matching uintptr) uint32
 	IOServiceGetMatchingServicesFunc      func(mainPort uint32, matching uintptr, existing *uint32) int
@@ -87,29 +350,6 @@ type (
 )
 
 const (
-	IOServiceGetMatchingServiceSym       = "IOServiceGetMatchingService"
-	IOServiceGetMatchingServicesSym      = "IOServiceGetMatchingServices"
-	IOServiceMatchingSym                 = "IOServiceMatching"
-	IOServiceOpenSym                     = "IOServiceOpen"
-	IOServiceCloseSym                    = "IOServiceClose"
-	IOIteratorNextSym                    = "IOIteratorNext"
-	IORegistryEntryGetNameSym            = "IORegistryEntryGetName"
-	IORegistryEntryGetParentEntrySym     = "IORegistryEntryGetParentEntry"
-	IORegistryEntryCreateCFPropertySym   = "IORegistryEntryCreateCFProperty"
-	IORegistryEntryCreateCFPropertiesSym = "IORegistryEntryCreateCFProperties"
-	IOObjectConformsToSym                = "IOObjectConformsTo"
-	IOObjectReleaseSym                   = "IOObjectRelease"
-	IOConnectCallStructMethodSym         = "IOConnectCallStructMethod"
-
-	IOHIDEventSystemClientCreateSym       = "IOHIDEventSystemClientCreate"
-	IOHIDEventSystemClientSetMatchingSym  = "IOHIDEventSystemClientSetMatching"
-	IOHIDServiceClientCopyEventSym        = "IOHIDServiceClientCopyEvent"
-	IOHIDServiceClientCopyPropertySym     = "IOHIDServiceClientCopyProperty"
-	IOHIDEventGetFloatValueSym            = "IOHIDEventGetFloatValue"
-	IOHIDEventSystemClientCopyServicesSym = "IOHIDEventSystemClientCopyServices"
-)
-
-const (
 	KIOMainPortDefault = 0
 
 	KIOHIDEventTypeTemperature = 15
@@ -122,7 +362,7 @@ const (
 	KIOServicePlane  = "IOService"
 )
 
-// CoreFoundation functions and symbols.
+// CoreFoundation types and constants.
 type (
 	CFGetTypeIDFunc        func(cf uintptr) int32
 	CFNumberCreateFunc     func(allocator uintptr, theType int32, valuePtr uintptr) unsafe.Pointer
@@ -143,31 +383,13 @@ type (
 )
 
 const (
-	CFGetTypeIDSym               = "CFGetTypeID"
-	CFNumberCreateSym            = "CFNumberCreate"
-	CFNumberGetValueSym          = "CFNumberGetValue"
-	CFDictionaryCreateSym        = "CFDictionaryCreate"
-	CFDictionaryAddValueSym      = "CFDictionaryAddValue"
-	CFDictionaryGetValueSym      = "CFDictionaryGetValue"
-	CFArrayGetCountSym           = "CFArrayGetCount"
-	CFArrayGetValueAtIndexSym    = "CFArrayGetValueAtIndex"
-	CFStringCreateMutableSym     = "CFStringCreateMutable"
-	CFStringGetLengthSym         = "CFStringGetLength"
-	CFStringGetCStringSym        = "CFStringGetCString"
-	CFStringCreateWithCStringSym = "CFStringCreateWithCString"
-	CFDataGetLengthSym           = "CFDataGetLength"
-	CFDataGetBytePtrSym          = "CFDataGetBytePtr"
-	CFReleaseSym                 = "CFRelease"
-)
-
-const (
 	KCFStringEncodingUTF8 = 0x08000100
 	KCFNumberSInt64Type   = 4
 	KCFNumberIntType      = 9
 	KCFAllocatorDefault   = 0
 )
 
-// Kernel functions and symbols.
+// libSystem types and constants.
 type MachTimeBaseInfo struct {
 	Numer uint32
 	Denom uint32
@@ -199,7 +421,6 @@ const (
 	HOST_VM_INFO_COUNT = 0xf
 )
 
-// System functions and symbols.
 type (
 	ProcPidPathFunc func(pid int32, buffer uintptr, bufferSize uint32) int32
 	ProcPidInfoFunc func(pid, flavor int32, arg uint64, buffer uintptr, bufferSize int32) int32
@@ -221,9 +442,8 @@ const (
 
 // SMC represents a SMC instance.
 type SMC struct {
-	lib        *Library
-	conn       uint32
-	callStruct IOConnectCallStructMethodFunc
+	lib  *IOKitLib
+	conn uint32
 }
 
 const ioServiceSMC = "AppleSMC"
@@ -245,47 +465,39 @@ const (
 	KSMCKeyNotFound = 132
 )
 
-func NewSMC(ioKit *Library) (*SMC, error) {
-	if ioKit.path != IOKit {
-		return nil, errors.New("library is not IOKit")
+func NewSMC() (*SMC, error) {
+	iokit, err := NewIOKitLib()
+	if err != nil {
+		return nil, err
 	}
 
-	ioServiceGetMatchingService := GetFunc[IOServiceGetMatchingServiceFunc](ioKit, IOServiceGetMatchingServiceSym)
-	ioServiceMatching := GetFunc[IOServiceMatchingFunc](ioKit, IOServiceMatchingSym)
-	ioServiceOpen := GetFunc[IOServiceOpenFunc](ioKit, IOServiceOpenSym)
-	ioObjectRelease := GetFunc[IOObjectReleaseFunc](ioKit, IOObjectReleaseSym)
-	machTaskSelf := GetFunc[MachTaskSelfFunc](ioKit, MachTaskSelfSym)
-
-	ioConnectCallStructMethod := GetFunc[IOConnectCallStructMethodFunc](ioKit, IOConnectCallStructMethodSym)
-
-	service := ioServiceGetMatchingService(0, uintptr(ioServiceMatching(ioServiceSMC)))
+	service := iokit.IOServiceGetMatchingService(0, uintptr(iokit.IOServiceMatching(ioServiceSMC)))
 	if service == 0 {
 		return nil, fmt.Errorf("ERROR: %s NOT FOUND", ioServiceSMC)
 	}
 
 	var conn uint32
-	if result := ioServiceOpen(service, machTaskSelf(), 0, &conn); result != 0 {
+	machTaskSelf := getFunc[MachTaskSelfFunc](iokit.library, "mach_task_self")
+	if result := iokit.IOServiceOpen(service, machTaskSelf(), 0, &conn); result != 0 {
 		return nil, errors.New("ERROR: IOServiceOpen failed")
 	}
 
-	ioObjectRelease(service)
+	iokit.IOObjectRelease(service)
 	return &SMC{
-		lib:        ioKit,
-		conn:       conn,
-		callStruct: ioConnectCallStructMethod,
+		lib:  iokit,
+		conn: conn,
 	}, nil
 }
 
 func (s *SMC) CallStruct(selector uint32, inputStruct, inputStructCnt, outputStruct uintptr, outputStructCnt *uintptr) int {
-	return s.callStruct(s.conn, selector, inputStruct, inputStructCnt, outputStruct, outputStructCnt)
+	return s.lib.IOConnectCallStructMethod(s.conn, selector, inputStruct, inputStructCnt, outputStruct, outputStructCnt)
 }
 
 func (s *SMC) Close() error {
-	ioServiceClose := GetFunc[IOServiceCloseFunc](s.lib, IOServiceCloseSym)
-
-	if result := ioServiceClose(s.conn); result != 0 {
+	if result := s.lib.IOServiceClose(s.conn); result != 0 {
 		return errors.New("ERROR: IOServiceClose failed")
 	}
+	s.lib.Close()
 	return nil
 }
 

--- a/mem/mem_darwin.go
+++ b/mem/mem_darwin.go
@@ -85,26 +85,23 @@ func VirtualMemory() (*VirtualMemoryStat, error) {
 }
 
 func VirtualMemoryWithContext(_ context.Context) (*VirtualMemoryStat, error) {
-	machLib, err := common.NewLibrary(common.System)
+	sys, err := common.NewSystemLib()
 	if err != nil {
 		return nil, err
 	}
-	defer machLib.Close()
-
-	hostStatistics := common.GetFunc[common.HostStatisticsFunc](machLib, common.HostStatisticsSym)
-	machHostSelf := common.GetFunc[common.MachHostSelfFunc](machLib, common.MachHostSelfSym)
+	defer sys.Close()
 
 	count := uint32(common.HOST_VM_INFO_COUNT)
 	var vmstat vmStatisticsData
 
-	status := hostStatistics(machHostSelf(), common.HOST_VM_INFO,
+	status := sys.HostStatistics(sys.MachHostSelf(), common.HOST_VM_INFO,
 		uintptr(unsafe.Pointer(&vmstat)), &count)
 
 	if status != common.KERN_SUCCESS {
 		return nil, fmt.Errorf("host_statistics error=%d", status)
 	}
 
-	pageSizeAddr, _ := machLib.Dlsym("vm_kernel_page_size")
+	pageSizeAddr, _ := sys.Dlsym("vm_kernel_page_size")
 	pageSize := **(**uint64)(unsafe.Pointer(&pageSizeAddr))
 	total, err := getHwMemsize()
 	if err != nil {

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -280,31 +280,21 @@ func callPsWithContext(ctx context.Context, arg string, pid int32, threadOption,
 }
 
 type dlFuncs struct {
-	lib *common.Library
-
-	procPidPath      common.ProcPidPathFunc
-	procPidInfo      common.ProcPidInfoFunc
-	machTimeBaseInfo common.MachTimeBaseInfoFunc
+	lib *common.SystemLib
 }
 
 func loadProcFuncs() (*dlFuncs, error) {
-	lib, err := common.NewLibrary(common.System)
+	lib, err := common.NewSystemLib()
 	if err != nil {
 		return nil, err
 	}
-
-	return &dlFuncs{
-		lib:              lib,
-		procPidPath:      common.GetFunc[common.ProcPidPathFunc](lib, common.ProcPidPathSym),
-		procPidInfo:      common.GetFunc[common.ProcPidInfoFunc](lib, common.ProcPidInfoSym),
-		machTimeBaseInfo: common.GetFunc[common.MachTimeBaseInfoFunc](lib, common.MachTimeBaseInfoSym),
-	}, nil
+	return &dlFuncs{lib}, err
 }
 
 func (f *dlFuncs) getTimeScaleToNanoSeconds() float64 {
 	var timeBaseInfo common.MachTimeBaseInfo
 
-	f.machTimeBaseInfo(uintptr(unsafe.Pointer(&timeBaseInfo)))
+	f.lib.MachTimeBaseInfo(uintptr(unsafe.Pointer(&timeBaseInfo)))
 
 	return float64(timeBaseInfo.Numer) / float64(timeBaseInfo.Denom)
 }
@@ -321,7 +311,7 @@ func (p *Process) ExeWithContext(_ context.Context) (string, error) {
 	defer funcs.Close()
 
 	buf := common.NewCStr(common.PROC_PIDPATHINFO_MAXSIZE)
-	ret := funcs.procPidPath(p.Pid, buf.Addr(), common.PROC_PIDPATHINFO_MAXSIZE)
+	ret := funcs.lib.ProcPidPath(p.Pid, buf.Addr(), common.PROC_PIDPATHINFO_MAXSIZE)
 
 	if ret <= 0 {
 		return "", fmt.Errorf("unknown error: proc_pidpath returned %d", ret)
@@ -348,7 +338,7 @@ func (p *Process) CwdWithContext(_ context.Context) (string, error) {
 
 	var vpi vnodePathInfo
 	const vpiSize = int32(unsafe.Sizeof(vpi))
-	ret := funcs.procPidInfo(p.Pid, common.PROC_PIDVNODEPATHINFO, 0, uintptr(unsafe.Pointer(&vpi)), vpiSize)
+	ret := funcs.lib.ProcPidInfo(p.Pid, common.PROC_PIDVNODEPATHINFO, 0, uintptr(unsafe.Pointer(&vpi)), vpiSize)
 	errno, _ := funcs.lib.Dlsym("errno")
 	err = *(**unix.Errno)(unsafe.Pointer(&errno))
 	if errors.Is(err, unix.EPERM) {
@@ -440,7 +430,7 @@ func (p *Process) NumThreadsWithContext(_ context.Context) (int32, error) {
 	defer funcs.Close()
 
 	var ti ProcTaskInfo
-	funcs.procPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
+	funcs.lib.ProcPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
 
 	return int32(ti.Threadnum), nil
 }
@@ -453,7 +443,7 @@ func (p *Process) TimesWithContext(_ context.Context) (*cpu.TimesStat, error) {
 	defer funcs.Close()
 
 	var ti ProcTaskInfo
-	funcs.procPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
+	funcs.lib.ProcPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
 
 	timescaleToNanoSeconds := funcs.getTimeScaleToNanoSeconds()
 	ret := &cpu.TimesStat{
@@ -472,7 +462,7 @@ func (p *Process) MemoryInfoWithContext(_ context.Context) (*MemoryInfoStat, err
 	defer funcs.Close()
 
 	var ti ProcTaskInfo
-	funcs.procPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
+	funcs.lib.ProcPidInfo(p.Pid, common.PROC_PIDTASKINFO, 0, uintptr(unsafe.Pointer(&ti)), int32(unsafe.Sizeof(ti)))
 
 	ret := &MemoryInfoStat{
 		RSS:  uint64(ti.Resident_size),
@@ -500,7 +490,7 @@ func (p *Process) NumFDsWithContext(_ context.Context) (int32, error) {
 	defer funcs.Close()
 
 	// First call: get required buffer size
-	bufferSize := funcs.procPidInfo(
+	bufferSize := funcs.lib.ProcPidInfo(
 		p.Pid,
 		common.PROC_PIDLISTFDS,
 		0,
@@ -517,7 +507,7 @@ func (p *Process) NumFDsWithContext(_ context.Context) (int32, error) {
 	buf := make([]procFDInfo, numEntries)
 
 	// Second call: get actual data
-	ret := funcs.procPidInfo(
+	ret := funcs.lib.ProcPidInfo(
 		p.Pid,
 		common.PROC_PIDLISTFDS,
 		0,

--- a/sensors/sensors_darwin.go
+++ b/sensors/sensors_darwin.go
@@ -12,13 +12,7 @@ import (
 )
 
 func TemperaturesWithContext(_ context.Context) ([]TemperatureStat, error) {
-	ioKit, err := common.NewLibrary(common.IOKit)
-	if err != nil {
-		return nil, err
-	}
-	defer ioKit.Close()
-
-	smc, err := common.NewSMC(ioKit)
+	smc, err := common.NewSMC()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`Library` is now a private struct, used to compose new structs representing different system libraries/frameworks: `CoreFoundationLib`, `IOKitLib`, and `SystemLib`. Each of them provides public methods that directly register and call the underlying library functions, improving readability by eliminating the need to use `GetFunc` in other packages.

A temporary cache `fnMap` is added to the `Library` struct to ensure the same lazy loading behavior as before.

~~Note: This PR contains changes from https://github.com/shirou/gopsutil/pull/1971 and https://github.com/shirou/gopsutil/pull/1973, so it has lower review priority than those. These changes are included here to make upcoming conflict fixing easier.~~