### PR TITLE
process: add SignalsPendingWithContext to Process interface

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -465,6 +465,11 @@ func (p *Process) Terminal() (string, error) {
 	return p.TerminalWithContext(context.Background())
 }
 
+// SignalsPending returns the signals pending for the process.
+func (p *Process) SignalsPending() (SignalInfoStat, error) {
+	return p.SignalsPendingWithContext(context.Background())
+}
+
 // Nice returns a nice value (priority).
 func (p *Process) Nice() (int32, error) {
 	return p.NiceWithContext(context.Background())

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -521,3 +521,7 @@ func (p *Process) NumFDsWithContext(_ context.Context) (int32, error) {
 	numFDs := ret / sizeofProcFDInfo
 	return numFDs, nil
 }
+
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -142,6 +142,10 @@ func (*Process) CPUAffinityWithContext(_ context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}
+
 func (*Process) MemoryInfoWithContext(_ context.Context) (*MemoryInfoStat, error) {
 	return nil, common.ErrNotImplementedError
 }

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -287,6 +287,10 @@ func (p *Process) MemoryInfoWithContext(_ context.Context) (*MemoryInfoStat, err
 	}, nil
 }
 
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}
+
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 	procs, err := ProcessesWithContext(ctx)
 	if err != nil {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -314,6 +314,17 @@ func (*Process) CPUAffinityWithContext(_ context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
+func (p *Process) SignalsPendingWithContext(ctx context.Context) (SignalInfoStat, error) {
+	err := p.fillFromStatusWithContext(ctx)
+	if err != nil {
+		return SignalInfoStat{}, err
+	}
+	if p.sigInfo == nil {
+		return SignalInfoStat{}, nil
+	}
+	return *p.sigInfo, nil
+}
+
 func (p *Process) MemoryInfoWithContext(ctx context.Context) (*MemoryInfoStat, error) {
 	meminfo, _, err := p.fillFromStatmWithContext(ctx)
 	if err != nil {

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -399,3 +399,7 @@ func callKernProcSyscall(op, arg int32) ([]byte, uint64, error) {
 
 	return buf, length, nil
 }
+
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}

--- a/process/process_plan9.go
+++ b/process/process_plan9.go
@@ -201,3 +201,7 @@ func (*Process) UsernameWithContext(_ context.Context) (string, error) {
 func (*Process) EnvironWithContext(_ context.Context) ([]string, error) {
 	return nil, common.ErrNotImplementedError
 }
+
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}

--- a/process/process_solaris.go
+++ b/process/process_solaris.go
@@ -165,6 +165,10 @@ func (*Process) MemoryInfoExWithContext(_ context.Context) (*MemoryInfoExStat, e
 	return nil, common.ErrNotImplementedError
 }
 
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}
+
 func (*Process) PageFaultsWithContext(_ context.Context) (*PageFaultsStat, error) {
 	return nil, common.ErrNotImplementedError
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -633,6 +633,10 @@ func (*Process) CPUAffinityWithContext(_ context.Context) ([]int32, error) {
 	return nil, common.ErrNotImplementedError
 }
 
+func (*Process) SignalsPendingWithContext(_ context.Context) (SignalInfoStat, error) {
+	return SignalInfoStat{}, common.ErrNotImplementedError
+}
+
 func (p *Process) MemoryInfoWithContext(_ context.Context) (*MemoryInfoStat, error) {
 	mem, err := getMemoryInfo(p.Pid)
 	if err != nil {


### PR DESCRIPTION
Adds a `SignalsPending()` wrapper and `SignalsPendingWithContext` method to the Process type. Linux gets a real implementation reading from /proc/<pid>/status. All other platforms return `ErrNotImplementedError`. This is a cross-platform interface addition needed for AIX process support.