### PR TITLE
[process][posix]: fix getTerminalMap path construction bug

### DIFF
--- a/process/process_posix_test.go
+++ b/process/process_posix_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func Test_SendSignal(t *testing.T) {
@@ -16,4 +18,17 @@ func Test_SendSignal(t *testing.T) {
 
 	p, _ := NewProcess(int32(checkPid))
 	assert.NoErrorf(t, p.SendSignal(unix.SIGCONT), "send signal")
+}
+
+func TestGetTerminalMapPathsExist(t *testing.T) {
+	termmap, err := getTerminalMap()
+	if err != nil {
+		t.Skipf("getTerminalMap not available: %v", err)
+	}
+
+	for _, name := range termmap {
+		fullPath := common.HostDev(name)
+		_, err := os.Stat(fullPath)
+		assert.NoErrorf(t, err, "terminal device should exist: %s", fullPath)
+	}
 }


### PR DESCRIPTION
fix #1869

This PR fixes incorrect path construction in `getTerminalMap()` that caused terminal device lookup to fail.

The `getTerminalMap()` function had two bugs in path handling:

1. `strings.HasPrefix(devname, "/dev/tty")` checked for `/dev/tty` but `Readdirnames()` returns just the
 filename (e.g., `tty1`), not the full path
2. `"/dev/tty/" + devname` created invalid paths like `/dev/tty/tty1` instead of `/dev/tty1`
3. `defer ptsd.Close()` was called twice - once outside the if block (potentially on a nil/error file descriptor) and again inside a nested block

These bugs caused `Process.Terminal()` to return empty strings even when the process had an associated terminal.

