### PR TITLE
[cpu][windows]: fix percpu stats on Windows hosts with multiple processor groups

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -25,6 +25,7 @@ var (
 	procGetLogicalProcessorInformationEx = common.Modkernel32.NewProc("GetLogicalProcessorInformationEx")
 	procGetSystemFirmwareTable           = common.Modkernel32.NewProc("GetSystemFirmwareTable")
 	procCallNtPowerInformation           = common.ModPowrProf.NewProc("CallNtPowerInformation")
+	procGetActiveProcessorGroupCount     = common.Modkernel32.NewProc("GetActiveProcessorGroupCount")
 )
 
 type win32_Processor struct { //nolint:revive //FIXME
@@ -263,6 +264,21 @@ func perCPUTimes() ([]TimesStat, error) {
 
 // makes call to Windows API function to retrieve performance information for each core
 func perfInfo() ([]win32_SystemProcessorPerformanceInformation, error) {
+	// On hosts with more than 64 logical CPUs Windows splits CPUs into Processor Groups
+	// (up to 64 logical CPUs per group). The non-Ex NtQuerySystemInformation only returns
+	// data for the calling thread's group, so whenever the Ex variant is available we
+	// iterate every active group and concatenate the results. See issue #887.
+	if common.ProcNtQuerySystemInformationEx.Find() == nil {
+		return perfInfoAllGroups()
+	}
+	return perfInfoSingleGroup()
+}
+
+// perfInfoSingleGroup queries SystemProcessorPerformanceInformation via the non-Ex
+// NtQuerySystemInformation call. This is the legacy fallback for environments where
+// NtQuerySystemInformationEx cannot be resolved; it only returns data for the calling
+// thread's processor group.
+func perfInfoSingleGroup() ([]win32_SystemProcessorPerformanceInformation, error) {
 	// Make maxResults large for safety.
 	// We can't invoke the api call with a results array that's too small.
 	// If we have more than 2056 cores on a single host, then it's probably the future.
@@ -286,16 +302,61 @@ func perfInfo() ([]win32_SystemProcessorPerformanceInformation, error) {
 
 	// check return code for errors
 	if retCode != 0 {
-		return nil, fmt.Errorf("call to NtQuerySystemInformation returned %d. err: %s", retCode, err.Error())
+		return nil, fmt.Errorf("call to NtQuerySystemInformation returned 0x%x: %w", retCode, err)
 	}
 
 	// calculate the number of returned elements based on the returned size
 	numReturnedElements := retSize / win32_SystemProcessorPerformanceInfoSize
 
 	// trim results to the number of returned elements
-	resultBuffer = resultBuffer[:numReturnedElements]
+	return resultBuffer[:numReturnedElements], nil
+}
 
-	return resultBuffer, nil
+// perfInfoAllGroups queries SystemProcessorPerformanceInformation for every active
+// processor group via NtQuerySystemInformationEx and concatenates the results. The
+// group index is passed as the InputBuffer per the Ex calling convention documented at
+// https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/queryex.htm
+func perfInfoAllGroups() ([]win32_SystemProcessorPerformanceInformation, error) {
+	// GetActiveProcessorGroupCount returns 0 only on failure; propagate the error
+	// rather than silently defaulting to a single group and returning partial data.
+	r, _, callErr := procGetActiveProcessorGroupCount.Call()
+	if r == 0 {
+		return nil, fmt.Errorf("GetActiveProcessorGroupCount returned 0: %w", callErr)
+	}
+	groupCount := uint16(r)
+
+	var result []win32_SystemProcessorPerformanceInformation
+	for g := uint16(0); g < groupCount; g++ {
+		numLP := windows.GetActiveProcessorCount(g)
+		if numLP == 0 {
+			return nil, fmt.Errorf("GetActiveProcessorCount returned 0 for processor group %d", g)
+		}
+		// buffer sized exactly for this group's logical CPU count
+		buf := make([]win32_SystemProcessorPerformanceInformation, numLP)
+		bufSize := uintptr(win32_SystemProcessorPerformanceInfoSize) * uintptr(numLP)
+		var retSize uint32
+		// InputBuffer is a USHORT (2 bytes) holding the target processor group index.
+		group := g
+		retCode, _, err := common.ProcNtQuerySystemInformationEx.Call(
+			win32_SystemProcessorPerformanceInformationClass, // System Information Class -> SystemProcessorPerformanceInformation
+			uintptr(unsafe.Pointer(&group)),                  // InputBuffer: pointer to USHORT group index
+			unsafe.Sizeof(group),                             // InputBufferLength: sizeof(USHORT) = 2
+			uintptr(unsafe.Pointer(&buf[0])),                 // pointer to first element in result buffer
+			bufSize,                                          // size of the buffer in memory
+			uintptr(unsafe.Pointer(&retSize)),                // pointer to the size of the returned results the windows proc will set this
+		)
+		if retCode != 0 {
+			return nil, fmt.Errorf("call to NtQuerySystemInformationEx(group=%d) returned 0x%x: %w", g, retCode, err)
+		}
+		// Guard against a retSize that is not a whole number of entries or exceeds
+		// the allocated buffer (e.g. CPU hot-add racing with GetActiveProcessorCount).
+		if retSize%win32_SystemProcessorPerformanceInfoSize != 0 || uintptr(retSize) > bufSize {
+			return nil, fmt.Errorf("NtQuerySystemInformationEx(group=%d) returned unexpected retSize=%d (bufSize=%d)", g, retSize, bufSize)
+		}
+		n := retSize / win32_SystemProcessorPerformanceInfoSize
+		result = append(result, buf[:n]...)
+	}
+	return result, nil
 }
 
 // SystemInfo is an equivalent representation of SYSTEM_INFO in the Windows API.

--- a/cpu/cpu_windows_test.go
+++ b/cpu/cpu_windows_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build windows
+
+package cpu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPerfInfoMatchesLogicalCount ensures perfInfo() returns one entry per logical
+// CPU on the host. This guards against regressions like issue #887 where only the
+// calling thread's processor group was reported on hosts with more than 64 CPUs.
+func TestPerfInfoMatchesLogicalCount(t *testing.T) {
+	info, err := perfInfo()
+	require.NoError(t, err)
+
+	n, err := CountsWithContext(context.Background(), true)
+	require.NoError(t, err)
+
+	require.Len(t, info, n, "perfInfo must return one entry per logical CPU across all processor groups")
+}

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -73,6 +73,7 @@ var (
 
 	ProcGetSystemTimes                   = Modkernel32.NewProc("GetSystemTimes")
 	ProcNtQuerySystemInformation         = ModNt.NewProc("NtQuerySystemInformation")
+	ProcNtQuerySystemInformationEx       = ModNt.NewProc("NtQuerySystemInformationEx")
 	ProcRtlGetNativeSystemInformation    = ModNt.NewProc("RtlGetNativeSystemInformation")
 	ProcRtlNtStatusToDosError            = ModNt.NewProc("RtlNtStatusToDosError")
 	ProcNtQueryInformationProcess        = ModNt.NewProc("NtQueryInformationProcess")


### PR DESCRIPTION
## Symptom

On Windows hosts with more than 64 logical CPUs (e.g. 36 cores × 2 HT = 72 logical CPUs, multi-socket servers, AWS EC2 instances with 96 vCPUs, etc.), `cpu.Percent(interval, percpu=true)` **returns the CPUs of only one Processor Group** instead of all CPUs.

- On a 72-CPU host, each call returns either 64 or 8 entries
- Which group is returned depends on which Processor Group the calling thread happens to be running on, so the result is non-deterministic
- Meanwhile `cpu.Counts(logical=true)` correctly returns 72 — so the array length of `Percent` does not match `Counts`, making aggregation by callers impossible

This has been reproduced by the reporter of #887 (72-CPU Server 2016), and by other users on a 92-vCPU Server 2022 and a 96-CPU EC2 instance.

## Cause

Windows splits logical CPUs into [**Processor Groups**](https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups) (up to 64 CPUs per group) on systems with more than 64 logical CPUs. Many legacy Win32 APIs only see "the group the calling thread belongs to."

`perfInfo()` uses [`NtQuerySystemInformation(SystemProcessorPerformanceInformation)`](https://docs.microsoft.com/en-us/windows/desktop/api/winternl/nf-winternl-ntquerysysteminformation#system_processor_performance_information) (class 8), which is exactly one of those non-group-aware APIs: it returns data only for the CPUs in the calling thread's group. Because the Go runtime may schedule the goroutine on any group, the result is non-deterministic.

Note that `cpu.Counts(logical=true)` is already Processor Group-aware via [`GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`](https://learn.microsoft.com/en-us/windows/win32/api/processtopologyapi/nf-processtopologyapi-getactiveprocessorcount) in `CountsWithContext` (`cpu/cpu_windows.go`). psutil handles this the same way ([psutil reference](https://github.com/giampaolo/psutil/blob/d01a9eaa35a8aadf6c519839e987a49d8be2d891/psutil/_psutil_windows.c#L97)). Only `perfInfo()` had been left behind.

## Fix

Use [`NtQuerySystemInformationEx`](https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/queryex.htm),  which takes a group number (`USHORT`) as `InputBuffer` and returns data for only that group's CPUs. Iterate over all active groups and concatenate the results.

- Get the number of groups via [`GetActiveProcessorGroupCount`](https://learn.microsoft.com/en-us/windows/win32/api/processtopologyapi/nf-processtopologyapi-getactiveprocessorgroupcount)
- For each group `g`, size the buffer using `GetActiveProcessorCount(g)` and call `NtQuerySystemInformationEx`
- When `NtQuerySystemInformationEx` cannot be resolved (older OS without the Ex entry point), fall back to the original `NtQuerySystemInformation` path

C++ reference implementation: https://github.com/r3p3r/WindowsInternals/blob/05638d4d28cfb1bdfe7d7d1d1331d5be541f91a3/CpuSet/CpuSet.cpp#L180-L182

`NtQuerySystemInformationEx` is available on Windows 7 / Server 2008 R2 and later, which matches gopsutil's supported OS range.

## Scope

- `Times(percpu=true)` — now returns entries for all CPUs
- `Percent(percpu=true)` — fixed automatically since it's built on `Times()`
- `Times(percpu=false)` — still uses `GetSystemTimes`, which is also not Processor Group-aware; out of scope for this PR (better tracked as a separate issue)
