### PR TITLE
Fix infinite loop when failed to find path for volume on Windows

### DIFF
--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -140,20 +140,6 @@ func processVolumesMountedAsFolders(ctx context.Context, partitionStats []Partit
 }
 
 func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []uint16, processedPaths map[string]struct{}, partitionStats []PartitionStat, warnings Warnings) []PartitionStat {
-	return processVolumeLoopWith(ctx, nextVolHandle, volNameBuf, processedPaths, partitionStats, warnings, getVolumePaths, processMountsForVolume, findNextVolume)
-}
-
-func processVolumeLoopWith(
-	ctx context.Context,
-	nextVolHandle uintptr,
-	volNameBuf []uint16,
-	processedPaths map[string]struct{},
-	partitionStats []PartitionStat,
-	warnings Warnings,
-	getVolumePathsFn func([]uint16) ([]string, error),
-	processMountsForVolumeFn func(context.Context, []string, map[string]struct{}, []PartitionStat, Warnings) []PartitionStat,
-	findNextVolumeFn func(uintptr, []uint16) (bool, error),
-) []PartitionStat {
 	for {
 		select {
 		case <-ctx.Done():
@@ -162,19 +148,22 @@ func processVolumeLoopWith(
 		default:
 		}
 
-		mounts, err := getVolumePathsFn(volNameBuf)
+		mounts, err := getVolumePaths(volNameBuf)
 		if err != nil {
 			warnings.Add(fmt.Errorf("failed to find paths for volume %s", windows.UTF16ToString(volNameBuf)))
 		} else {
-			partitionStats = processMountsForVolumeFn(ctx, mounts, processedPaths, partitionStats, warnings)
+			partitionStats = processMountsForVolume(ctx, mounts, processedPaths, partitionStats, warnings)
 		}
 
 		volNameBuf = make([]uint16, maxVolumeNameLength)
-		done, err := findNextVolumeFn(nextVolHandle, volNameBuf)
-		if done {
-			break
-		}
-		if err != nil {
+		if volRet, _, err := procFindNextVolumeW.Call(
+			nextVolHandle,
+			uintptr(unsafe.Pointer(&volNameBuf[0])),
+			uintptr(maxVolumeNameLength)); err != nil && volRet == 0 {
+			var errno syscall.Errno
+			if errors.As(err, &errno) && errno == windows.ERROR_NO_MORE_FILES {
+				break
+			}
 			warnings.Add(fmt.Errorf("failed to find next volume: %w", err))
 			if len(warnings.List) > maxWarningsInDrive {
 				break
@@ -182,22 +171,6 @@ func processVolumeLoopWith(
 		}
 	}
 	return partitionStats
-}
-
-func findNextVolume(nextVolHandle uintptr, volNameBuf []uint16) (bool, error) {
-	volRet, _, err := procFindNextVolumeW.Call(
-		nextVolHandle,
-		uintptr(unsafe.Pointer(&volNameBuf[0])),
-		uintptr(maxVolumeNameLength),
-	)
-	if err != nil && volRet == 0 {
-		var errno syscall.Errno
-		if errors.As(err, &errno) && errno == windows.ERROR_NO_MORE_FILES {
-			return true, nil
-		}
-		return false, err
-	}
-	return false, nil
 }
 
 func processMountsForVolume(ctx context.Context, mounts []string, processedPaths map[string]struct{}, partitionStats []PartitionStat, warnings Warnings) []PartitionStat {

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -151,10 +151,9 @@ func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []
 		mounts, err := getVolumePaths(volNameBuf)
 		if err != nil {
 			warnings.Add(fmt.Errorf("failed to find paths for volume %s", windows.UTF16ToString(volNameBuf)))
-			continue
+		} else {
+			partitionStats = processMountsForVolume(ctx, mounts, processedPaths, partitionStats, warnings)
 		}
-
-		partitionStats = processMountsForVolume(ctx, mounts, processedPaths, partitionStats, warnings)
 
 		volNameBuf = make([]uint16, maxVolumeNameLength)
 		if volRet, _, err := procFindNextVolumeW.Call(

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -140,6 +140,20 @@ func processVolumesMountedAsFolders(ctx context.Context, partitionStats []Partit
 }
 
 func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []uint16, processedPaths map[string]struct{}, partitionStats []PartitionStat, warnings Warnings) []PartitionStat {
+	return processVolumeLoopWith(ctx, nextVolHandle, volNameBuf, processedPaths, partitionStats, warnings, getVolumePaths, processMountsForVolume, findNextVolume)
+}
+
+func processVolumeLoopWith(
+	ctx context.Context,
+	nextVolHandle uintptr,
+	volNameBuf []uint16,
+	processedPaths map[string]struct{},
+	partitionStats []PartitionStat,
+	warnings Warnings,
+	getVolumePathsFn func([]uint16) ([]string, error),
+	processMountsForVolumeFn func(context.Context, []string, map[string]struct{}, []PartitionStat, Warnings) []PartitionStat,
+	findNextVolumeFn func(uintptr, []uint16) (bool, error),
+) []PartitionStat {
 	for {
 		select {
 		case <-ctx.Done():
@@ -148,22 +162,19 @@ func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []
 		default:
 		}
 
-		mounts, err := getVolumePaths(volNameBuf)
+		mounts, err := getVolumePathsFn(volNameBuf)
 		if err != nil {
 			warnings.Add(fmt.Errorf("failed to find paths for volume %s", windows.UTF16ToString(volNameBuf)))
 		} else {
-			partitionStats = processMountsForVolume(ctx, mounts, processedPaths, partitionStats, warnings)
+			partitionStats = processMountsForVolumeFn(ctx, mounts, processedPaths, partitionStats, warnings)
 		}
 
 		volNameBuf = make([]uint16, maxVolumeNameLength)
-		if volRet, _, err := procFindNextVolumeW.Call(
-			nextVolHandle,
-			uintptr(unsafe.Pointer(&volNameBuf[0])),
-			uintptr(maxVolumeNameLength)); err != nil && volRet == 0 {
-			var errno syscall.Errno
-			if errors.As(err, &errno) && errno == windows.ERROR_NO_MORE_FILES {
-				break
-			}
+		done, err := findNextVolumeFn(nextVolHandle, volNameBuf)
+		if done {
+			break
+		}
+		if err != nil {
 			warnings.Add(fmt.Errorf("failed to find next volume: %w", err))
 			if len(warnings.List) > maxWarningsInDrive {
 				break
@@ -171,6 +182,22 @@ func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []
 		}
 	}
 	return partitionStats
+}
+
+func findNextVolume(nextVolHandle uintptr, volNameBuf []uint16) (bool, error) {
+	volRet, _, err := procFindNextVolumeW.Call(
+		nextVolHandle,
+		uintptr(unsafe.Pointer(&volNameBuf[0])),
+		uintptr(maxVolumeNameLength),
+	)
+	if err != nil && volRet == 0 {
+		var errno syscall.Errno
+		if errors.As(err, &errno) && errno == windows.ERROR_NO_MORE_FILES {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func processMountsForVolume(ctx context.Context, mounts []string, processedPaths map[string]struct{}, partitionStats []PartitionStat, warnings Warnings) []PartitionStat {

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -71,3 +71,39 @@ func TestProcessLogicalDrives(t *testing.T) {
 	assert.Equal(t, "NTFS", parts[0].Fstype)
 	assert.Contains(t, parts[0].Opts, rw)
 }
+
+func TestProcessVolumeLoopContinuesAfterGetVolumePathsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	getVolumePathsCalls := 0
+	findNextVolumeCalls := 0
+
+	parts := processVolumeLoopWith(
+		ctx,
+		1,
+		[]uint16{'v', 0},
+		map[string]struct{}{},
+		nil,
+		Warnings{},
+		func([]uint16) ([]string, error) {
+			getVolumePathsCalls++
+			if getVolumePathsCalls == 2 {
+				cancel()
+			}
+			return nil, assert.AnError
+		},
+		func(context.Context, []string, map[string]struct{}, []PartitionStat, Warnings) []PartitionStat {
+			t.Fatal("processMountsForVolume should not be called when getVolumePaths fails")
+			return nil
+		},
+		func(uintptr, []uint16) (bool, error) {
+			findNextVolumeCalls++
+			return true, nil
+		},
+	)
+
+	assert.Empty(t, parts)
+	assert.Equal(t, 1, getVolumePathsCalls)
+	assert.Equal(t, 1, findNextVolumeCalls)
+}

--- a/disk/disk_windows_test.go
+++ b/disk/disk_windows_test.go
@@ -71,39 +71,3 @@ func TestProcessLogicalDrives(t *testing.T) {
 	assert.Equal(t, "NTFS", parts[0].Fstype)
 	assert.Contains(t, parts[0].Opts, rw)
 }
-
-func TestProcessVolumeLoopContinuesAfterGetVolumePathsError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	getVolumePathsCalls := 0
-	findNextVolumeCalls := 0
-
-	parts := processVolumeLoopWith(
-		ctx,
-		1,
-		[]uint16{'v', 0},
-		map[string]struct{}{},
-		nil,
-		Warnings{},
-		func([]uint16) ([]string, error) {
-			getVolumePathsCalls++
-			if getVolumePathsCalls == 2 {
-				cancel()
-			}
-			return nil, assert.AnError
-		},
-		func(context.Context, []string, map[string]struct{}, []PartitionStat, Warnings) []PartitionStat {
-			t.Fatal("processMountsForVolume should not be called when getVolumePaths fails")
-			return nil
-		},
-		func(uintptr, []uint16) (bool, error) {
-			findNextVolumeCalls++
-			return true, nil
-		},
-	)
-
-	assert.Empty(t, parts)
-	assert.Equal(t, 1, getVolumePathsCalls)
-	assert.Equal(t, 1, findNextVolumeCalls)
-}


### PR DESCRIPTION
When `getVolumePaths` returns an error, we should not just continue the for loop. We should skip `processMountsForVolume`, then update `volNameBuf ` using `procFindNextVolumeW`. Otherwise it would loop forever.

I discovered this bug when running wandb, which uses gopsutil to collect system info, and there is a virtual CD program on my machine that leaves a stale volume that causes an error in `getVolumePaths`. It's discussed in https://github.com/shirou/gopsutil/issues/1911 but not really fixed yet.