### PR TITLE
fix(mem): map correct PageFile fields for Windows VirtualMemory calcu…

### DIFF
--- a/mem/mem_windows.go
+++ b/mem/mem_windows.go
@@ -48,13 +48,15 @@ func VirtualMemoryWithContext(_ context.Context) (*VirtualMemoryStat, error) {
 	}
 
 	ret := &VirtualMemoryStat{
-		Total:       memInfo.ullTotalPhys,
-		Available:   memInfo.ullAvailPhys,
-		Free:        memInfo.ullAvailPhys,
-		UsedPercent: float64(memInfo.dwMemoryLoad),
+		Total:     memInfo.ullTotalPageFile,
+		Available: memInfo.ullAvailPageFile,
+		Free:      memInfo.ullAvailPageFile,
 	}
 
 	ret.Used = ret.Total - ret.Available
+	if ret.Total > 0 {
+		ret.UsedPercent = float64(ret.Used) / float64(ret.Total) * 100.0
+	}
 	return ret, nil
 }
 


### PR DESCRIPTION
Fixes #1875

## Problem
On Windows systems, `VirtualMemoryWithContext` incorrectly populates the `Total`, `Available`, and `Free` metrics using physical RAM bytes (`ullTotalPhys` / `ullAvailPhys`) instead of reporting the actual system virtual memory space.

## Fix
Updated `mem_windows.go` to correctly map fields from the `GlobalMemoryStatusEx` Win32 API structure:
- Swapped `ullTotalPhys` out for `ullTotalPageFile`.
- Swapped `ullAvailPhys` out for `ullAvailPageFile`.
- Adjusted the `UsedPercent` calculation to dynamically evaluate based on total virtual allocations instead of reading the physical hardware load scalar.

## Tested on
Windows 11 (Cross-compiled and verified via `go test ./mem/... -v`).