### PR TITLE
[mem]: fix OpenBSD virtual memory on -current

### DIFF
--- a/mem/mem_openbsd_386.go
+++ b/mem/mem_openbsd_386.go
@@ -13,7 +13,7 @@ const (
 )
 
 const (
-	sizeOfBcachestats = 0x90
+	sizeOfBcachestats = 0x68
 )
 
 type Bcachestats struct {
@@ -27,12 +27,7 @@ type Bcachestats struct {
 	Numreads      int64
 	Cachehits     int64
 	Busymapped    int64
-	Dmapages      int64
-	Highpages     int64
 	Delwribufs    int64
 	Kvaslots      int64
 	Avail         int64
-	Highflips     int64
-	Highflops     int64
-	Dmaflips      int64
 }

--- a/mem/mem_openbsd_amd64.go
+++ b/mem/mem_openbsd_amd64.go
@@ -11,7 +11,7 @@ const (
 )
 
 const (
-	sizeOfBcachestats = 0x78
+	sizeOfBcachestats = 0x68
 )
 
 type Bcachestats struct {
@@ -25,8 +25,6 @@ type Bcachestats struct {
 	Numreads      int64
 	Cachehits     int64
 	Busymapped    int64
-	Dmapages      int64
-	Highpages     int64
 	Delwribufs    int64
 	Kvaslots      int64
 	Avail         int64

--- a/mem/mem_openbsd_arm.go
+++ b/mem/mem_openbsd_arm.go
@@ -13,7 +13,7 @@ const (
 )
 
 const (
-	sizeOfBcachestats = 0x90
+	sizeOfBcachestats = 0x68
 )
 
 type Bcachestats struct {
@@ -27,12 +27,7 @@ type Bcachestats struct {
 	Numreads      int64
 	Cachehits     int64
 	Busymapped    int64
-	Dmapages      int64
-	Highpages     int64
 	Delwribufs    int64
 	Kvaslots      int64
 	Avail         int64
-	Highflips     int64
-	Highflops     int64
-	Dmaflips      int64
 }

--- a/mem/mem_openbsd_arm64.go
+++ b/mem/mem_openbsd_arm64.go
@@ -13,7 +13,7 @@ const (
 )
 
 const (
-	sizeOfBcachestats = 0x90
+	sizeOfBcachestats = 0x68
 )
 
 type Bcachestats struct {
@@ -27,12 +27,7 @@ type Bcachestats struct {
 	Numreads      int64
 	Cachehits     int64
 	Busymapped    int64
-	Dmapages      int64
-	Highpages     int64
 	Delwribufs    int64
 	Kvaslots      int64
 	Avail         int64
-	Highflips     int64
-	Highflops     int64
-	Dmaflips      int64
 }

--- a/mem/mem_openbsd_riscv64.go
+++ b/mem/mem_openbsd_riscv64.go
@@ -13,7 +13,7 @@ const (
 )
 
 const (
-	sizeOfBcachestats = 0x90
+	sizeOfBcachestats = 0x68
 )
 
 type Bcachestats struct {
@@ -27,12 +27,7 @@ type Bcachestats struct {
 	Numreads      int64
 	Cachehits     int64
 	Busymapped    int64
-	Dmapages      int64
-	Highpages     int64
 	Delwribufs    int64
 	Kvaslots      int64
 	Avail         int64
-	Highflips     int64
-	Highflops     int64
-	Dmaflips      int64
 }


### PR DESCRIPTION
VirtualMemory() on OpenBSD reads the vfs.generic.bcachestat sysctl into the generated Bcachestats struct and rejects the result when the kernel returns fewer bytes than sizeOfBcachestats:

```
    error getting virtual memory info: short syscall ret 104 bytes
```

OpenBSD removed the buffer cache "flipper" in kernel commit [ff03df9b11f](https://github.com/openbsd/src/commit/ff03df9b11fd39a4f2b179d937db13ec424c06fa) ("Remove the buffer flipper", 2026-06-10), which deletes the dmapages, highpages, highflips, highflops and dmaflips fields from struct bcachestats (sys/sys/mount.h). struct bcachestats is now 13 int64_t fields = 104 bytes on every architecture.

https://marc.info/?l=openbsd-cvs&m=178104984860610&w=2

The generated per-arch files still expect the larger struct (0x78 on amd64, 0x90 on the others), so the length guard tripped and mem metrics broke on -current.

Regenerate the struct for all OpenBSD arches: drop the removed fields and set sizeOfBcachestats to 0x68 (104). Only Numbufpages (offset 8) is consumed, and the guard is `length < sizeOfBcachestats`, so this stays compatible with older OpenBSD releases that return a larger struct.