### PR TITLE
refactor: move timeSince and timeSinceMillis to common package

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
@@ -145,12 +144,4 @@ func Virtualization() (string, string, error) {
 
 func KernelVersion() (string, error) {
 	return KernelVersionWithContext(context.Background())
-}
-
-func timeSince(ts uint64) uint64 {
-	return uint64(time.Now().Unix()) - ts
-}
-
-func timeSinceMillis(ts uint64) uint64 {
-	return uint64(time.Now().UnixMilli()) - ts
 }

--- a/host/host_bsd.go
+++ b/host/host_bsd.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 // cachedBootTime must be accessed via atomic.Load/StoreUint64
@@ -37,5 +39,5 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return timeSince(boot), nil
+	return common.TimeSince(boot), nil
 }

--- a/host/host_solaris.go
+++ b/host/host_solaris.go
@@ -88,7 +88,7 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return timeSince(bootTime), nil
+	return common.TimeSince(bootTime), nil
 }
 
 func UsersWithContext(_ context.Context) ([]UserStat, error) {

--- a/host/host_windows.go
+++ b/host/host_windows.go
@@ -129,7 +129,7 @@ func BootTimeWithContext(_ context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	t := uint64((time.Duration(timeSinceMillis(up)) * time.Millisecond).Seconds())
+	t := uint64((time.Duration(common.TimeSinceMillis(up)) * time.Millisecond).Seconds())
 	if enableBootTimeCache {
 		atomic.StoreUint64(&cachedBootTime, t)
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -466,6 +466,10 @@ func Round(val float64, n int) float64 {
 	return math.Round(val*pow10) / pow10
 }
 
-func timeSince(ts uint64) uint64 {
+func TimeSince(ts uint64) uint64 {
 	return uint64(time.Now().Unix()) - ts
+}
+
+func TimeSinceMillis(ts uint64) uint64 {
+	return uint64(time.Now().UnixMilli()) - ts
 }

--- a/internal/common/common_aix.go
+++ b/internal/common/common_aix.go
@@ -20,7 +20,7 @@ func BootTimeWithContext(ctx context.Context, invoke Invoker) (btime uint64, err
 		return 0, errors.New("uptime was not set, so cannot calculate boot time from it")
 	}
 
-	return timeSince(ut), nil
+	return TimeSince(ut), nil
 }
 
 // Uses ps to get the elapsed time for PID 1 in DAYS-HOURS:MINUTES:SECONDS format.


### PR DESCRIPTION
This addresses the issue raised when #1979 was merged. It refactors both timeSince functions into the common package and makes all of the existing calls use those new functions.