### PR TITLE
Use getconf instead of bootinfo on AIX to get kernel architecture

### DIFF
--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -116,9 +116,12 @@ func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 }
 
 func KernelArch() (arch string, err error) {
-	out, err := getInvoker().Command("bootinfo", "-y")
+	out, err := getInvoker().Command("getconf", "LONG_BIT")
 	if err != nil {
-		return "", err
+		out, err = getInvoker().Command("bootinfo", "-y")
+		if err != nil {
+			return "", err
+		}
 	}
 	arch = strings.TrimRight(string(out), "\n")
 

--- a/host/host_aix.go
+++ b/host/host_aix.go
@@ -116,7 +116,7 @@ func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 }
 
 func KernelArch() (arch string, err error) {
-	out, err := getInvoker().Command("getconf", "LONG_BIT")
+	out, err := getInvoker().Command("getconf", "KERNEL_BITMODE")
 	if err != nil {
 		out, err = getInvoker().Command("bootinfo", "-y")
 		if err != nil {


### PR DESCRIPTION
`bootinfo` is a deprecated AIX-specific tool, while `getconf` is a POSIX-standard utility that provides the same information.

Additionally, `bootinfo` requires special permissions to run in some AIX environments (`bin` group), whereas `getconf` is executable by all users out of the box (NB: at least on my host).

This PR updates `KernelArch()` to try `getconf KERNEL_BITMODE` first, and falls back to `bootinfo -y` if `getconf` fails, preserving backward compatibility.

https://www.ibm.com/support/pages/use-getconf-instead-bootinfo