### PR TITLE
feat(mem): add KernelStack field for ExVirtualMemory on linux

### DIFF
--- a/mem/ex_linux.go
+++ b/mem/ex_linux.go
@@ -15,6 +15,7 @@ type ExVirtualMemory struct {
 	InactiveAnon uint64 `json:"inactiveanon"`
 	Unevictable  uint64 `json:"unevictable"`
 	Percpu       uint64 `json:"percpu"`
+	KernelStack  uint64 `json:"kernelstack"`
 }
 
 func (v ExVirtualMemory) String() string {

--- a/mem/mem.go
+++ b/mem/mem.go
@@ -62,7 +62,6 @@ type VirtualMemoryStat struct {
 	Slab           uint64 `json:"slab"`
 	Sreclaimable   uint64 `json:"sreclaimable"`
 	Sunreclaim     uint64 `json:"sunreclaim"`
-	KernelStack    uint64 `json:"kernelStack"`
 	PageTables     uint64 `json:"pageTables"`
 	SwapCached     uint64 `json:"swapCached"`
 	CommitLimit    uint64 `json:"commitLimit"`

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -192,7 +192,7 @@ func fillFromMeminfoWithContext(ctx context.Context) (*VirtualMemoryStat, *ExVir
 			if err != nil {
 				return ret, retEx, err
 			}
-			ret.KernelStack = t * 1024
+			retEx.KernelStack = t * 1024
 		case "PageTables":
 			t, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -51,7 +51,6 @@ var virtualMemoryTests = []struct {
 			Slab:           253771776,
 			Sreclaimable:   186470400,
 			Sunreclaim:     67301376,
-			KernelStack:    14224,
 			PageTables:     65241088,
 			SwapCached:     0,
 			CommitLimit:    16509730816,
@@ -79,6 +78,7 @@ var virtualMemoryTests = []struct {
 			InactiveAnon: 1186612 * 1024,
 			Unevictable:  32 * 1024,
 			Percpu:       19136 * 1024,
+			KernelStack:  14224 * 1024,
 		},
 	},
 	{
@@ -101,7 +101,6 @@ var virtualMemoryTests = []struct {
 			Slab:           9293824,
 			Sreclaimable:   2764800,
 			Sunreclaim:     6529024,
-			KernelStack:    624,
 			PageTables:     405504,
 			SwapCached:     0,
 			CommitLimit:    130289664,
@@ -129,6 +128,7 @@ var virtualMemoryTests = []struct {
 			InactiveAnon: 0,
 			Unevictable:  0,
 			Percpu:       0,
+			KernelStack:  624 * 1024,
 		},
 	},
 	{


### PR DESCRIPTION
This is a PR under #1884. But this PR moves KernelStack field to ExVirtualMemory because that is Linux only .