### PR TITLE
chore: golangci-lint v2.12.0 compat

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - errorlint
     - fatcontext
     - gocritic
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - govet
     - importas
@@ -51,7 +51,7 @@ linters:
         - tooManyResultsChecker
         - unnamedResult
       enable-all: true
-    gomodguard:
+    gomodguard_v2:
       blocked:
         modules:
           - io/ioutil:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,11 +53,10 @@ linters:
       enable-all: true
     gomodguard_v2:
       blocked:
-        modules:
-          - io/ioutil:
-              recommendations:
-                - io
-                - os
+        - module: io/ioutil
+          recommendations:
+            - io
+            - os
     gosec:
       excludes:
         - G115

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -306,7 +306,7 @@ func IntContains(target []int, src int) bool {
 // This method is used only for debugging platform dependent code.
 func attributes(m any) map[string]reflect.Type {
 	typ := reflect.TypeOf(m)
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 


### PR DESCRIPTION
## Summary

golangci-lint v2.12.0 (released 2026-05-01) introduced two changes that break the current CI:

1. **`gomodguard` is deprecated** in favor of `gomodguard_v2` (new major version of the underlying linter library).
2. **A new `inline` analyzer in govet** flags `reflect.Ptr` as a constant that should be inlined to its canonical `reflect.Pointer`.

Together with a separate panic bug in v2.12.0's deprecation-message printer (filed upstream at golangci/golangci-lint#6541), the deprecated-linter warning currently crashes golangci-lint on startup, blocking all CI in this repo.

This PR makes the minimal changes to keep CI green on v2.12.0:

- `.golangci.yml`: rename `gomodguard` → `gomodguard_v2` (two locations: `linters.enable` list and `linters.settings`).
- `internal/common/common.go`: replace `reflect.Ptr` with `reflect.Pointer` (they are aliases, but `Ptr` carries a `//go:fix inline` directive in the standard library).

Verified locally with golangci-lint v2.12.0 (exit 0, no findings) on master and on the integration of all currently-open AIX PRs.

## Notes

- Backward compatibility: `gomodguard_v2` requires golangci-lint v2.12.0 or later. Anyone running an older local golangci-lint will see "unknown linter" until they upgrade. The workflow uses `version: latest`, so CI is always on the new version.
- Even with golangci/golangci-lint#6541 fixed, this PR's renames are still needed because the deprecation is real.
