### PR TITLE
[net][linux]: guard against malformed /proc/net/dev lines to avoid panic

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -69,6 +69,10 @@ func IOCountersByFileWithContext(_ context.Context, pernic bool, filename string
 		}
 
 		fields := strings.Fields(strings.TrimSpace(statsPart))
+		if len(fields) < 13 {
+			// malformed line in /proc/net/dev, avoid panic by ignoring.
+			continue
+		}
 		bytesRecv, err := strconv.ParseUint(fields[0], 10, 64)
 		if err != nil {
 			return ret, err


### PR DESCRIPTION
`IOCountersByFileWithContext `accessed fields[0]..fields[12] without checking the slice length, causing an index-out-of-range panic on truncated interface lines (custom HOST_PROC, partial reads, etc.). Skip such lines instead, matching the existing pattern in `disk/disk_linux.go`.

Fixes #2069
