### PR TITLE
Return an error on reading empty proc pid stat file

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -346,7 +346,7 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	ret := make([]*Process, 0, len(statFiles))
 	for _, statFile := range statFiles {
 		statContents, err := os.ReadFile(statFile)
-		if err != nil {
+		if err != nil || len(statContents) == 0 {
 			continue
 		}
 		fields := splitProcStat(statContents)
@@ -1038,6 +1038,9 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 	}
 
 	contents, err := os.ReadFile(statPath)
+	if err == nil && len(contents) == 0 {
+		err = fmt.Errorf("process %d: stat file is empty, process may have terminated", pid)
+	}
 	if err != nil {
 		return 0, 0, nil, 0, 0, 0, nil, err
 	}


### PR DESCRIPTION
There is a race when reading `/proc/<pid>/stat` where the file can be opened while the process still exists but then it's gone when reading the content.
Depending on the underlying procfs, the file can just appear as empty in this case (ie. read just returns EOF directly), and the code happily tries to parse the file with the expected format, eventually resulting in a panic.

Testing whether the content is empty before calling `splitProcStat` should prevent most similar occurrences.

Note that more subtle cases can still happen, eg. if the file is long enough we might only read some of it, but Go's `os.ReadFile` uses a big enough buffer by default that it should be very rare.
Ideally the code should still check that the content has the expected format and not blindly access it.

### Example

Below is a stack trace from an occurence:

```
panic: runtime error: slice bounds out of range [1:0]
goroutine 23291 [running]:
github.com/shirou/gopsutil/v4/process.splitProcStat({0xc0030e8a00, 0x0, 0x200})
	/pkg/mod/github.com/shirou/gopsutil/v4@v4.24.12/process/process_linux.go:1198 +0x29e
github.com/shirou/gopsutil/v4/process.(*Process).fillFromTIDStatWithContext(0x777657949328?, {0x5b72770, 0x9557240}, 0x30e4640?)
	/pkg/mod/github.com/shirou/gopsutil/v4@v4.24.12/process/process_linux.go:1053 +0x1de
```

`splitProcStat` is given an empty bytes slice, so `LastIndexByte` returns -1, and we index the empty slice starting at index 1 (`-1 + 2`), resulting in a panic.

```go
	nameEnd := bytes.LastIndexByte(content, ')')
	restFields := strings.Fields(string(content[nameEnd+2:])) // +2 skip ') '
```
