### PR TITLE
host: implement VirtualizationWithContext for AIX (WPAR/LPAR)

### DIFF
--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -149,6 +149,26 @@ func KernelArch() (arch string, err error) {
 	return arch, nil
 }
 
-func VirtualizationWithContext(_ context.Context) (string, string, error) {
-	return "", "", common.ErrNotImplementedError
+func VirtualizationWithContext(ctx context.Context) (string, string, error) {
+	// Check for WPAR (Workload Partition) first — most specific virtualization layer.
+	// uname -W returns "0" if not in a WPAR, or the WPAR ID if inside one.
+	out, err := getInvoker().CommandWithContext(ctx, "uname", "-W")
+	if err == nil {
+		wparID := strings.TrimSpace(string(out))
+		if wparID != "" && wparID != "0" {
+			return "wpar", "guest", nil
+		}
+	}
+
+	// Check for LPAR (Logical Partition) via PowerVM.
+	// uname -L returns "<id> <name>", e.g. "25 soaix422". If name is "NULL", no LPAR.
+	out, err = getInvoker().CommandWithContext(ctx, "uname", "-L")
+	if err == nil {
+		fields := strings.Fields(strings.TrimSpace(string(out)))
+		if len(fields) >= 2 && fields[1] != "NULL" {
+			return "powervm", "guest", nil
+		}
+	}
+
+	return "", "", nil
 }

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -4,7 +4,10 @@
 package host
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
+	"os"
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/internal/common"
@@ -45,39 +48,57 @@ func UptimeWithContext(ctx context.Context) (uint64, error) {
 	return common.UptimeWithContext(ctx, getInvoker())
 }
 
-// This is a weak implementation due to the limitations on retrieving this data in AIX
-func UsersWithContext(ctx context.Context) ([]UserStat, error) {
-	var ret []UserStat
-	out, err := getInvoker().CommandWithContext(ctx, "w")
+// aixUtmp matches the AIX /etc/utmp binary record layout (see /usr/include/utmp.h).
+// Reading utmp directly is ~180x faster than spawning `who` and avoids locale
+// dependencies when parsing timestamps — ut_time is an epoch value.
+type aixUtmp struct {
+	User     [256]byte // ut_user: login name
+	ID       [14]byte  // ut_id: inittab id
+	Line     [64]byte  // ut_line: device name (pts/0, etc.)
+	Pid      int32     // ut_pid
+	Type     int16     // ut_type (7 = USER_PROCESS)
+	Time     int64     // ut_time: epoch seconds (time64_t)
+	Exit     [4]byte   // ut_exit: termination/exit status
+	Host     [256]byte // ut_host: remote host
+	Pad      [4]byte   // __dbl_word_pad
+	Reserved [32]byte  // __reservedA[2] + __reservedV[6]
+}
+
+// UsersWithContext returns currently logged-in users by reading /etc/utmp directly.
+// This avoids spawning a subprocess and eliminates locale dependencies for
+// timestamp parsing — the utmp struct contains epoch seconds in ut_time.
+func UsersWithContext(_ context.Context) ([]UserStat, error) {
+	f, err := os.Open("/etc/utmp")
 	if err != nil {
 		return nil, err
 	}
-	lines := strings.Split(string(out), "\n")
-	if len(lines) < 3 {
-		return []UserStat{}, common.ErrNotImplementedError
-	}
+	defer f.Close()
 
-	hf := strings.Fields(lines[1]) // headers
-	for l := 2; l < len(lines); l++ {
-		v := strings.Fields(lines[l]) // values
-		if len(v) == 0 || v[0] == "-" {
+	var ret []UserStat
+	for {
+		var entry aixUtmp
+		err := binary.Read(f, binary.BigEndian, &entry)
+		if err != nil {
+			break // EOF or read error
+		}
+
+		// Only include active user sessions (ut_type == USER_PROCESS)
+		if entry.Type != user_PROCESS {
 			continue
 		}
-		us := &UserStat{}
-		for i, header := range hf {
-			if i >= len(v) {
-				break
-			}
-			switch header {
-			case "User":
-				us.User = v[i]
-			case "tty":
-				us.Terminal = v[i]
-			}
+
+		user := strings.TrimRight(string(bytes.TrimRight(entry.User[:], "\x00")), " ")
+		if user == "" {
+			continue
 		}
 
-		// Valid User data, so append it
-		ret = append(ret, *us)
+		us := UserStat{
+			User:     user,
+			Terminal: string(bytes.TrimRight(entry.Line[:], "\x00")),
+			Host:     string(bytes.TrimRight(entry.Host[:], "\x00")),
+			Started:  int(entry.Time),
+		}
+		ret = append(ret, us)
 	}
 
 	return ret, nil

--- a/host/host_aix_test.go
+++ b/host/host_aix_test.go
@@ -26,3 +26,19 @@ func TestUptimeWithContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Positive(t, uptime)
 }
+
+func TestUsersWithContext(t *testing.T) {
+	// Integration test — reads /etc/utmp directly on a real AIX system.
+	// Verifies the binary utmp parsing returns valid user data.
+	users, err := UsersWithContext(context.TODO())
+	require.NoError(t, err)
+
+	// At least one user should be logged in (us, running this test)
+	require.NotEmpty(t, users, "expected at least one logged-in user")
+
+	for _, u := range users {
+		assert.NotEmpty(t, u.User, "user name should not be empty")
+		assert.NotEmpty(t, u.Terminal, "terminal should not be empty")
+		assert.Positive(t, u.Started, "started time should be a positive epoch timestamp")
+	}
+}

--- a/host/host_aix_test.go
+++ b/host/host_aix_test.go
@@ -5,11 +5,38 @@ package host
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockInvoker returns canned output for specific commands.
+type mockInvoker struct {
+	responses map[string]string
+}
+
+func (m *mockInvoker) Command(name string, arg ...string) ([]byte, error) {
+	key := name + " " + strings.Join(arg, " ")
+	key = strings.TrimSpace(key)
+	if resp, ok := m.responses[key]; ok {
+		return []byte(resp), nil
+	}
+	return nil, fmt.Errorf("unexpected command: %s", key)
+}
+
+func (m *mockInvoker) CommandWithContext(_ context.Context, name string, arg ...string) ([]byte, error) {
+	return m.Command(name, arg...)
+}
+
+func withMockInvoker(t *testing.T, responses map[string]string) {
+	t.Helper()
+	old := testInvoker
+	testInvoker = &mockInvoker{responses: responses}
+	t.Cleanup(func() { testInvoker = old })
+}
 
 func TestBootTimeWithContext(t *testing.T) {
 	// This is a wrapper function that delegates to common.BootTimeWithContext
@@ -41,4 +68,93 @@ func TestUsersWithContext(t *testing.T) {
 		assert.NotEmpty(t, u.Terminal, "terminal should not be empty")
 		assert.Positive(t, u.Started, "started time should be a positive epoch timestamp")
 	}
+}
+
+func TestHostIDWithContext(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"uname -u": "IBM,0221D80FV\n",
+	})
+
+	id, err := HostIDWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "IBM,0221D80FV", id)
+}
+
+func TestPlatformInformationWithContext(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"uname -s": "AIX\n",
+		"oslevel":  "7.3.0.0\n",
+	})
+
+	platform, family, version, err := PlatformInformationWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "AIX", platform)
+	assert.Equal(t, "AIX", family)
+	assert.Equal(t, "7.3.0.0", version)
+}
+
+func TestKernelVersionWithContext(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"oslevel -s": "7300-03-00-2446\n",
+	})
+
+	version, err := KernelVersionWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "7300-03-00-2446", version)
+}
+
+func TestKernelArch(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"bootinfo -y": "64\n",
+	})
+
+	arch, err := KernelArch()
+	require.NoError(t, err)
+	assert.Equal(t, "64", arch)
+}
+
+func TestVirtualizationWithContext(t *testing.T) {
+	system, role, err := VirtualizationWithContext(context.TODO())
+	require.NoError(t, err)
+	// On a real AIX system, we expect either powervm or wpar
+	if system != "" {
+		assert.Contains(t, []string{"powervm", "wpar"}, system)
+		assert.Equal(t, "guest", role)
+	}
+}
+
+func TestVirtualizationWithContext_LPAR(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"uname -W": "0\n",
+		"uname -L": "25 soaix422\n",
+	})
+
+	system, role, err := VirtualizationWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "powervm", system)
+	assert.Equal(t, "guest", role)
+}
+
+func TestVirtualizationWithContext_WPAR(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"uname -W": "2\n",
+		"uname -L": "25 soaix422\n",
+	})
+
+	system, role, err := VirtualizationWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "wpar", system)
+	assert.Equal(t, "guest", role)
+}
+
+func TestVirtualizationWithContext_BareMetal(t *testing.T) {
+	withMockInvoker(t, map[string]string{
+		"uname -W": "0\n",
+		"uname -L": "-1 NULL\n",
+	})
+
+	system, role, err := VirtualizationWithContext(context.TODO())
+	require.NoError(t, err)
+	assert.Empty(t, system)
+	assert.Empty(t, role)
 }


### PR DESCRIPTION
> ⚠️ **Review order:** This PR depends on #2040 being merged first. See #2072 for the full review order.

## Summary

Replaces the `ErrNotImplementedError` stub for `VirtualizationWithContext` on AIX with a real implementation that detects:

1. **WPAR (Workload Partition)**: Checks `uname -W`. Returns `("wpar", "guest")` if the WPAR ID is non-zero.
2. **LPAR (Logical Partition via PowerVM)**: Checks `uname -L`. Returns `("powervm", "guest")` if the LPAR name is not "NULL".
3. **Bare metal**: Returns `("", "")` if neither virtualization layer is detected.

Includes unit tests covering LPAR, WPAR, bare metal, and live system scenarios.

> **Note:** This PR depends on #2040 being merged first.

Only affects AIX — no cross-platform changes.