### PR TITLE
disk: report effective mount mode on Linux

### DIFF
--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -359,6 +359,14 @@ func parseFieldsOnMountinfo(ctx context.Context, lines []string, all bool, filen
 		}
 		fsType := fields[0]
 		mntSrc := fields[1]
+		superOpts := []string{}
+		if len(fields) >= 3 {
+			superOpts = strings.Split(fields[2], ",")
+		}
+		// Since Linux 2.6.16, read-only can be set independently on the
+		// mount point and the filesystem superblock. The mount is writable
+		// only when both option sets are read-write.
+		mountOpts = effectiveMountOpts(mountOpts, superOpts)
 		isBind := false
 		// Per fstab(5), the device can be any string for non-storage-backed filesystems.
 		if !all && !strings.HasPrefix(mntSrc, "/") {
@@ -419,6 +427,49 @@ func parseFieldsOnMountinfo(ctx context.Context, lines []string, all bool, filen
 		ret = append(ret, d)
 	}
 	return ret, nil
+}
+
+func effectiveMountOpts(mountOpts, superOpts []string) []string {
+	mode := effectiveReadWriteMode(mountOpts, superOpts)
+	if mode == "" {
+		return mountOpts
+	}
+
+	updated := make([]string, 0, len(mountOpts)+1)
+	modeSet := false
+	for _, opt := range mountOpts {
+		if opt == "ro" || opt == "rw" {
+			if !modeSet {
+				updated = append(updated, mode)
+				modeSet = true
+			}
+			continue
+		}
+		updated = append(updated, opt)
+	}
+	if !modeSet {
+		updated = append([]string{mode}, updated...)
+	}
+	return updated
+}
+
+func effectiveReadWriteMode(mountOpts, superOpts []string) string {
+	if containsMountOpt(mountOpts, "ro") || containsMountOpt(superOpts, "ro") {
+		return "ro"
+	}
+	if containsMountOpt(mountOpts, "rw") && containsMountOpt(superOpts, "rw") {
+		return "rw"
+	}
+	return ""
+}
+
+func containsMountOpt(opts []string, opt string) bool {
+	for _, o := range opts {
+		if o == opt {
+			return true
+		}
+	}
+	return false
 }
 
 // getFileSystems returns supported filesystems from /proc/filesystems

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -454,22 +455,13 @@ func effectiveMountOpts(mountOpts, superOpts []string) []string {
 }
 
 func effectiveReadWriteMode(mountOpts, superOpts []string) string {
-	if containsMountOpt(mountOpts, "ro") || containsMountOpt(superOpts, "ro") {
+	if slices.Contains(mountOpts, "ro") || slices.Contains(superOpts, "ro") {
 		return "ro"
 	}
-	if containsMountOpt(mountOpts, "rw") && containsMountOpt(superOpts, "rw") {
+	if slices.Contains(mountOpts, "rw") && slices.Contains(superOpts, "rw") {
 		return "rw"
 	}
 	return ""
-}
-
-func containsMountOpt(opts []string, opt string) bool {
-	for _, o := range opts {
-		if o == opt {
-			return true
-		}
-	}
-	return false
 }
 
 // getFileSystems returns supported filesystems from /proc/filesystems

--- a/disk/disk_linux_test.go
+++ b/disk/disk_linux_test.go
@@ -79,6 +79,24 @@ func Test_parseFieldsOnMountinfo_multiMount(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func Test_parseFieldsOnMountinfo_effectiveReadWriteMode(t *testing.T) {
+	lines := []string{
+		"36 35 253:0 / / rw,relatime - ext4 /dev/mapper/vg1-lv_root ro,seclabel,relatime,commit=60,data=ordered",
+		"37 35 253:1 / /mnt/readonly ro,relatime - ext4 /dev/mapper/vg1-lv_ro rw,seclabel,relatime,commit=60,data=ordered",
+		"38 35 253:2 / /mnt/readwrite rw,relatime - ext4 /dev/mapper/vg1-lv_rw rw,seclabel,relatime,commit=60,data=ordered",
+	}
+
+	actual, err := parseFieldsOnMountinfo(context.Background(), lines, true, "")
+	require.NoError(t, err)
+
+	expected := []PartitionStat{
+		{Device: "/dev/mapper/vg1-lv_root", Mountpoint: "/", Fstype: "ext4", Opts: []string{"ro", "relatime"}},
+		{Device: "/dev/mapper/vg1-lv_ro", Mountpoint: "/mnt/readonly", Fstype: "ext4", Opts: []string{"ro", "relatime"}},
+		{Device: "/dev/mapper/vg1-lv_rw", Mountpoint: "/mnt/readwrite", Fstype: "ext4", Opts: []string{"rw", "relatime"}},
+	}
+	assert.Equal(t, expected, actual)
+}
+
 func Test_parseFieldsOnMounts(t *testing.T) {
 	fs := []string{"sysfs", "tmpfs"}
 


### PR DESCRIPTION
## Summary

Fix Linux `disk.PartitionStat.Opts` mode detection when mountpoint options and superblock options disagree.
Since Linux 2.6.16, `MS_RDONLY` can be set or cleared independently on the mount point and on the underlying filesystem superblock. A mounted filesystem is writable only when both option sets are read-write.
gopsutil currently parses only the mountpoint options from `/proc/*/mountinfo`, so it can report `rw` even when the superblock is `ro`.

## Changes
- Parse Linux `mountinfo` superblock options.
- Replace the `ro`/`rw` option in `PartitionStat.Opts` with the effective mode.
- Treat the mount as `ro` if either the mountpoint options or superblock options contain `ro`.
- Treat the mount as `rw` only when both option sets contain `rw`.
- Add a regression test covering mixed mountpoint/superblock option cases.

## Reproduction
This can be reproduced without corrupting a filesystem by creating a loopback ext4 mount where the mountpoint/VFS options are `rw`, but the filesystem superblock options are `ro`.

```sh
sudo dd if=/dev/zero of=/tmp/gopsutil-disk-test.img bs=1M count=128
sudo mkfs.ext4 -F /tmp/gopsutil-disk-test.img
sudo mkdir -p /mnt/gopsutil-disk-test
sudo mount -o loop,rw /tmp/gopsutil-disk-test.img /mnt/gopsutil-disk-test

target=/mnt/gopsutil-disk-test

sudo mount -o remount,rw "$target"
sudo mount -o remount,ro "$target"
sudo mount -o remount,bind,rw "$target"

findmnt -no TARGET,SOURCE,FSTYPE,VFS-OPTIONS,FS-OPTIONS "$target"
grep " $target " /proc/self/mountinfo
grep " $target " /proc/mounts
```

Expected output shows the mismatch:

```sh
/mnt/gopsutil-disk-test /dev/loop0 ext4 rw,relatime ro
... /mnt/gopsutil-disk-test rw,relatime ... - ext4 /dev/loop0 ro
/dev/loop0 /mnt/gopsutil-disk-test ext4 ro,relatime 0 0
```

Writes fail because the effective mount state is read-only:

```sh
touch "$target/write-should-fail"
touch: cannot touch '/mnt/gopsutil-disk-test/write-should-fail': Read-only file system
```

## Impact

Consumers are relying on `PartitionStat.Opts` to determine read/write mode can currently make the wrong decision for mounts where the mountpoint is `rw` but the superblock is `ro`.

One example is Telegraf's disk input, which emits a mode tag from `PartitionStat.Opts`. In this state, Telegraf can emit `mode="rw"` while `/proc/mounts` and actual write attempts show the filesystem is read-only.

## Notes

This change keeps the existing PartitionStat API and avoids appending duplicate conflicting options, such as both rw and ro.

Relates: #788