### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -92,19 +92,19 @@ func InfoWithContext(_ context.Context) ([]InfoStat, error) {
 	c.Stepping = int32(stepping)
 	features, err := unix.Sysctl("machdep.cpu.features")
 	if err == nil {
-		for _, v := range strings.Fields(features) {
+		for v := range strings.FieldsSeq(features) {
 			c.Flags = append(c.Flags, strings.ToLower(v))
 		}
 	}
 	leaf7Features, err := unix.Sysctl("machdep.cpu.leaf7_features")
 	if err == nil {
-		for _, v := range strings.Fields(leaf7Features) {
+		for v := range strings.FieldsSeq(leaf7Features) {
 			c.Flags = append(c.Flags, strings.ToLower(v))
 		}
 	}
 	extfeatures, err := unix.Sysctl("machdep.cpu.extfeatures")
 	if err == nil {
-		for _, v := range strings.Fields(extfeatures) {
+		for v := range strings.FieldsSeq(extfeatures) {
 			c.Flags = append(c.Flags, strings.ToLower(v))
 		}
 	}

--- a/host/host_darwin.go
+++ b/host/host_darwin.go
@@ -26,7 +26,7 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		if strings.Contains(line, "IOPlatformUUID") {
 			parts := strings.SplitAfter(line, `" = "`)
 			if len(parts) == 2 {

--- a/net/net_darwin.go
+++ b/net/net_darwin.go
@@ -205,10 +205,10 @@ func IOCountersWithContext(ctx context.Context, pernic bool) ([]IOCountersStat, 
 		if out, err = invoke.CommandWithContext(ctx, "ifconfig", "-l"); err != nil {
 			return nil, err
 		}
-		interfaceNames := strings.Fields(strings.TrimRight(string(out), endOfLine))
+		interfaceNames := strings.FieldsSeq(strings.TrimRight(string(out), endOfLine))
 
 		// for each of the interface name, run netstat if we don't have any stats yet
-		for _, interfaceName := range interfaceNames {
+		for interfaceName := range interfaceNames {
 			truncated := true
 			for index := range nsInterfaces {
 				if nsInterfaces[index].linkID != nil && nsInterfaces[index].stat.Name == interfaceName {

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -264,7 +264,7 @@ func callPsWithContext(ctx context.Context, arg string, pid int32, threadOption,
 		if nameOption {
 			lr = append(lr, l)
 		} else {
-			for _, r := range strings.Split(l, " ") {
+			for r := range strings.SplitSeq(l, " ") {
 				if r == "" {
 					continue
 				}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901