### PR TITLE
Implement net ProtoCounters for AIX

### DIFF
--- a/net/net_aix.go
+++ b/net/net_aix.go
@@ -31,8 +31,240 @@ func ConntrackStatsWithContext(_ context.Context, _ bool) ([]ConntrackStat, erro
 	return nil, common.ErrNotImplementedError
 }
 
-func ProtoCountersWithContext(_ context.Context, _ []string) ([]ProtoCountersStat, error) {
-	return nil, common.ErrNotImplementedError
+func ProtoCountersWithContext(ctx context.Context, protocols []string) ([]ProtoCountersStat, error) {
+	out, err := invoke.CommandWithContext(ctx, "netstat", "-s")
+	if err != nil {
+		return nil, err
+	}
+	return parseNetstatS(string(out), protocols)
+}
+
+// parseNetstatS parses "netstat -s" output on AIX.
+//
+// Format:
+//
+//	<proto>:
+//	\t<count> <description>
+//	\t\t<count> <sub-description>
+//
+// Descriptions containing parenthetical sub-counts (e.g. "(6302116893 bytes)")
+// are normalised by stripping the parenthetical before matching.
+func parseNetstatS(output string, protocols []string) ([]ProtoCountersStat, error) {
+	var stats []ProtoCountersStat
+	var currentProto string
+	var currentStats map[string]int64
+
+	for _, line := range strings.Split(output, "\n") {
+		// Protocol header: no leading whitespace, ends with ":"
+		if line != "" && line[0] != '\t' {
+			if currentProto != "" && len(currentStats) > 0 {
+				if len(protocols) == 0 || common.StringsHas(protocols, currentProto) {
+					stats = append(stats, ProtoCountersStat{
+						Protocol: currentProto,
+						Stats:    currentStats,
+					})
+				}
+			}
+			currentProto = strings.TrimSuffix(strings.TrimSpace(line), ":")
+			currentStats = make(map[string]int64)
+			continue
+		}
+
+		if currentProto == "" {
+			continue
+		}
+
+		// Count leading tabs to track indentation depth (1 = top-level metric).
+		depth := 0
+		rest := line
+		for rest != "" && rest[0] == '\t' {
+			depth++
+			rest = rest[1:]
+		}
+		if depth == 0 || rest == "" {
+			continue
+		}
+
+		// Split "<number> <description>".
+		spaceIdx := strings.IndexByte(rest, ' ')
+		if spaceIdx <= 0 {
+			continue
+		}
+		val, err := strconv.ParseInt(rest[:spaceIdx], 10, 64)
+		if err != nil {
+			continue
+		}
+		// Normalise: remove parenthetical sub-counts like "(6302116893 bytes)".
+		desc := normaliseNetstatDesc(strings.TrimSpace(rest[spaceIdx+1:]))
+
+		if key := aixProtoKey(currentProto, depth, desc); key != "" {
+			currentStats[key] += val
+		}
+	}
+
+	if currentProto != "" && len(currentStats) > 0 {
+		if len(protocols) == 0 || common.StringsHas(protocols, currentProto) {
+			stats = append(stats, ProtoCountersStat{
+				Protocol: currentProto,
+				Stats:    currentStats,
+			})
+		}
+	}
+
+	return stats, nil
+}
+
+// normaliseNetstatDesc strips a single parenthetical from a netstat -s description,
+// e.g. "data packets (6302116893 bytes) retransmitted" → "data packets retransmitted".
+func normaliseNetstatDesc(s string) string {
+	start := strings.Index(s, "(")
+	if start == -1 {
+		return s
+	}
+	end := strings.LastIndex(s, ")")
+	if end < start {
+		return s
+	}
+	return strings.Join(strings.Fields(s[:start]+s[end+1:]), " ")
+}
+
+// aixProtoKey maps a normalised AIX netstat -s description to a ProtoCountersStat key.
+// depth is the tab-indentation level (1 = top-level line under the protocol header).
+// Returns "" for lines that should be ignored.
+func aixProtoKey(proto string, depth int, desc string) string {
+	switch proto {
+	case "tcp":
+		return aixTCPKey(depth, desc)
+	case "udp":
+		return aixUDPKey(desc)
+	case "ip":
+		return aixIPKey(depth, desc)
+	case "ipv6":
+		return aixIPv6Key(depth, desc)
+	}
+	return ""
+}
+
+func aixTCPKey(depth int, desc string) string {
+	switch {
+	// Top-level totals — depth check avoids matching sub-lines like "N data packets sent".
+	case depth == 1 && desc == "packets sent":
+		return "OutSegs"
+	case depth == 1 && desc == "packets received":
+		return "InSegs"
+	// Sub-line: "data packets NNN bytes retransmitted" → normalised "data packets retransmitted"
+	case strings.Contains(desc, "retransmitted"):
+		return "RetransSegs"
+	case desc == "connection requests":
+		return "ActiveOpens"
+	case desc == "connection accepts":
+		return "PassiveOpens"
+	case desc == "embryonic connections dropped":
+		return "AttemptFails"
+	case strings.HasPrefix(desc, "discarded for bad checksums"):
+		return "InCsumErrors"
+	// Other input errors accumulate into InErrs.
+	case strings.HasPrefix(desc, "discarded for bad header") ||
+		strings.HasPrefix(desc, "discarded because packet too short"):
+		return "InErrs"
+	}
+	return ""
+}
+
+func aixUDPKey(desc string) string {
+	switch {
+	case desc == "delivered":
+		return "InDatagrams"
+	// Both unicast and broadcast "dropped due to no socket" map to NoPorts.
+	case strings.Contains(desc, "dropped due to no socket"):
+		return "NoPorts"
+	case desc == "bad checksums":
+		return "InCsumErrors"
+	case desc == "socket buffer overflows":
+		return "RcvbufErrors"
+	case desc == "datagrams output":
+		return "OutDatagrams"
+	case desc == "incomplete headers" || desc == "bad data length fields":
+		return "InErrors"
+	}
+	return ""
+}
+
+func aixIPKey(depth int, desc string) string {
+	switch {
+	case desc == "total packets received":
+		return "InReceives"
+	// All header-error variants accumulate into InHdrErrors.
+	case desc == "bad header checksums" ||
+		desc == "with size smaller than minimum" ||
+		desc == "with data size < data length" ||
+		desc == "with header length < data size" ||
+		desc == "with data length < header length" ||
+		desc == "with bad options" ||
+		desc == "with incorrect version number":
+		return "InHdrErrors"
+	case strings.Contains(desc, "unknown/unsupported protocol"):
+		return "InUnknownProtos"
+	case desc == "packets for this host":
+		return "InDelivers"
+	case depth == 1 && desc == "packets forwarded":
+		return "ForwDatagrams"
+	case desc == "packets sent from this host":
+		return "OutRequests"
+	case desc == "packets reassembled ok":
+		return "ReasmOKs"
+	case strings.HasPrefix(desc, "fragments dropped after timeout"):
+		return "ReasmFails"
+	case desc == "fragments received":
+		return "ReasmReqds"
+	case strings.HasPrefix(desc, "fragments dropped"):
+		return "InDiscards"
+	case desc == "fragments created":
+		return "FragCreates"
+	case desc == "output packets discarded due to no route":
+		return "OutNoRoutes"
+	case strings.HasPrefix(desc, "output packets dropped due to no bufs"):
+		return "OutDiscards"
+	}
+	return ""
+}
+
+func aixIPv6Key(depth int, desc string) string {
+	switch {
+	case desc == "total packets received":
+		return "InReceives"
+	case desc == "with size smaller than minimum" ||
+		desc == "with data size < data length" ||
+		desc == "with incorrect version number" ||
+		desc == "with illegal source":
+		return "InHdrErrors"
+	case strings.Contains(desc, "unknown/unsupported protocol"):
+		return "InUnknownProtos"
+	case desc == "input packets without enough memory":
+		return "InDiscards"
+	case desc == "packets for this host":
+		return "InDelivers"
+	case depth == 1 && desc == "packets forwarded":
+		return "ForwDatagrams"
+	case desc == "packets sent from this host":
+		return "OutRequests"
+	case desc == "packets reassembled ok":
+		return "ReasmOKs"
+	case strings.HasPrefix(desc, "fragments dropped after timeout"):
+		return "ReasmFails"
+	case desc == "fragments received":
+		return "ReasmReqds"
+	case strings.HasPrefix(desc, "fragments dropped"):
+		return "InDiscards"
+	case desc == "fragments created":
+		return "FragCreates"
+	case desc == "output packets discarded due to no route":
+		return "OutNoRoutes"
+	case strings.HasPrefix(desc, "output packets dropped due to no bufs") ||
+		desc == "output packets without enough memory":
+		return "OutDiscards"
+	}
+	return ""
 }
 
 func parseNetstatNetLine(line string) (ConnectionStat, error) {

--- a/net/net_aix_test.go
+++ b/net/net_aix_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//go:build aix
+
+package net
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNetstatS(t *testing.T) {
+	data, err := os.ReadFile("testdata/aix/netstat_s.txt")
+	require.NoError(t, err)
+
+	stats, err := parseNetstatS(string(data), nil)
+	require.NoError(t, err)
+
+	protos := map[string]ProtoCountersStat{}
+	for _, s := range stats {
+		protos[s.Protocol] = s
+	}
+
+	var gotProtocols []string
+	for p := range protos {
+		gotProtocols = append(gotProtocols, p)
+	}
+	assert.ElementsMatch(t, []string{"tcp", "udp", "ip", "ipv6"}, gotProtocols)
+
+	t.Run("tcp", func(t *testing.T) {
+		tcp, ok := protos["tcp"]
+		require.True(t, ok, "tcp section not found")
+		assert.Equal(t, map[string]int64{
+			"OutSegs":      1001,
+			"InSegs":       2002,
+			"RetransSegs":  303,
+			"ActiveOpens":  404,
+			"PassiveOpens": 505,
+			"AttemptFails": 606,
+			"InCsumErrors": 707,
+			"InErrs":       1603, // 801 (bad header offset) + 802 (packet too short)
+		}, tcp.Stats)
+	})
+
+	t.Run("udp", func(t *testing.T) {
+		udp, ok := protos["udp"]
+		require.True(t, ok, "udp section not found")
+		assert.Equal(t, map[string]int64{
+			"InDatagrams":  1100,
+			"OutDatagrams": 2200,
+			"NoPorts":      7700, // 3300 (unicast) + 4400 (broadcast)
+			"InCsumErrors": 5500,
+			"RcvbufErrors": 6600,
+			"InErrors":     330, // 110 (incomplete headers) + 220 (bad data length)
+		}, udp.Stats)
+	})
+
+	t.Run("ip", func(t *testing.T) {
+		ip, ok := protos["ip"]
+		require.True(t, ok, "ip section not found")
+		assert.Equal(t, map[string]int64{
+			"InReceives":      50000,
+			"InDelivers":      40000,
+			"OutRequests":     30000,
+			"InHdrErrors":     308, // 11+22+33+44+55+66+77 (seven header-error lines)
+			"InUnknownProtos": 9000,
+			"ForwDatagrams":   100,
+			"ReasmOKs":        200,
+			"ReasmReqds":      900,
+			"ReasmFails":      300,
+			"InDiscards":      500,
+			"FragCreates":     600,
+			"OutNoRoutes":     700,
+			"OutDiscards":     800,
+		}, ip.Stats)
+	})
+
+	t.Run("ipv6", func(t *testing.T) {
+		ipv6, ok := protos["ipv6"]
+		require.True(t, ok, "ipv6 section not found")
+		assert.Equal(t, map[string]int64{
+			"InReceives":      60000,
+			"InDelivers":      55000,
+			"OutRequests":     45000,
+			"ForwDatagrams":   110,
+			"ReasmOKs":        220,
+			"ReasmReqds":      990,
+			"ReasmFails":      330,
+			"InDiscards":      651, // 550 (fragments) + 101 (input no memory)
+			"FragCreates":     660,
+			"OutNoRoutes":     770,
+			"InHdrErrors":     110, // 11+22+33+44 (four header-error lines)
+			"InUnknownProtos": 880,
+			"OutDiscards":     777, // 333 (no bufs) + 444 (no memory)
+		}, ipv6.Stats)
+	})
+}
+
+func TestParseNetstatSFiltered(t *testing.T) {
+	data, err := os.ReadFile("testdata/aix/netstat_s.txt")
+	require.NoError(t, err)
+
+	stats, err := parseNetstatS(string(data), []string{"tcp", "udp"})
+	require.NoError(t, err)
+
+	protos := map[string]ProtoCountersStat{}
+	for _, s := range stats {
+		protos[s.Protocol] = s
+	}
+	assert.Contains(t, protos, "tcp")
+	assert.Contains(t, protos, "udp")
+	assert.NotContains(t, protos, "ip")
+	assert.NotContains(t, protos, "ipv6")
+}
+
+func TestNormaliseNetstatDesc(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"packets sent", "packets sent"},
+		{"data packets (6302116893 bytes) retransmitted", "data packets retransmitted"},
+		{"823508 segments updated rtt (of 120622 attempts)", "823508 segments updated rtt"},
+		{"connections closed (including 74 drops)", "connections closed"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, normaliseNetstatDesc(tc.input), "input: %q", tc.input)
+	}
+}

--- a/net/testdata/aix/netstat_s.txt
+++ b/net/testdata/aix/netstat_s.txt
@@ -1,0 +1,180 @@
+icmp:
+	0 calls to icmp_error
+	0 errors not generated because old message was icmp
+	Output histogram:
+		destination unreachable: 0
+	0 messages with bad code fields
+	0 messages < minimum length
+	0 bad checksums
+	0 messages with bad length
+	Input histogram:
+		destination unreachable: 0
+	0 message responses generated
+igmp:
+	0 messages received
+	0 messages received with too few bytes
+	0 messages received with bad checksum
+	0 membership queries received
+	0 membership queries received with invalid field(s)
+	0 membership reports received
+	0 membership reports received with invalid field(s)
+	0 membership reports received for groups to which we belong
+	0 membership reports sent
+tcp:
+	1001 packets sent
+		800 data packets (123456 bytes)
+		303 data packets (9876 bytes) retransmitted
+		100 ack-only packets (42 delayed)
+		0 URG only packets
+		0 window probe packets
+		0 window update packets
+		2 control packets
+		0 large sends
+		0 bytes sent using largesend
+		0 bytes is the biggest largesend
+	2002 packets received
+		700 acks (for 123456 bytes)
+		0 duplicate acks
+		0 acks for unsent data
+		1200 packets (987654 bytes) received in-sequence
+		0 completely duplicate packets (0 bytes)
+		0 old duplicate packets
+		0 packets with some dup. data (0 bytes duped)
+		0 out-of-order packets (0 bytes)
+		0 packets (0 bytes) of data after window
+		0 window probes
+		0 window update packets
+		0 packets received after close
+		0 packets with bad hardware assisted checksum
+		707 discarded for bad checksums
+		801 discarded for bad header offset fields
+		802 discarded because packet too short
+		5 discarded by listeners
+		0 discarded due to listener's queue full
+		600 ack packet headers correctly predicted
+		900 data packet headers correctly predicted
+	404 connection requests
+	505 connection accepts
+	600 connections established (including accepts)
+	100 connections closed (including 10 drops)
+	0 connections with ECN capability
+	0 times responded to ECN
+	606 embryonic connections dropped
+	500 segments updated rtt (of 400 attempts)
+	0 segments with congestion window reduced bit set
+	0 segments with congestion experienced bit set
+	0 resends due to path MTU discovery
+	0 path MTU discovery terminations due to retransmits
+	0 retransmit timeouts
+		0 connections dropped by rexmit timeout
+	0 fast retransmits
+		0 when congestion window less than 4 segments
+	0 newreno retransmits
+	0 times avoided false fast retransmits
+	0 persist timeouts
+		0 connections dropped due to persist timeout
+	0 keepalive timeouts
+		0 keepalive probes sent
+		0 connections dropped by keepalive
+	0 times SACK blocks array is extended
+	0 times SACK holes array is extended
+	0 packets dropped due to memory allocation failure
+	0 connections in timewait reused
+	0 delayed ACKs for SYN
+	0 delayed ACKs for FIN
+	0 send_and_disconnects
+	0 spliced connections
+	0 spliced connections closed
+	0 spliced connections reset
+	0 spliced connections timeout
+	0 spliced connections persist timeout
+	0 spliced connections keepalive timeout
+	0 TCP checksum offload disabled during retransmit
+	0 Connections dropped due to bad ACKs
+	0 Connections dropped due to duplicate SYN packets
+	0 fastpath loopback connections
+	0 fastpath loopback sent packets (0 bytes)
+	0 fastpath loopback received packets (0 bytes)
+	0 fake SYN segments dropped
+	0 fake RST segments dropped
+	0 data injection segments dropped
+	0 TCPTR max connections dropped
+	0 TCPTR connections dropped for no memory
+	0 TCPTR maximum per host connections dropped
+	0 connections dropped due to max assembly queue depth
+	0 exhausted ephemeral ports errors
+udp:
+	9999 datagrams received
+	110 incomplete headers
+	220 bad data length fields
+	5500 bad checksums
+	3300 dropped due to no socket
+	4400 broadcast/multicast datagrams dropped due to no socket
+	6600 socket buffer overflows
+	1100 delivered
+	2200 datagrams output
+	0 exhausted ephemeral ports errors
+ip:
+	50000 total packets received
+	11 bad header checksums
+	22 with size smaller than minimum
+	33 with data size < data length
+	44 with header length < data size
+	55 with data length < header length
+	66 with bad options
+	77 with incorrect version number
+	900 fragments received
+	500 fragments dropped (dup or out of space)
+	300 fragments dropped after timeout
+	200 packets reassembled ok
+	40000 packets for this host
+	9000 packets for unknown/unsupported protocol
+	100 packets forwarded
+	1234 packets not forwardable
+	0 redirects sent
+	30000 packets sent from this host
+	0 packets sent with fabricated ip header
+	800 output packets dropped due to no bufs, etc.
+	700 output packets discarded due to no route
+	0 output datagrams fragmented
+	600 fragments created
+	0 datagrams that can't be fragmented
+	0 IP Multicast packets dropped due to no receiver
+	0 ipintrq overflows
+	0 with illegal source
+	0 packets processed by threads
+	0 packets dropped by threads
+	0 packets dropped due to the full socket receive buffer
+	0 incoming packets dropped due to MLS filters
+	0 packets not sent due to MLS filters
+
+ipv6:
+	60000 total packets received
+	Input histogram:
+		UDP: 30000
+		ICMP v6: 25000
+	11 with size smaller than minimum
+	22 with data size < data length
+	33 with incorrect version number
+	44 with illegal source
+	101 input packets without enough memory
+	990 fragments received
+	550 fragments dropped (dup or out of space)
+	330 fragments dropped after timeout
+	220 packets reassembled ok
+	55000 packets for this host
+	880 packets for unknown/unsupported protocol
+	110 packets forwarded
+	0 packets not forwardable
+	0 too big packets not forwarded
+	45000 packets sent from this host
+	0 packets sent with fabricated ipv6 header
+	333 output packets dropped due to no bufs, etc.
+	444 output packets without enough memory
+	770 output packets discarded due to no route
+	0 output datagrams fragmented
+	660 fragments created
+	0 packets dropped due to the full socket receive buffer
+	0 packets not delivered due to bad raw IPv6 checksum
+	0 incoming packets dropped due to MLS filters
+	0 packets not sent due to MLS filters


### PR DESCRIPTION
Implement `net.ProtoCounters()` on AIX, by parsing `netstat -s` output, similar to other functions / platforms.

Tested on AIX 7.2 TL2 and AIX 7.3 TL2.

NB: I think this implementation of `ProtoCounters` parsing `netstat -s` could be reused for other platforms, but I would need to get hosts to validate so for now just AIX is a good start (and what I'm really interested in)