### PR TITLE
fix: harden parsers against malformed/truncated input

### DIFF
--- a/cpu/cpu_freebsd.go
+++ b/cpu/cpu_freebsd.go
@@ -81,6 +81,9 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(buf) < int(unsafe.Sizeof(cpuTimes{})) {
+		return nil, fmt.Errorf("unexpected size: kern.cp_time, %d", len(buf))
+	}
 
 	times := (*cpuTimes)(unsafe.Pointer(&buf[0]))
 	return []TimesStat{*timeStat("cpu-total", times)}, nil

--- a/cpu/cpu_netbsd.go
+++ b/cpu/cpu_netbsd.go
@@ -44,6 +44,9 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		if len(buf) < int(unsafe.Sizeof(cpuTimes{})) {
+			return ret, fmt.Errorf("unexpected size: kern.cp_time, %d", len(buf))
+		}
 		times := (*cpuTimes)(unsafe.Pointer(&buf[0]))
 		ret = append(ret, TimesStat{
 			CPU:    "cpu-total",
@@ -67,6 +70,9 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 		buf, _, err := common.CallSyscall(mib)
 		if err != nil {
 			return ret, err
+		}
+		if len(buf) < int(unsafe.Sizeof(cpuTimes{})) {
+			continue
 		}
 
 		stats := (*cpuTimes)(unsafe.Pointer(&buf[0]))

--- a/cpu/cpu_openbsd.go
+++ b/cpu/cpu_openbsd.go
@@ -62,6 +62,9 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 		if err != nil {
 			return ret, err
 		}
+		if len(buf) < int(unsafe.Sizeof(cpuTimes{})) {
+			return ret, fmt.Errorf("unexpected size: kern.cp_time, %d", len(buf))
+		}
 		times := (*cpuTimes)(unsafe.Pointer(&buf[0]))
 		ret = append(ret, TimesStat{
 			CPU:    "cpu-total",
@@ -85,6 +88,9 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 		buf, _, err := common.CallSyscall(mib)
 		if err != nil {
 			return ret, err
+		}
+		if len(buf) < int(unsafe.Sizeof(cpuStats{})) {
+			continue
 		}
 
 		stats := (*cpuStats)(unsafe.Pointer(&buf[0]))

--- a/disk/disk_aix.go
+++ b/disk/disk_aix.go
@@ -23,6 +23,10 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	if strings.HasPrefix(name, "/dev/") {
 		return "", errors.New("devices on /dev are not physical disks on aix")
 	}
+	// Reject names that would be interpreted as command-line options by lscfg.
+	if strings.HasPrefix(name, "-") {
+		return "", errors.New("invalid device name")
+	}
 	out, err := invoke.CommandWithContext(ctx, "lscfg", "-vl", name)
 	if err != nil {
 		return "", err

--- a/disk/disk_freebsd.go
+++ b/disk/disk_freebsd.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -166,6 +167,10 @@ func getFsType(stat unix.Statfs_t) string {
 }
 
 func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
+	// Reject names that would be interpreted as command-line options by geom.
+	if strings.HasPrefix(name, "-") {
+		return "", errors.New("invalid device name")
+	}
 	geomOut, err := invoke.CommandWithContext(ctx, "geom", "disk", "list", name)
 	if err != nil {
 		return "", fmt.Errorf("exec geom: %w", err)

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -305,6 +305,9 @@ func parseFieldsOnMounts(lines []string, all bool, fs []string) []PartitionStat 
 	ret := make([]PartitionStat, 0, len(lines))
 	for _, line := range lines {
 		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
 
 		d := PartitionStat{
 			Device:     fields[0],

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -100,7 +100,10 @@ func CgroupCPUUsage(containerID, base string) (float64, error) {
 }
 
 func CgroupCPUWithContext(ctx context.Context, containerID, base string) (*CgroupCPUStat, error) {
-	statfile := getCgroupFilePath(ctx, containerID, base, "cpuacct", "cpuacct.stat")
+	statfile, err := getCgroupFilePath(ctx, containerID, base, "cpuacct", "cpuacct.stat")
+	if err != nil {
+		return nil, err
+	}
 	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return nil, err
@@ -136,7 +139,10 @@ func CgroupCPUWithContext(ctx context.Context, containerID, base string) (*Cgrou
 }
 
 func CgroupCPUUsageWithContext(ctx context.Context, containerID, base string) (float64, error) {
-	usagefile := getCgroupFilePath(ctx, containerID, base, "cpuacct", "cpuacct.usage")
+	usagefile, err := getCgroupFilePath(ctx, containerID, base, "cpuacct", "cpuacct.usage")
+	if err != nil {
+		return 0.0, err
+	}
 	lines, err := common.ReadLinesOffsetN(usagefile, 0, 1)
 	if err != nil {
 		return 0.0, err
@@ -171,7 +177,10 @@ func CgroupMem(containerID, base string) (*CgroupMemStat, error) {
 }
 
 func CgroupMemWithContext(ctx context.Context, containerID, base string) (*CgroupMemStat, error) {
-	statfile := getCgroupFilePath(ctx, containerID, base, "memory", "memory.stat")
+	statfile, err := getCgroupFilePath(ctx, containerID, base, "memory", "memory.stat")
+	if err != nil {
+		return nil, err
+	}
 
 	// empty containerID means all cgroup
 	if containerID == "" {
@@ -275,7 +284,12 @@ func CgroupMemDockerWithContext(ctx context.Context, containerID string) (*Cgrou
 }
 
 // getCgroupFilePath constructs file path to get targeted stats file.
-func getCgroupFilePath(ctx context.Context, containerID, base, target, file string) string {
+func getCgroupFilePath(ctx context.Context, containerID, base, target, file string) (string, error) {
+	// Prevent a caller-supplied containerID from escaping the cgroup base
+	// directory via path separators or ".." traversal.
+	if strings.ContainsAny(containerID, `/\`) || strings.Contains(containerID, "..") {
+		return "", fmt.Errorf("invalid container ID %q", containerID)
+	}
 	if base == "" {
 		base = common.HostSysWithContext(ctx, fmt.Sprintf("fs/cgroup/%s/docker", target))
 	}
@@ -286,12 +300,15 @@ func getCgroupFilePath(ctx context.Context, containerID, base, target, file stri
 			common.HostSysWithContext(ctx, fmt.Sprintf("fs/cgroup/%s/system.slice", target)), "docker-"+containerID+".scope", file)
 	}
 
-	return statfile
+	return statfile, nil
 }
 
 // getCgroupMemFile reads a cgroup file and return the contents as uint64.
 func getCgroupMemFile(ctx context.Context, containerID, base, file string) (uint64, error) {
-	statfile := getCgroupFilePath(ctx, containerID, base, "memory", file)
+	statfile, err := getCgroupFilePath(ctx, containerID, base, "memory", file)
+	if err != nil {
+		return 0, err
+	}
 	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return 0, err

--- a/load/load_openbsd.go
+++ b/load/load_openbsd.go
@@ -4,6 +4,7 @@
 package load
 
 import (
+	"fmt"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -13,6 +14,9 @@ func getForkStat() (forkstat, error) {
 	b, err := unix.SysctlRaw("kern.forkstat")
 	if err != nil {
 		return forkstat{}, err
+	}
+	if len(b) < int(unsafe.Sizeof(forkstat{})) {
+		return forkstat{}, fmt.Errorf("unexpected size: kern.forkstat, %d", len(b))
 	}
 	return *(*forkstat)(unsafe.Pointer((&b[0]))), nil
 }

--- a/mem/mem_linux.go
+++ b/mem/mem_linux.go
@@ -479,7 +479,7 @@ func parseSwapsFile(ctx context.Context, r io.Reader) ([]*SwapDevice, error) {
 
 	// Check header headerFields are as expected
 	headerFields := strings.Fields(scanner.Text())
-	if len(headerFields) < usedCol {
+	if len(headerFields) <= usedCol {
 		return nil, fmt.Errorf("couldn't parse %q: too few fields in header", swapsFilePath)
 	}
 	if headerFields[nameCol] != "Filename" {
@@ -495,7 +495,7 @@ func parseSwapsFile(ctx context.Context, r io.Reader) ([]*SwapDevice, error) {
 	var swapDevices []*SwapDevice
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		if len(fields) < usedCol {
+		if len(fields) <= usedCol {
 			return nil, fmt.Errorf("couldn't parse %q: too few fields", swapsFilePath)
 		}
 

--- a/mem/mem_linux_test.go
+++ b/mem/mem_linux_test.go
@@ -218,3 +218,17 @@ func TestParseSwapsFile_EmptyFile(t *testing.T) {
 	_, err := parseSwapsFile(context.Background(), strings.NewReader(""))
 	assert.Error(t, err)
 }
+
+// A data row with too few columns must return an error, not panic.
+func TestParseSwapsFile_ShortDataRow(t *testing.T) {
+	shortRow := "Filename\tType\tSize\tUsed\tPriority\n/dev/dm-2\tpartition\t1024\n"
+	_, err := parseSwapsFile(context.Background(), strings.NewReader(shortRow))
+	assert.Error(t, err)
+}
+
+// A header row with too few columns must return an error, not panic.
+func TestParseSwapsFile_ShortHeader(t *testing.T) {
+	shortHeader := "Filename\tType\tSize\n"
+	_, err := parseSwapsFile(context.Background(), strings.NewReader(shortHeader))
+	assert.Error(t, err)
+}

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -50,6 +50,10 @@ func IOCountersByFileWithContext(_ context.Context, pernic bool, filename string
 		return nil, err
 	}
 
+	if len(lines) < 2 {
+		return nil, fmt.Errorf("malformed %s: expected at least 2 header lines, got %d", filename, len(lines))
+	}
+
 	statlen := len(lines) - 1
 
 	ret := make([]IOCountersStat, 0, statlen)
@@ -764,7 +768,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 	// skip first line
 	for _, line := range lines[1:] {
 		tokens := strings.Fields(string(line))
-		if len(tokens) < 6 {
+		if len(tokens) < 7 {
 			continue
 		}
 		st, err := strconv.ParseInt(tokens[4], 10, 32)

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -350,6 +350,9 @@ func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {
 			continue
 		}
 		fields := splitProcStat(statContents)
+		if len(fields) < 5 {
+			continue
+		}
 		pid, err := strconv.ParseInt(fields[1], 10, 32)
 		if err != nil {
 			continue
@@ -756,6 +759,9 @@ func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat
 		return nil, nil, err
 	}
 	fields := strings.Split(string(contents), " ")
+	if len(fields) < 6 {
+		return nil, nil, fmt.Errorf("malformed statm file: expected at least 6 fields, got %d", len(fields))
+	}
 
 	vms, err := strconv.ParseUint(fields[0], 10, 64)
 	if err != nil {
@@ -861,6 +867,12 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 			// Ensure we have a copy and not reference into slice
 			p.name = string([]byte(p.name))
 		case "State":
+			if value == "" {
+				// Clear rather than leave a stale status from a previous
+				// parse, since Process objects can be reused across calls.
+				p.status = ""
+				continue
+			}
 			p.status = convertStatusChar(value[0:1])
 			// Ensure we have a copy and not reference into slice
 			p.status = string([]byte(p.status))
@@ -1195,6 +1207,12 @@ func readPidsFromDir(path string) ([]int32, error) {
 func splitProcStat(content []byte) []string {
 	nameStart := bytes.IndexByte(content, '(')
 	nameEnd := bytes.LastIndexByte(content, ')')
+	// Guard against a malformed/truncated stat file that is missing the
+	// parentheses around comm, which would otherwise cause the slice
+	// operations below to panic. Callers validate the field count.
+	if nameStart < 0 || nameEnd < nameStart || nameEnd+2 > len(content) {
+		return nil
+	}
 	restFields := strings.Fields(string(content[nameEnd+2:])) // +2 skip ') '
 	name := content[nameStart+1 : nameEnd]
 	pid := strings.TrimSpace(string(content[:nameStart]))

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -112,6 +112,26 @@ func TestSplitProcStat(t *testing.T) {
 	}
 }
 
+func TestSplitProcStat_malformed(t *testing.T) {
+	// Malformed/truncated stat contents must not panic; splitProcStat
+	// returns nil so callers' field-count checks can reject them.
+	cases := []string{
+		"",             // empty
+		"123",          // no parentheses
+		"123 name S 4", // no parentheses, plain fields
+		"123 (name",    // missing closing paren
+		"name) S 4",    // missing opening paren
+		"123 (name)",   // ')' as final byte, no trailing fields
+	}
+	for _, content := range cases {
+		t.Run(content, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_ = splitProcStat([]byte(content))
+			})
+		})
+	}
+}
+
 func TestSplitProcStat_fromFile(t *testing.T) {
 	pids, err := os.ReadDir("testdata/linux/")
 	require.NoError(t, err)

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"sort"
@@ -94,6 +95,9 @@ func (p *Process) CmdlineSliceWithContext(_ context.Context) ([]string, error) {
 	pointers followed by the strings themselves. The last char
 	pointer is a NULL pointer. */
 	var strParts []string
+	if len(buf) == 0 {
+		return strParts, nil
+	}
 	r := bytes.NewReader(buf)
 	baseAddr := uintptr(unsafe.Pointer(&buf[0]))
 	for {
@@ -105,7 +109,17 @@ func (p *Process) CmdlineSliceWithContext(_ context.Context) ([]string, error) {
 			break
 		}
 		offset := argvp - baseAddr
-		length := uintptr(bytes.IndexByte(buf[offset:], 0))
+		// Reject a malformed/truncated sysctl reply whose pointers fall
+		// outside buf or whose strings are not NUL-terminated, which would
+		// otherwise cause the slice operations below to panic.
+		if offset >= uintptr(len(buf)) {
+			return nil, fmt.Errorf("malformed KERN_PROC_ARGV reply for pid %d: argv pointer out of bounds", p.Pid)
+		}
+		idx := bytes.IndexByte(buf[offset:], 0)
+		if idx < 0 {
+			return nil, fmt.Errorf("malformed KERN_PROC_ARGV reply for pid %d: argv string not NUL-terminated", p.Pid)
+		}
+		length := uintptr(idx)
 		str := string(buf[offset : offset+length])
 		strParts = append(strParts, str)
 	}


### PR DESCRIPTION
Add missing length and bounds checks so that malformed, truncated, or empty /proc files and BSD sysctl buffers return an error instead of panicking. Reachable via HOST_PROC-style overrides or transient short reads while a process is terminating.

- process: guard splitProcStat against missing parentheses, add field-count checks in ChildrenWithContext and fillFromStatm, guard empty State value, and bounds-check OpenBSD CmdlineSlice pointers
- mem: fix off-by-one guard in parseSwapsFile
- disk: skip short lines in parseFieldsOnMounts
- net: guard IOCountersByFile short files and fix processUnix off-by-one
- cpu/load (bsd): validate sysctl buffer size before unsafe cast

Also validate caller-supplied input in public APIs to prevent argument injection and path traversal:

- disk.SerialNumber rejects device names starting with '-' (freebsd/aix)
- docker cgroup path rejects containerID with '/', '\' or '..'

Add tests covering the malformed-input cases.