### PR TITLE
[host][darwin]: fix utmpx database parsing

### DIFF
--- a/host/host_darwin_amd64.go
+++ b/host/host_darwin_amd64.go
@@ -4,18 +4,18 @@
 
 package host
 
-type Utmpx struct {
-	User      [256]int8
-	ID        [4]int8
-	Line      [32]int8
-	Pid       int32
-	Type      int16
-	Pad_cgo_0 [6]byte
-	Tv        Timeval
-	Host      [256]int8
-	Pad       [16]uint32
+type utmpx32 struct {
+	User [256]int8
+	Id   [4]int8
+	Line [32]int8
+	Pid  int32
+	Type int16
+	Tv   timeval32
+	Host [256]int8
+	Pad  [16]uint32
 }
 
-type Timeval struct {
-	Sec int32
+type timeval32 struct {
+	Sec  int32
+	Usec int32
 }

--- a/host/host_darwin_arm64.go
+++ b/host/host_darwin_arm64.go
@@ -6,18 +6,18 @@
 
 package host
 
-type Utmpx struct {
+type utmpx32 struct {
 	User [256]int8
 	Id   [4]int8
 	Line [32]int8
 	Pid  int32
 	Type int16
-	Tv   Timeval
+	Tv   timeval32
 	Host [256]int8
 	Pad  [16]uint32
 }
-type Timeval struct {
-	Sec       int64
-	Usec      int32
-	Pad_cgo_0 [4]byte
+
+type timeval32 struct {
+	Sec  int32
+	Usec int32
 }

--- a/host/types_darwin.go
+++ b/host/types_darwin.go
@@ -10,12 +10,24 @@ Input to cgo -godefs.
 package host
 
 /*
-#include <sys/time.h>
 #include <utmpx.h>
+#include <sys/_types/_timeval32.h>
+
+// https://github.com/apple-oss-distributions/Libc/blob/55b54c0a0c37b3b24393b42b90a4c561d6c606b1/gen/utmpx-darwin.h#L86
+struct utmpx32 {
+  char ut_user[_UTX_USERSIZE];
+  char ut_id[_UTX_IDSIZE];
+  char ut_line[_UTX_LINESIZE];
+  pid_t ut_pid;
+  short ut_type;
+  struct timeval32 ut_tv;
+  char ut_host[_UTX_HOSTSIZE];
+  __uint32_t ut_pad[16];
+};
 */
 import "C"
 
 type (
-	Utmpx   C.struct_utmpx
-	Timeval C.struct_timeval
+	utmpx32   C.struct_utmpx32
+	timeval32 C.struct_timeval32
 )


### PR DESCRIPTION
Close https://github.com/shirou/gopsutil/issues/1989

Fixed the parsing logic in `UsersWithContext()` to align with the [current implementation of `getutxent()`](https://github.com/apple-oss-distributions/Libc/blob/main/gen/NetBSD/utmpx.c#L149-L150), which uses the compatibility struct `utmpx32` to read the utmpx database file `/var/run/utmpx`.

Since `utmpx32` is not available in the system headers, the struct definition must be manually copied from the Darwin Libc source.