### PR TITLE
fix: add bounds check for /proc/net/dev fields to prevent panic

### DIFF
--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -69,6 +69,9 @@ func IOCountersByFileWithContext(_ context.Context, pernic bool, filename string
 		}
 
 		fields := strings.Fields(strings.TrimSpace(statsPart))
+		if len(fields) < 13 {
+			continue
+		}
 		bytesRecv, err := strconv.ParseUint(fields[0], 10, 64)
 		if err != nil {
 			return ret, err


### PR DESCRIPTION
Fixes #2069

## Problem

`IOCountersByFileWithContext` in `net/net_linux.go` accesses `fields[0]` through `fields[12]` without checking slice length first. This causes an index-out-of-range panic when `/proc/net/dev` contains truncated interface lines, which can happen in:
- Container environments with partial kernel state
- Corrupted/modified proc filesystem

## Fix

Add a bounds check before field access, matching the existing pattern used in `disk/disk_linux.go`:

```go
if len(fields) < 13 {
    continue
}
```

This is a minimal one-line guard that prevents the panic while preserving all existing behavior for well-formed input.