### PR TITLE
[cpu][windows]: compute cpu-total times from integer ticks

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -122,18 +122,19 @@ func TimesWithContext(_ context.Context, percpu bool) ([]TimesStat, error) {
 		return nil, err
 	}
 
-	LOT := float64(0.0000001)
-	HIT := (LOT * 4294967296.0)
-	idle := ((HIT * float64(lpIdleTime.DwHighDateTime)) + (LOT * float64(lpIdleTime.DwLowDateTime)))
-	user := ((HIT * float64(lpUserTime.DwHighDateTime)) + (LOT * float64(lpUserTime.DwLowDateTime)))
-	kernel := ((HIT * float64(lpKernelTime.DwHighDateTime)) + (LOT * float64(lpKernelTime.DwLowDateTime)))
-	system := (kernel - idle)
+	// Do all arithmetic on the integer tick counts and convert to float64
+	// only once, mirroring perCPUTimes. Converting each FILETIME half to
+	// float64 first loses precision on large counters and can make the
+	// returned values non-monotonic. See issue #2110.
+	idle := uint64(lpIdleTime.DwHighDateTime)<<32 | uint64(lpIdleTime.DwLowDateTime)
+	user := uint64(lpUserTime.DwHighDateTime)<<32 | uint64(lpUserTime.DwLowDateTime)
+	kernel := uint64(lpKernelTime.DwHighDateTime)<<32 | uint64(lpKernelTime.DwLowDateTime)
 
 	ret = append(ret, TimesStat{
 		CPU:    "cpu-total",
-		Idle:   float64(idle),
-		User:   float64(user),
-		System: float64(system),
+		Idle:   float64(idle) / ClocksPerSec,
+		User:   float64(user) / ClocksPerSec,
+		System: float64(kernel-idle) / ClocksPerSec, // kernel time includes idle time
 	})
 	return ret, nil
 }


### PR DESCRIPTION
Fixes #2110.

`Times(percpu=false)` converts each FILETIME half of the `GetSystemTimes` counters to float64 separately and then computes `system = kernel - idle` in floating point. On machines with a few days of uptime the cumulative counters are large enough that the conversion carries a rounding error of around 2^-30 s, and the error changes from call to call. As a result the returned `System`, `Idle` and `User` values are not monotonic even though the underlying Windows counters are, and consumers computing usage deltas occasionally see small negative values (see influxdata/telegraf#18141).

This change reassembles the full 64-bit tick counts from the FILETIME halves, does the subtraction on integers, and converts to seconds once, the same way `perCPUTimes` already does it. Since integer-to-float conversion and division by a constant are monotone, the reported values can no longer appear to decrease.

Running the simulation from #2110 against the new conversion shows 0 phantom decreases in 100000 intervals, versus 27674 with the current code.
