### PR TITLE
fix(sensors/darwin): parse sp78 temperatures instead of returning 0.0

### DIFF
--- a/sensors/sensors_darwin.go
+++ b/sensors/sensors_darwin.go
@@ -106,9 +106,14 @@ func getTemperature(smc *common.SMC, key string) float64 {
 	}
 
 	if result.dataSize == 2 && result.dataType == toUint32(dataTypeSp78) {
-		return 0.0
+		// sp78: signed 7.8 fixed-point — high byte is signed integer degrees,
+		// low byte is fractional part in 1/256 increments.
+		// Previously this branch incorrectly returned 0.0, causing all SMC
+		// temperature sensors on Intel Macs to report 0°C.
+		return float64(int8(result.data[0])) + float64(result.data[1])/256.0
 	}
 
+	// Non-sp78 single-byte readings (legacy/unknown formats)
 	return float64(result.data[0])
 }
 


### PR DESCRIPTION
## Summary

`sensors.TemperaturesWithContext()` returns 0.0°C for every sensor on Intel Macs because `getTemperature()` in `sensors_darwin.go` explicitly returns `0.0` when it detects the sp78 data type — but sp78 is exactly the format Apple's SMC uses for temperature readings.

## Bug

[`sensors/sensors_darwin.go:108-110`](https://github.com/shirou/gopsutil/blob/master/sensors/sensors_darwin.go#L108-L110):

```go
if result.dataSize == 2 && result.dataType == toUint32(dataTypeSp78) {
    return 0.0
}
```

This branch is supposed to *parse* the sp78 reading, not discard it. Looks like an unfinished placeholder.

## Fix

Parse the two-byte sp78 response according to spec — high byte = signed integer degrees, low byte = fractional part in 1/256 increments:

```go
if result.dataSize == 2 && result.dataType == toUint32(dataTypeSp78) {
    return float64(int8(result.data[0])) + float64(result.data[1])/256.0
}
```

## Verification

Tested on Mac mini 2018 (Intel Core i5-8500B, T2 chip) running macOS 15.7.5 (Sequoia):

**Before:**
```
TC0P: 0.0°C  TM0P: 0.0°C  TW0P: 0.0°C  ... (all 21 keys returned 0.0)
```

**After:**
```
TC0P: 60.3°C  (CPU 0 Proximity)
TM0P: 57.6°C  (Memory Slots Proximity)
TW0P: 49.6°C  (Wireless Module)
```

Cross-checked against `osx-cpu-temp` which reports 59.7°C for the same hardware/load — values match.

Other keys (TC0D, TC0H, TG0D, etc.) still legitimately return 0.0 — those sensors aren't physically present on T2-chip Mac mini hardware. The IOKit + SMC stack is fine; only the parsing was broken.

## Affected platforms

`darwin && !arm64` (Intel Macs). Apple Silicon Macs use a different code path (`sensors_darwin_arm64.go`) and are not affected.

## Test plan

- [x] Build & run on Intel Mac mini 2018 (macOS 15.7.5)
- [x] Verify temperatures match `osx-cpu-temp` output
- [x] Verify other key types (single-byte readings) still work
- [x] CI to verify cross-compile still succeeds
