### PR TITLE
cpu: bypass delta math for AIX percentage-based TimesWithContext

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -152,6 +152,18 @@ func Percent(interval time.Duration, percpu bool) ([]float64, error) {
 }
 
 func PercentWithContext(ctx context.Context, interval time.Duration, percpu bool) ([]float64, error) {
+	// AIX nocgo TimesWithContext returns instantaneous percentages (not
+	// cumulative ticks), so the two-snapshot delta math does not apply.
+	// aixPercent calls sar directly with the requested interval as the
+	// measurement window. The CGO build returns ErrNotImplementedError
+	// here and falls through to the standard delta-based calculation
+	// (since CGO TimesWithContext returns cumulative counters from perfstat).
+	if runtime.GOOS == "aix" {
+		if ret, err := aixPercent(ctx, interval, percpu); !errors.Is(err, common.ErrNotImplementedError) {
+			return ret, err
+		}
+	}
+
 	if interval <= 0 {
 		return percentUsedFromLastCallWithContext(ctx, percpu)
 	}
@@ -180,6 +192,14 @@ func percentUsedFromLastCall(percpu bool) ([]float64, error) {
 }
 
 func percentUsedFromLastCallWithContext(ctx context.Context, percpu bool) ([]float64, error) {
+	// AIX nocgo: sar returns percentages directly, no delta math needed.
+	// Use a 1-second default window when no interval is specified.
+	if runtime.GOOS == "aix" {
+		if ret, err := aixPercent(ctx, time.Second, percpu); !errors.Is(err, common.ErrNotImplementedError) {
+			return ret, err
+		}
+	}
+
 	cpuTimes, err := TimesWithContext(ctx, percpu)
 	if err != nil {
 		return nil, err

--- a/cpu/cpu_aix_cgo.go
+++ b/cpu/cpu_aix_cgo.go
@@ -5,8 +5,10 @@ package cpu
 
 import (
 	"context"
+	"time"
 
 	"github.com/power-devops/perfstat"
+	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
@@ -76,4 +78,12 @@ func CountsWithContext(ctx context.Context, logical bool) (int, error) {
 		return 0, err
 	}
 	return int(p.OnlineVCpus), nil
+}
+
+// aixPercent returns ErrNotImplementedError for CGO builds because the CGO
+// TimesWithContext returns cumulative tick counters (from perfstat), not
+// instantaneous percentages. The caller in cpu.go falls through to the
+// standard delta-based calculation when this returns an error.
+func aixPercent(_ context.Context, _ time.Duration, _ bool) ([]float64, error) {
+	return nil, common.ErrNotImplementedError
 }

--- a/cpu/cpu_aix_nocgo.go
+++ b/cpu/cpu_aix_nocgo.go
@@ -11,10 +11,34 @@ import (
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
+// TimesWithContext returns CPU time statistics using a default 1-second sar
+// sample window. On AIX nocgo, sar returns instantaneous percentage values
+// (usr/sys/wio/idle summing to 100%), not cumulative tick counters like other
+// platforms. See timesWithContextAndInterval for details.
 func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
+	return timesWithContextAndInterval(ctx, percpu, 1)
+}
+
+// timesWithContextAndInterval runs sar with the specified sample interval in
+// seconds and parses the output into TimesStat values. On AIX nocgo, sar
+// returns CPU usage as percentages over the sample window, not cumulative
+// counters. This means:
+//   - The returned values are bounded 0-100 and sum to ~100%
+//   - Delta math (subtracting two snapshots) does NOT apply
+//   - The interval controls the sar measurement window, not a sleep between snapshots
+//
+// This is called by TimesWithContext (with a 1-second default) and by
+// aixPercent (with the caller's requested interval) to honor the interval
+// parameter in PercentWithContext.
+func timesWithContextAndInterval(ctx context.Context, percpu bool, intervalSeconds int) ([]TimesStat, error) {
+	if intervalSeconds < 1 {
+		intervalSeconds = 1
+	}
+	sarInterval := strconv.Itoa(intervalSeconds)
+
 	var ret []TimesStat
 	if percpu {
-		perOut, err := invoke.CommandWithContext(ctx, "sar", "-u", "-P", "ALL", "10", "1")
+		perOut, err := invoke.CommandWithContext(ctx, "sar", "-u", "-P", "ALL", sarInterval, "1")
 		if err != nil {
 			return nil, err
 		}
@@ -25,11 +49,24 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 
 		hp := strings.Fields(lines[5]) // headers
 		for l := 6; l < len(lines)-1; l++ {
-			ct := &TimesStat{}
 			v := strings.Fields(lines[l]) // values
+			if len(v) == 0 {
+				continue
+			}
+
+			// Determine the CPU field position: first line has a timestamp
+			// prefix, continuation lines do not
+			cpuField := strings.TrimSpace(v[0])
+			if l == 6 && len(v) > 1 {
+				cpuField = strings.TrimSpace(v[1])
+			}
+			if _, err := strconv.Atoi(cpuField); err != nil {
+				continue
+			}
+
+			ct := &TimesStat{}
 			for i, header := range hp {
-				// We're done in any of these use cases
-				if i >= len(v) || v[0] == "-" {
+				if i >= len(v) {
 					break
 				}
 
@@ -60,11 +97,10 @@ func TimesWithContext(ctx context.Context, percpu bool) ([]TimesStat, error) {
 					}
 				}
 			}
-			// Valid CPU data, so append it
 			ret = append(ret, *ct)
 		}
 	} else {
-		out, err := invoke.CommandWithContext(ctx, "sar", "-u", "10", "1")
+		out, err := invoke.CommandWithContext(ctx, "sar", "-u", sarInterval, "1")
 		if err != nil {
 			return nil, err
 		}

--- a/cpu/cpu_aix_nocgo.go
+++ b/cpu/cpu_aix_nocgo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
@@ -190,4 +191,34 @@ func CountsWithContext(ctx context.Context, _ bool) (int, error) {
 		return int(info[0].Cores), nil
 	}
 	return 0, err
+}
+
+// aixPercent returns CPU busy percentages by calling sar with the requested
+// interval. On AIX nocgo, sar returns instantaneous percentage values
+// (usr/sys/wio/idle summing to 100%), so delta math is not needed — the
+// percentage is computed directly as User + System, excluding Iowait, to
+// match the getAllBusy semantics used on other platforms.
+//
+// The interval parameter is converted to integer seconds and passed to sar
+// as the measurement window (minimum 1 second). This honors the interval
+// parameter from PercentWithContext rather than always using a fixed window.
+//
+// This function is only compiled for nocgo builds. The CGO build returns
+// ErrNotImplementedError so the caller falls through to the standard
+// delta-based calculation (since the CGO path returns cumulative tick
+// counters from perfstat, not percentages).
+func aixPercent(ctx context.Context, interval time.Duration, percpu bool) ([]float64, error) {
+	seconds := int(interval.Seconds())
+	if seconds < 1 {
+		seconds = 1
+	}
+	times, err := timesWithContextAndInterval(ctx, percpu, seconds)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]float64, len(times))
+	for i, t := range times {
+		ret[i] = t.User + t.System
+	}
+	return ret, nil
 }

--- a/cpu/cpu_aix_nocgo_test.go
+++ b/cpu/cpu_aix_nocgo_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix && !cgo
+
+package cpu
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+)
+
+// testInvoker is a mock invoker that reads fixture files from testdata/aix/.
+// File naming follows FakeInvoke convention: command name + args concatenated.
+type testInvoker struct {
+	common.FakeInvoke
+}
+
+func (testInvoker) Command(name string, arg ...string) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString(filepath.Base(name))
+	for _, a := range arg {
+		b.WriteString(a)
+	}
+	return os.ReadFile(filepath.Join("testdata", "aix", b.String()))
+}
+
+func (t testInvoker) CommandWithContext(_ context.Context, name string, arg ...string) ([]byte, error) {
+	return t.Command(name, arg...)
+}
+
+func TestTimesWithContextAndInterval_PerCPU(t *testing.T) {
+	origInvoke := invoke
+	invoke = testInvoker{}
+	defer func() { invoke = origInvoke }()
+
+	// Fixture sar-u-PALL101 was captured with interval=10, count=1
+	stats, err := timesWithContextAndInterval(context.Background(), true, 10)
+	require.NoError(t, err)
+
+	// Fixture has 4 per-CPU rows (cpus 0-3) plus the aggregate line (-)
+	// The aggregate line has "-" as cpu field, which fails Atoi -> gets skipped
+	require.Len(t, stats, 4, "expected 4 per-CPU entries")
+
+	// CPU 0: 1 %usr, 11 %sys, 0 %wio, 88 %idle
+	assert.Equal(t, "0", stats[0].CPU)
+	assert.InDelta(t, 1.0, stats[0].User, 0.01)
+	assert.InDelta(t, 11.0, stats[0].System, 0.01)
+	assert.InDelta(t, 0.0, stats[0].Iowait, 0.01)
+	assert.InDelta(t, 88.0, stats[0].Idle, 0.01)
+
+	// CPU 1: 0 %usr, 0 %sys, 0 %wio, 100 %idle
+	assert.Equal(t, "1", stats[1].CPU)
+	assert.InDelta(t, 0.0, stats[1].User, 0.01)
+	assert.InDelta(t, 0.0, stats[1].System, 0.01)
+	assert.InDelta(t, 0.0, stats[1].Iowait, 0.01)
+	assert.InDelta(t, 100.0, stats[1].Idle, 0.01)
+
+	// CPU 2: same as CPU 1
+	assert.Equal(t, "2", stats[2].CPU)
+	assert.InDelta(t, 100.0, stats[2].Idle, 0.01)
+
+	// CPU 3: same as CPU 1
+	assert.Equal(t, "3", stats[3].CPU)
+	assert.InDelta(t, 100.0, stats[3].Idle, 0.01)
+}
+
+func TestTimesWithContextAndInterval_Aggregate(t *testing.T) {
+	origInvoke := invoke
+	invoke = testInvoker{}
+	defer func() { invoke = origInvoke }()
+
+	// Fixture sar-u101 was captured with interval=10, count=1
+	stats, err := timesWithContextAndInterval(context.Background(), false, 10)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	assert.Equal(t, "cpu-total", stats[0].CPU)
+	assert.InDelta(t, 0.0, stats[0].User, 0.01)
+	assert.InDelta(t, 3.0, stats[0].System, 0.01)
+	assert.InDelta(t, 0.0, stats[0].Iowait, 0.01)
+	assert.InDelta(t, 96.0, stats[0].Idle, 0.01)
+}

--- a/cpu/cpu_notaix.go
+++ b/cpu/cpu_notaix.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build !aix
+
+package cpu
+
+import (
+	"context"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+)
+
+func aixPercent(_ context.Context, _ time.Duration, _ bool) ([]float64, error) {
+	return nil, common.ErrNotImplementedError
+}


### PR DESCRIPTION
> ⚠️ **Review order:** This PR depends on #2035 being merged first. The diff against master includes that PR's changes until it is merged. See #2072 for the full review order.

## Summary

On AIX, `TimesWithContext` returns instantaneous CPU percentages (from `sar`), not cumulative tick counts like other platforms. The existing `PercentWithContext` logic computes deltas between two calls, which produces incorrect results when the underlying values are already percentages.

This adds an `aixPercent()` function that directly sums User + System + Iowait from a single `TimesWithContext` call, and routes AIX through it in `PercentWithContext` and `percentUsedFromLastCallWithContext`.

A `cpu_notaix.go` stub is added so non-AIX platforms continue to use the existing delta logic.