### PR TITLE
Fix windows open files with context

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -751,6 +751,7 @@ func (p *Process) OpenFilesWithContext(ctx context.Context) ([]OpenFilesStat, er
 		ch := make(chan struct{}, 1)
 
 		go func() {
+			defer close(ch)
 			var buf [syscall.MAX_LONG_PATH]uint16
 			n, err := windows.GetFinalPathNameByHandle(windows.Handle(file), &buf[0], syscall.MAX_LONG_PATH, 0)
 			if err != nil {


### PR DESCRIPTION
This PR fixes a bug where a goroutine is stuck when context is done in Windows `OpenFilesWithContext(ctx context.Context)` implementation.

Current `TestOpenFiles` unit test is covering the new lines with success.
