### PR TITLE
load: implement SystemCallsWithContext and InterruptsWithContext for AIX

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -25,7 +25,17 @@ type MiscStat struct {
 	ProcsCreated int `json:"procsCreated"`
 	ProcsRunning int `json:"procsRunning"`
 	ProcsBlocked int `json:"procsBlocked"`
-	Ctxt         int `json:"ctxt"`
+	// Ctxt is the cumulative number of context switches since boot.
+	// Populated on Linux (from /proc/stat) and AIX (from vmstat -s or perfstat).
+	Ctxt int `json:"ctxt"`
+	// SysCalls is the cumulative number of system calls since boot.
+	// Not all platforms populate this field; zero means unavailable.
+	// Populated on AIX (from vmstat -s or perfstat).
+	SysCalls int `json:"sysCalls"`
+	// Interrupts is the cumulative number of device interrupts since boot.
+	// Not all platforms populate this field; zero means unavailable.
+	// Populated on AIX (from vmstat -s or perfstat).
+	Interrupts int `json:"interrupts"`
 }
 
 func (m MiscStat) String() string {

--- a/load/load_aix_cgo.go
+++ b/load/load_aix_cgo.go
@@ -79,5 +79,14 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 		ret.ProcsBlocked = int(cpuStat.iowait) + int(cpuStat.physio)
 	}
 
+	// Populate system-wide counters from perfstat.
+	// These are cumulative since-boot values matching vmstat -s output.
+	c, err := perfstat.CpuTotalStat()
+	if err == nil {
+		ret.SysCalls = int(c.Syscall)
+		ret.Interrupts = int(c.DevIntrs)
+		ret.Ctxt = int(c.Pswitch)
+	}
+
 	return &ret, nil
 }

--- a/load/load_aix_nocgo.go
+++ b/load/load_aix_nocgo.go
@@ -6,6 +6,7 @@ package load
 import (
 	"bytes"
 	"context"
+	"errors"
 	"regexp"
 	"strconv"
 	"strings"
@@ -95,5 +96,68 @@ func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 		ret.ProcsTotal++
 	}
 
+	// Get context switches, interrupts, and syscalls from vmstat.
+	// These are cumulative since-boot counters from vmstat -s.
+	ctxt, interrupts, syscalls, err := getVmstatMetrics(ctx)
+	if err == nil {
+		ret.Ctxt = ctxt
+		ret.Interrupts = interrupts
+		ret.SysCalls = syscalls
+	}
+
 	return ret, nil
+}
+
+// getVmstatMetrics runs vmstat -s and returns cumulative since-boot counters
+// for context switches, device interrupts, and syscalls.
+func getVmstatMetrics(ctx context.Context) (ctxt, interrupts, syscalls int, err error) {
+	out, err := getInvoker().CommandWithContext(ctx, "vmstat", "-s")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	// vmstat -s output format: <whitespace><number> <description>
+	// Example lines:
+	//   5842393706 cpu context switches
+	//      33412179 device interrupts
+	//  12918944607 syscalls
+	lines := strings.Split(string(out), "\n")
+	foundCtxt, foundInterrupts, foundSyscalls := false, false, false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Split into number and description at the first space after the number
+		idx := strings.IndexByte(line, ' ')
+		if idx < 0 {
+			continue
+		}
+		valStr := line[:idx]
+		desc := strings.TrimSpace(line[idx+1:])
+
+		v, parseErr := strconv.Atoi(valStr)
+		if parseErr != nil {
+			continue
+		}
+
+		switch desc {
+		case "cpu context switches":
+			ctxt = v
+			foundCtxt = true
+		case "device interrupts":
+			interrupts = v
+			foundInterrupts = true
+		case "syscalls":
+			syscalls = v
+			foundSyscalls = true
+		}
+	}
+
+	if !foundCtxt || !foundInterrupts || !foundSyscalls {
+		return ctxt, interrupts, syscalls, errors.New("incomplete vmstat output: missing expected counters")
+	}
+	return ctxt, interrupts, syscalls, nil
 }

--- a/load/load_aix_nocgo.go
+++ b/load/load_aix_nocgo.go
@@ -15,8 +15,19 @@ import (
 
 var separator = regexp.MustCompile(`,?\s+`)
 
+// testInvoker is used for dependency injection in tests
+var testInvoker common.Invoker
+
+// getInvoker returns the test invoker if set, otherwise returns the default
+func getInvoker() common.Invoker {
+	if testInvoker != nil {
+		return testInvoker
+	}
+	return common.Invoke{}
+}
+
 func AvgWithContext(ctx context.Context) (*AvgStat, error) {
-	line, err := invoke.CommandWithContext(ctx, "uptime")
+	line, err := getInvoker().CommandWithContext(ctx, "uptime")
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +56,7 @@ func AvgWithContext(ctx context.Context) (*AvgStat, error) {
 }
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
-	out, err := invoke.CommandWithContext(ctx, "ps", "-e", "-o", "state")
+	out, err := getInvoker().CommandWithContext(ctx, "ps", "-e", "-o", "state")
 	if err != nil {
 		return nil, err
 	}

--- a/load/load_aix_nocgo_test.go
+++ b/load/load_aix_nocgo_test.go
@@ -42,13 +42,12 @@ func TestMiscWithContext_ProcessStates(t *testing.T) {
 	//   Total = 8
 	psOutput := "ST\nA\nA\nI\nW\nZ\nT\nA\nW\n"
 
-	origInvoke := invoke
-	invoke = mockInvoker{
+	testInvoker = mockInvoker{
 		output: map[string][]byte{
 			"ps -e -o state": []byte(psOutput),
 		},
 	}
-	defer func() { invoke = origInvoke }()
+	defer func() { testInvoker = nil }()
 
 	misc, err := MiscWithContext(context.Background())
 	require.NoError(t, err)

--- a/load/load_aix_test.go
+++ b/load/load_aix_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix
+
+package load
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiscWithContextAIX(t *testing.T) {
+	ctx := context.Background()
+	misc, err := MiscWithContext(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, misc)
+
+	// Process counts should be non-negative
+	assert.GreaterOrEqual(t, misc.ProcsTotal, 0)
+	assert.GreaterOrEqual(t, misc.ProcsRunning, 0)
+	assert.GreaterOrEqual(t, misc.ProcsBlocked, 0)
+
+	// Total should be >= running + blocked
+	assert.GreaterOrEqual(t, misc.ProcsTotal, misc.ProcsRunning+misc.ProcsBlocked)
+
+	// Cumulative since-boot counters should be positive on a running system
+	assert.Positive(t, misc.Ctxt, "Context switches should be > 0 since system is running")
+	assert.Positive(t, misc.SysCalls, "System calls should be > 0 since system is running")
+	assert.Positive(t, misc.Interrupts, "Interrupts should be > 0 since system is running")
+}
+
+func TestMiscAIX(t *testing.T) {
+	misc, err := Misc()
+	require.NoError(t, err)
+	assert.NotNil(t, misc)
+	assert.GreaterOrEqual(t, misc.ProcsTotal, 0)
+	assert.GreaterOrEqual(t, misc.ProcsRunning, 0)
+	assert.GreaterOrEqual(t, misc.ProcsBlocked, 0)
+}

--- a/load/load_mock_invoker_test.go
+++ b/load/load_mock_invoker_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix && !cgo
+
+package load
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+)
+
+// MockInvoker allows mocking command output for testing
+type MockInvoker struct {
+	commands map[string][]byte
+}
+
+// NewMockInvoker creates a new mock invoker with predefined responses
+func NewMockInvoker() *MockInvoker {
+	return &MockInvoker{
+		commands: make(map[string][]byte),
+	}
+}
+
+// SetResponse sets the response for a command
+func (m *MockInvoker) SetResponse(name string, args []string, output string) {
+	key := name + " " + strings.Join(args, " ")
+	m.commands[key] = []byte(output)
+}
+
+// Command implements the Invoker interface
+func (m *MockInvoker) Command(name string, arg ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), common.Timeout)
+	defer cancel()
+	return m.CommandWithContext(ctx, name, arg...)
+}
+
+// CommandWithContext implements the Invoker interface
+func (m *MockInvoker) CommandWithContext(_ context.Context, name string, arg ...string) ([]byte, error) {
+	key := name + " " + strings.Join(arg, " ")
+	if output, ok := m.commands[key]; ok {
+		return output, nil
+	}
+	return nil, fmt.Errorf("command not mocked: %s", key)
+}
+
+// SetupSystemMetricsMock configures the mock for system metrics testing
+func (m *MockInvoker) SetupSystemMetricsMock() {
+	// AIX vmstat -s output (cumulative since-boot counters)
+	vmstatSOutput := `           3492560274 total address trans. faults
+               116707 page ins
+              3595620 page outs
+                    0 paging space page ins
+                    0 paging space page outs
+                    0 total reclaims
+            627328604 zero filled pages faults
+                11232 executable filled pages faults
+                    0 pages examined by clock
+                    0 revolutions of the clock hand
+                    0 pages freed by the clock
+             46730047 backtracks
+                    0 free frame waits
+                    0 extend XPT waits
+                26953 pending I/O waits
+              3712327 start I/Os
+              1823837 iodones
+           5842393706 cpu context switches
+             33412179 device interrupts
+            357175605 software interrupts
+           2684865841 decrementer interrupts
+                 1106 mpc-sent interrupts
+                 1106 mpc-receive interrupts
+                    0 phantom interrupts
+                    0 traps
+          12918944607 syscalls
+`
+	m.SetResponse("vmstat", []string{"-s"}, vmstatSOutput)
+
+	// AIX ps output for process state
+	psOutput := `STATE
+A
+A
+A
+W
+I
+A
+A
+A
+Z
+A
+`
+	m.SetResponse("ps", []string{"-e", "-o", "state"}, psOutput)
+}

--- a/load/load_mock_test.go
+++ b/load/load_mock_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix && !cgo
+
+package load
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests using mocked AIX command output to verify parsing logic.
+
+func TestMiscWithContextMock(t *testing.T) {
+	mock := NewMockInvoker()
+	mock.SetupSystemMetricsMock()
+	testInvoker = mock
+	defer func() { testInvoker = nil }()
+
+	ctx := context.Background()
+	misc, err := MiscWithContext(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, misc)
+
+	// Mock data has: 7 A, 1 W, 1 I, 1 Z = 10 total
+	// Running: 7 (A) + 1 (I) = 8
+	// Blocked: 1 (W) = 1
+	assert.Equal(t, 10, misc.ProcsTotal)
+	assert.Equal(t, 8, misc.ProcsRunning)
+	assert.Equal(t, 1, misc.ProcsBlocked)
+
+	// Cumulative since-boot counters from vmstat -s mock output
+	assert.Equal(t, 5842393706, misc.Ctxt)
+	assert.Equal(t, 12918944607, misc.SysCalls)
+	assert.Equal(t, 33412179, misc.Interrupts)
+}
+
+func TestMiscMock(t *testing.T) {
+	mock := NewMockInvoker()
+	mock.SetupSystemMetricsMock()
+	testInvoker = mock
+	defer func() { testInvoker = nil }()
+
+	misc, err := Misc()
+	require.NoError(t, err)
+	assert.NotNil(t, misc)
+	assert.Equal(t, 10, misc.ProcsTotal)
+	assert.Equal(t, 8, misc.ProcsRunning)
+	assert.Equal(t, 1, misc.ProcsBlocked)
+	assert.Equal(t, 5842393706, misc.Ctxt)
+	assert.Equal(t, 12918944607, misc.SysCalls)
+	assert.Equal(t, 33412179, misc.Interrupts)
+}

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -54,7 +54,7 @@ func TestMiscStatString(t *testing.T) {
 		ProcsBlocked: 2,
 		Ctxt:         3,
 	}
-	e := `{"procsTotal":4,"procsCreated":5,"procsRunning":1,"procsBlocked":2,"ctxt":3}`
+	e := `{"procsTotal":4,"procsCreated":5,"procsRunning":1,"procsBlocked":2,"ctxt":3,"sysCalls":0,"interrupts":0}`
 	assert.JSONEqf(t, e, v.String(), "TestMiscString string is invalid: %v", v)
 	t.Log(e)
 }


### PR DESCRIPTION
> ⚠️ **Review order:** This PR depends on #2038 and #2064 being merged first. See #2072 for the full review order.

## Summary

Populates the `MiscStat.SysCalls` and `MiscStat.Interrupts` fields (added in #2064) for AIX, with both CGO and nocgo implementations:

- **CGO**: Uses `perfstat.CpuTotalStat()` to read `Syscall`, `DevIntrs`, and `Pswitch` (context switches) counters. Also populates `MiscStat.Ctxt` from perfstat for consistency with the nocgo path.
- **nocgo**: Parses `vmstat -s` output via `getVmstatMetrics()` to extract cumulative system call, device interrupt, and context switch counts. Returns an error if expected counters are missing from vmstat output.
- **Tests**: Integration tests (`load_aix_test.go`) verify fields are positive on a running system. Mock-based unit tests (`load_mock_test.go`, `load_mock_invoker_test.go`) verify parsing with realistic AIX command fixtures.

> **Note:** This PR depends on #2064 (MiscStat struct field additions) and #2038 (testInvoker DI) being merged first.

Only affects AIX — no cross-platform changes beyond the struct fields in #2064.