### PR TITLE
host: add testInvoker dependency injection for AIX

### DIFF
--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -15,8 +15,19 @@ const (
 	user_PROCESS = 7 //nolint:revive //FIXME
 )
 
+// testInvoker is used for dependency injection in tests
+var testInvoker common.Invoker
+
+// getInvoker returns the test invoker if set, otherwise returns the default
+func getInvoker() common.Invoker {
+	if testInvoker != nil {
+		return testInvoker
+	}
+	return invoke
+}
+
 func HostIDWithContext(ctx context.Context) (string, error) {
-	out, err := invoke.CommandWithContext(ctx, "uname", "-u")
+	out, err := getInvoker().CommandWithContext(ctx, "uname", "-u")
 	if err != nil {
 		return "", err
 	}
@@ -26,18 +37,18 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 }
 
 func BootTimeWithContext(ctx context.Context) (btime uint64, err error) {
-	return common.BootTimeWithContext(ctx, invoke)
+	return common.BootTimeWithContext(ctx, getInvoker())
 }
 
 // Uses ps to get the elapsed time for PID 1 in DAYS-HOURS:MINUTES:SECONDS format.
 func UptimeWithContext(ctx context.Context) (uint64, error) {
-	return common.UptimeWithContext(ctx, invoke)
+	return common.UptimeWithContext(ctx, getInvoker())
 }
 
 // This is a weak implementation due to the limitations on retrieving this data in AIX
 func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	var ret []UserStat
-	out, err := invoke.CommandWithContext(ctx, "w")
+	out, err := getInvoker().CommandWithContext(ctx, "w")
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +86,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 // Much of this function could be static. However, to be future proofed, I've made it call the OS for the information in all instances.
 func PlatformInformationWithContext(ctx context.Context) (platform, family, version string, err error) {
 	// Set the platform (which should always, and only be, "AIX") from `uname -s`
-	out, err := invoke.CommandWithContext(ctx, "uname", "-s")
+	out, err := getInvoker().CommandWithContext(ctx, "uname", "-s")
 	if err != nil {
 		return "", "", "", err
 	}
@@ -85,7 +96,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform, family, vers
 	family = strings.TrimRight(string(out), "\n")
 
 	// Set the version
-	out, err = invoke.CommandWithContext(ctx, "oslevel")
+	out, err = getInvoker().CommandWithContext(ctx, "oslevel")
 	if err != nil {
 		return "", "", "", err
 	}
@@ -95,7 +106,7 @@ func PlatformInformationWithContext(ctx context.Context) (platform, family, vers
 }
 
 func KernelVersionWithContext(ctx context.Context) (version string, err error) {
-	out, err := invoke.CommandWithContext(ctx, "oslevel", "-s")
+	out, err := getInvoker().CommandWithContext(ctx, "oslevel", "-s")
 	if err != nil {
 		return "", err
 	}
@@ -105,7 +116,7 @@ func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 }
 
 func KernelArch() (arch string, err error) {
-	out, err := invoke.Command("bootinfo", "-y")
+	out, err := getInvoker().Command("bootinfo", "-y")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

Adds a `testInvoker` variable and `getInvoker()` helper to the AIX host package, enabling mock-based unit testing. All direct `invoke.CommandWithContext` / `invoke.Command` calls are replaced with `getInvoker().*` calls.

This is a structural refactor with no behavior change — it enables comprehensive testing for subsequent AIX host PRs without requiring a real AIX system.

Only affects AIX — no cross-platform changes.