### PR TITLE
load: add testInvoker dependency injection for AIX nocgo tests

### DIFF
--- a/load/load_aix_nocgo.go
+++ b/load/load_aix_nocgo.go
@@ -15,8 +15,19 @@ import (
 
 var separator = regexp.MustCompile(`,?\s+`)
 
+// testInvoker is used for dependency injection in tests
+var testInvoker common.Invoker
+
+// getInvoker returns the test invoker if set, otherwise returns the default
+func getInvoker() common.Invoker {
+	if testInvoker != nil {
+		return testInvoker
+	}
+	return common.Invoke{}
+}
+
 func AvgWithContext(ctx context.Context) (*AvgStat, error) {
-	line, err := invoke.CommandWithContext(ctx, "uptime")
+	line, err := getInvoker().CommandWithContext(ctx, "uptime")
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +56,7 @@ func AvgWithContext(ctx context.Context) (*AvgStat, error) {
 }
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
-	out, err := invoke.CommandWithContext(ctx, "ps", "-e", "-o", "state")
+	out, err := getInvoker().CommandWithContext(ctx, "ps", "-e", "-o", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/load/load_aix_nocgo_test.go
+++ b/load/load_aix_nocgo_test.go
@@ -42,13 +42,12 @@ func TestMiscWithContext_ProcessStates(t *testing.T) {
 	//   Total = 8
 	psOutput := "ST\nA\nA\nI\nW\nZ\nT\nA\nW\n"
 
-	origInvoke := invoke
-	invoke = mockInvoker{
+	testInvoker = mockInvoker{
 		output: map[string][]byte{
 			"ps -e -o state": []byte(psOutput),
 		},
 	}
-	defer func() { invoke = origInvoke }()
+	defer func() { testInvoker = nil }()
 
 	misc, err := MiscWithContext(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
> ⚠️ **Review order:** This PR depends on #2037 being merged first. The diff against master includes that PR's changes until it is merged. See #2072 for the full review order.

## Summary

Adds a `testInvoker` variable and `getInvoker()` helper to the AIX nocgo load package, following the same dependency injection pattern used in the host package. All `invoke.CommandWithContext` calls are replaced with `getInvoker().CommandWithContext`.

This is a structural refactor with no behavior change — it enables mock-based unit testing for subsequent AIX load features.

> **Note:** This PR depends on #2037 being merged first.

Only affects AIX nocgo path — no cross-platform changes.