### PR TITLE
disk: fix UsageWithContext unit conversions on AIX nocgo

### DIFF
--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -5,6 +5,7 @@ package disk
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -94,85 +95,117 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 		return nil, err
 	}
 
-	ret := &UsageStat{}
-
 	blocksize := uint64(512)
 	lines := strings.Split(string(out), "\n")
 	if len(lines) < 2 {
-		return &UsageStat{}, common.ErrNotImplementedError
+		return nil, common.ErrNotImplementedError
 	}
 
 	hf := strings.Fields(strings.ReplaceAll(lines[0], "Mounted on", "Path")) // headers
+
+	// Find the Path column index once before the loop.
+	pathIdx := -1
+	for i, header := range hf {
+		if header == "Path" {
+			pathIdx = i
+			break
+		}
+	}
+
 	for line := 1; line < len(lines); line++ {
 		fs := strings.Fields(lines[line]) // values
+		if len(fs) < len(hf) {
+			continue
+		}
+
+		if pathIdx < 0 || fs[pathIdx] != path {
+			continue
+		}
+
+		ret := &UsageStat{}
 		for i, header := range hf {
-			// We're done in any of these use cases
 			if i >= len(fs) {
 				break
 			}
 
 			switch header {
-			case `Filesystem`:
-				// This is not a valid fs for us to parse
-				if fs[i] == "/proc" || fs[i] == "/ahafs" || fs[i] != path {
-					break
-				}
-
-				ret.Fstype, err = GetMountFSTypeWithContext(ctx, fs[i])
-				if err != nil {
-					return nil, err
-				}
 			case `Path`:
 				ret.Path = fs[i]
 			case `512-blocks`:
+				if fs[i] == "-" {
+					continue
+				}
 				total, err := strconv.ParseUint(fs[i], 10, 64)
+				if err != nil {
+					return nil, err
+				}
 				ret.Total = total * blocksize
-				if err != nil {
-					return nil, err
-				}
 			case `Used`:
-				ret.Used, err = strconv.ParseUint(fs[i], 10, 64)
+				if fs[i] == "-" {
+					continue
+				}
+				used, err := strconv.ParseUint(fs[i], 10, 64)
 				if err != nil {
 					return nil, err
 				}
+				ret.Used = used * blocksize
 			case `Free`:
-				ret.Free, err = strconv.ParseUint(fs[i], 10, 64)
+				if fs[i] == "-" {
+					continue
+				}
+				free, err := strconv.ParseUint(fs[i], 10, 64)
 				if err != nil {
 					return nil, err
 				}
+				ret.Free = free * blocksize
 			case `%Used`:
+				if fs[i] == "-" {
+					continue
+				}
 				val, err := strconv.ParseInt(strings.ReplaceAll(fs[i], "%", ""), 10, 32)
 				if err != nil {
 					return nil, err
 				}
-				ret.UsedPercent = float64(val) / float64(100)
+				ret.UsedPercent = float64(val)
 			case `Ifree`:
+				if fs[i] == "-" {
+					continue
+				}
 				ret.InodesFree, err = strconv.ParseUint(fs[i], 10, 64)
 				if err != nil {
 					return nil, err
 				}
 			case `Iused`:
+				if fs[i] == "-" {
+					continue
+				}
 				ret.InodesUsed, err = strconv.ParseUint(fs[i], 10, 64)
 				if err != nil {
 					return nil, err
 				}
 			case `%Iused`:
+				if fs[i] == "-" {
+					continue
+				}
 				val, err := strconv.ParseInt(strings.ReplaceAll(fs[i], "%", ""), 10, 32)
 				if err != nil {
 					return nil, err
 				}
-				ret.InodesUsedPercent = float64(val) / float64(100)
+				ret.InodesUsedPercent = float64(val)
 			}
 		}
 
-		// Calculated value, since it isn't returned by the command
 		ret.InodesTotal = ret.InodesUsed + ret.InodesFree
 
-		// Valid Usage data, so append it
+		var statfs unix.Statfs_t
+		if err := unix.Statfs(path, &statfs); err == nil {
+			ret.Fstype = getFsType(statfs)
+		}
+
 		return ret, nil
 	}
 
-	return ret, nil
+	return nil, fmt.Errorf("mountpoint %s not found", path)
 }
 
 func GetMountFSTypeWithContext(ctx context.Context, mp string) (string, error) {


### PR DESCRIPTION
## Summary

Fixes several bugs in the AIX nocgo `UsageWithContext` implementation:

- **Used/Free not converted to bytes**: The `df -v` output reports values in 512-byte blocks, but they were stored directly without multiplying by the blocksize. Now correctly converts to bytes.
- **UsedPercent/InodesUsedPercent incorrect scale**: The `%Used` and `%Iused` columns from `df` are already whole percentages (e.g., `42` means 42%), but the code was dividing by 100, producing values like `0.42`. Removed the incorrect division.
- **Path matching broken**: The code compared the `Filesystem` column (device name like `/dev/hd4`) against the requested path (mount point like `/var`), which never matched. Now correctly matches against the `Mounted on` column and iterates all lines instead of returning the first filesystem.
- **Dash values cause parse errors**: AIX virtual filesystems (`/proc`, `/ahafs`) report `-` for numeric fields. `strconv.ParseUint` fails on `-`. Now treats `-` as zero for all numeric fields.
- **Total assigned before error check**: `ret.Total = total * blocksize` was executed before checking the `strconv.ParseUint` error. Reordered to check error first.
- **No error on missing path**: Previously returned an empty struct if no filesystem matched. Now returns `fmt.Errorf("mountpoint %s not found", path)`, consistent with the CGO variant.

Only affects AIX nocgo path — no cross-platform changes.