### PR TITLE
[cpu][linux]: Add support for CPU clusters in lscpu tests

### DIFF
--- a/cpu/cpu_linux_test.go
+++ b/cpu/cpu_linux_test.go
@@ -51,7 +51,7 @@ func TestCountsAgainstLscpu(t *testing.T) {
 		}
 		t.Errorf("error executing lscpu: %v", err)
 	}
-	var threadsPerCore, coresPerSocket, sockets, books, drawers int
+	var threadsPerCore, coresPerSocket, sockets, clusters, books, drawers int
 	books = 1
 	drawers = 1
 	lines := strings.Split(string(out), "\n")
@@ -63,15 +63,20 @@ func TestCountsAgainstLscpu(t *testing.T) {
 		switch fields[0] {
 		case "Thread(s) per core":
 			threadsPerCore, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
-		case "Core(s) per socket":
+		case "Core(s) per socket", "Core(s) per cluster":
 			coresPerSocket, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
 		case "Socket(s)", "Socket(s) per book":
 			sockets, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
+		case "Cluster(s)":
+			clusters, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
 		case "Book(s) per drawer":
 			books, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
 		case "Drawer(s)":
 			drawers, _ = strconv.Atoi(strings.TrimSpace(fields[1]))
 		}
+	}
+	if sockets == 0 {
+		sockets = clusters
 	}
 	if threadsPerCore == 0 || coresPerSocket == 0 || sockets == 0 {
 		t.Errorf("missing info from lscpu: threadsPerCore=%d coresPerSocket=%d sockets=%d", threadsPerCore, coresPerSocket, sockets)


### PR DESCRIPTION
The lscpu tool can print various fields for CPU Clusters, and no Socket field. Adapt the code for that kind of output, seen on an ARM64 CI system.

See util-linux/sys-utils/lscpu.c:print_summary_cputype().

This was noticed on an ARM64 CI system testing for reproducibility issues, where `lscpu` gives the following output that the test could not parse (from https://tests.reproducible-builds.org/debian/rb-pkg/unstable/arm64/golang-github-shirou-gopsutil.html):

```
Architecture:                            aarch64
CPU op-mode(s):                          32-bit, 64-bit
Byte Order:                              Little Endian
CPU(s):                                  12
On-line CPU(s) list:                     0-11
Vendor ID:                               ARM
Model name:                              Neoverse-N1
Model:                                   1
Thread(s) per core:                      1
Core(s) per cluster:                     12
Socket(s):                               -
Cluster(s):                              1
Stepping:                                r3p1
BogoMIPS:                                50.00
Flags:                                   fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
NUMA node(s):                            1
NUMA node0 CPU(s):                       0-11
Vulnerability Gather data sampling:      Not affected
Vulnerability Indirect target selection: Not affected
Vulnerability Itlb multihit:             Not affected
Vulnerability L1tf:                      Not affected
Vulnerability Mds:                       Not affected
Vulnerability Meltdown:                  Not affected
Vulnerability Mmio stale data:           Not affected
Vulnerability Reg file data sampling:    Not affected
Vulnerability Retbleed:                  Not affected
Vulnerability Spec rstack overflow:      Not affected
Vulnerability Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:                Mitigation; __user pointer sanitization
Vulnerability Spectre v2:                Mitigation; CSV2, BHB
Vulnerability Srbds:                     Not affected
Vulnerability Tsa:                       Not affected
Vulnerability Tsx async abort:           Not affected
Vulnerability Vmscape:                   Not affected
```
