### PR TITLE
fix: add bounds check for /proc/[pid]/stat fields in fillFromTIDStat

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1046,6 +1046,9 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 	}
 	// Indexing from one, as described in `man proc` about the file /proc/[pid]/stat
 	fields := splitProcStat(contents)
+	if len(fields) < 23 {
+		return 0, 0, nil, 0, 0, 0, nil, fmt.Errorf("malformed stat file: expected at least 23 fields, got %d", len(fields))
+	}
 
 	terminal, err := strconv.ParseUint(fields[7], 10, 64)
 	if err != nil {


### PR DESCRIPTION
Fixes #2070

## Problem

`fillFromTIDStatWithContext` accesses `fields[4]`, `fields[7]`, `fields[14]`, `fields[15]`, `fields[18]`, and `fields[22]` without bounds checking. This causes an index-out-of-range panic when `/proc/[pid]/stat` has fewer than 23 fields.

The function already guards `fields[42]` at line 1073:
```go
if len(fields) > 42 {
    iotime, err = strconv.ParseFloat(fields[42], 64)
} else {
    iotime = 0 // e.g. SmartOS containers
}
```

But the same protection is missing for the lower-indexed fields.

## Fix

Add an early bounds check:
```go
if len(fields) < 23 {
    return 0, 0, nil, 0, 0, 0, nil, fmt.Errorf("malformed stat file: expected at least 23 fields, got %d", len(fields))
}
```

This complements the fix in #1995 which added a similar check in a different code path.