### PR TITLE
[process]: fix envp leak into Cmdline on darwin

### DIFF
--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -375,29 +375,38 @@ func (p *Process) cmdlineSlice() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The first bytes hold the nargs int, skip it.
-	args := bytes.Split((pargs)[unsafe.Sizeof(int(0)):], []byte{0})
-	var argStr string
-	// The first element is the actual binary/command path.
-	// command := args[0]
-	var argSlice []string
-	// var envSlice []string
-	// All other, non-zero elements are arguments. The first "nargs" elements
-	// are the arguments. Everything else in the slice is then the environment
-	// of the process.
-	for _, arg := range args[1:] {
-		argStr = string(arg)
-		if argStr != "" {
-			if nargs > 0 {
-				argSlice = append(argSlice, argStr)
-				nargs--
-				continue
-			}
-			break
-			// envSlice = append(envSlice, argStr)
-		}
+	return parseCmdline(pargs[unsafe.Sizeof(int(0)):], nargs), nil
+}
+
+// parseCmdline extracts argv from the kern.procargs2 buffer with the leading
+// nargs int already stripped. Layout:
+//
+//	exec_path \0 [padding \0...] argv[0] \0 ... argv[nargs-1] \0 envp[0] \0 ...
+//
+// Empty argv elements within the nargs count are preserved — skipping them
+// would advance past argv[nargs-1] into envp, leaking environment values
+// (potentially secrets) into Cmdline output.
+func parseCmdline(args []byte, nargs int) []string {
+	chunks := bytes.Split(args, []byte{0})
+	if len(chunks) <= 1 {
+		return nil
 	}
-	return argSlice, err
+	// Skip exec_path (chunks[0]) and any padding NULs before argv[0].
+	i := 1
+	for ; i < len(chunks) && len(chunks[i]) == 0; i++ {
+	}
+	if nargs > len(chunks)-i {
+		nargs = len(chunks) - i
+	}
+	if nargs < 0 {
+		nargs = 0
+	}
+	argSlice := make([]string, 0, nargs)
+	for ; nargs > 0; nargs-- {
+		argSlice = append(argSlice, string(chunks[i]))
+		i++
+	}
+	return argSlice
 }
 
 // cmdNameWithContext returns the command name (including spaces) without any arguments

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -375,7 +375,12 @@ func (p *Process) cmdlineSlice() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseCmdline(pargs[unsafe.Sizeof(int(0)):], nargs), nil
+	// procArgs reads nargs as a 4-byte uint32; skip exactly those 4 bytes
+	// (matches Apple's ps using sizeof(nargs)). The previous code used
+	// unsafe.Sizeof(int(0)) which is 8 on 64-bit and would discard the
+	// first 4 bytes of exec_path — harmless only because chunks[0] is
+	// dropped, but logically wrong.
+	return parseCmdline(pargs[4:], nargs), nil
 }
 
 // parseCmdline extracts argv from the kern.procargs2 buffer with the leading
@@ -386,6 +391,12 @@ func (p *Process) cmdlineSlice() ([]string, error) {
 // Empty argv elements within the nargs count are preserved — skipping them
 // would advance past argv[nargs-1] into envp, leaking environment values
 // (potentially secrets) into Cmdline output.
+//
+// Known limitation: a process whose argv[0] is itself an empty string is
+// indistinguishable from padding by this parser, since XNU does not expose
+// the exec/argv alignment boundary. Such a process will still see one envp
+// entry leak. Fixing it requires libgetargv-style alignment math against
+// the XNU exec layout, which is out of scope for this change.
 func parseCmdline(args []byte, nargs int) []string {
 	chunks := bytes.Split(args, []byte{0})
 	if len(chunks) <= 1 {

--- a/process/process_darwin_test.go
+++ b/process/process_darwin_test.go
@@ -43,6 +43,70 @@ func TestNumFDs_NonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseCmdline(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		nargs int
+		want  []string
+	}{
+		{
+			name:  "normal argv stops before envp",
+			input: []byte("/bin/sh\x00\x00sh\x00-c\x00echo hi\x00HOME=/root\x00PATH=/bin\x00"),
+			nargs: 3,
+			want:  []string{"sh", "-c", "echo hi"},
+		},
+		{
+			name:  "empty argv element does not leak envp",
+			input: []byte("/bin/sh\x00\x00sh\x00\x00after\x00SECRET=hunter2\x00"),
+			nargs: 3,
+			want:  []string{"sh", "", "after"},
+		},
+		{
+			name:  "multiple padding NULs between exec_path and argv",
+			input: []byte("/usr/bin/prog\x00\x00\x00\x00\x00prog\x00arg1\x00ENV=value\x00"),
+			nargs: 2,
+			want:  []string{"prog", "arg1"},
+		},
+		{
+			name:  "trailing empty argv element preserved",
+			input: []byte("/bin/cmd\x00\x00cmd\x00arg\x00\x00ENV=x\x00"),
+			nargs: 3,
+			want:  []string{"cmd", "arg", ""},
+		},
+		{
+			name:  "no env present",
+			input: []byte("/bin/cmd\x00\x00cmd\x00only\x00"),
+			nargs: 2,
+			want:  []string{"cmd", "only"},
+		},
+		{
+			name:  "nargs larger than available chunks does not panic",
+			input: []byte("/bin/cmd\x00\x00cmd\x00arg\x00"),
+			nargs: 99,
+			want:  []string{"cmd", "arg", ""},
+		},
+		{
+			name:  "zero nargs returns empty slice",
+			input: []byte("/bin/cmd\x00\x00cmd\x00arg\x00"),
+			nargs: 0,
+			want:  []string{},
+		},
+		{
+			name:  "empty buffer returns nil",
+			input: []byte{},
+			nargs: 0,
+			want:  nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCmdline(tc.input, tc.nargs)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func BenchmarkNumFDs(b *testing.B) {
 	pid := int32(os.Getpid())
 	p, err := NewProcess(pid)


### PR DESCRIPTION
On darwin, `Process.Cmdline()` could leak the first environment
variable of the target process when its argv contained a legitimate
empty element.

`cmdlineSlice` skipped empty entries from `bytes.Split` without
decrementing `nargs` — needed for padding NULs between `exec_path` and
`argv[0]`, but it also skipped real empty argv elements, causing the
loop to consume one chunk past `argv[nargs-1]` (i.e. `envp[0]`).

Extracted parsing into a pure `parseCmdline` helper that skips padding
only until `argv[0]`, then consumes exactly `nargs` chunks including
empties. Added table-driven unit tests covering the leak scenario,
padding variations and bogus `nargs` values.

Fixes #2082