### PR TITLE
feat: add psutil comparison tests for cpu, mem and load

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,19 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
+      # psutil enables the *_Against_Psutil comparison tests; they skip
+      # when it is missing, so both steps are best-effort.
+      - name: Install Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+        continue-on-error: true
+      - name: Install psutil
+        # Pinned like the SHA-pinned actions above: the *_Against_Psutil
+        # tests are verified against this psutil version; bump deliberately
+        # after re-checking the comparisons.
+        run: python -m pip install psutil==7.2.2
+        continue-on-error: true
       - name: Test
         run: |
           go test -coverprofile='coverage.out' -covermode=atomic ./...

--- a/cpu/cpu_psutil_test.go
+++ b/cpu/cpu_psutil_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package cpu
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+	pt "github.com/shirou/gopsutil/v4/internal/common/psutiltest"
+)
+
+const (
+	cpuTimesSlack = 0.2 // seconds; rounding differences between samples
+	iowaitDelta   = 1.0 // seconds; iowait can decrease, see proc(5)
+)
+
+// Percent and Info are deliberately not compared: Percent is an
+// instantaneous value and Info has no direct psutil equivalent.
+
+func TestCounts_Against_Psutil(t *testing.T) {
+	pt.RequirePsutil(t)
+
+	// The linux implementation is a direct port of psutil's algorithm
+	// (see the links in cpu_linux.go), so the counts must match exactly.
+	for _, tc := range []struct {
+		name    string
+		logical bool
+		expr    string
+	}{
+		{"logical", true, "psutil.cpu_count(logical=True)"},
+		{"physical", false, "psutil.cpu_count(logical=False)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Counts(tc.logical)
+			if errors.Is(err, common.ErrNotImplementedError) {
+				t.Skip("not implemented")
+			}
+			require.NoError(t, err)
+
+			want, err := pt.Eval[*int](t, tc.expr)
+			require.NoError(t, err)
+			if want == nil {
+				// psutil returns None for a count it cannot determine
+				// (e.g. some containers).
+				t.Skip("psutil could not determine the count")
+			}
+			assert.Equal(t, *want, got)
+		})
+	}
+}
+
+type pyCPUTimes struct {
+	User    float64 `json:"user"`
+	System  float64 `json:"system"`
+	Idle    float64 `json:"idle"`
+	Nice    float64 `json:"nice"`
+	Iowait  float64 `json:"iowait"`
+	Irq     float64 `json:"irq"`
+	Softirq float64 `json:"softirq"`
+	Steal   float64 `json:"steal"`
+}
+
+func TestTimes_Against_Psutil(t *testing.T) {
+	pt.RequirePsutil(t)
+
+	before, err := pt.Eval[pyCPUTimes](t, "psutil.cpu_times(percpu=False)")
+	require.NoError(t, err)
+
+	times, err := Times(false)
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+	require.Len(t, times, 1)
+	got := times[0]
+
+	after, err := pt.Eval[pyCPUTimes](t, "psutil.cpu_times(percpu=False)")
+	require.NoError(t, err)
+
+	// user/system/idle exist on all supported platforms and both sides
+	// derive them identically (linux: /proc/stat; windows: GetSystemTimes
+	// with system = kernel - idle; darwin: mach host statistics).
+	pt.AssertBracketedDelta(t, "User", before.User, got.User, after.User, cpuTimesSlack)
+	pt.AssertBracketedDelta(t, "System", before.System, got.System, after.System, cpuTimesSlack)
+	pt.AssertBracketedDelta(t, "Idle", before.Idle, got.Idle, after.Idle, cpuTimesSlack)
+
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		// nice is also common to linux (/proc/stat) and darwin, where both
+		// sides read the same mach nice tick counter.
+		pt.AssertBracketedDelta(t, "Nice", before.Nice, got.Nice, after.Nice, cpuTimesSlack)
+	}
+
+	if runtime.GOOS == "linux" {
+		// The remaining fields exist only in linux's /proc/stat accounting,
+		// which both sides report raw, in seconds.
+		pt.AssertBracketedDelta(t, "Irq", before.Irq, got.Irq, after.Irq, cpuTimesSlack)
+		pt.AssertBracketedDelta(t, "Softirq", before.Softirq, got.Softirq, after.Softirq, cpuTimesSlack)
+		pt.AssertBracketedDelta(t, "Steal", before.Steal, got.Steal, after.Steal, cpuTimesSlack)
+		// iowait can decrease (see proc(5)) and, as a sum over all CPUs,
+		// can legitimately advance by more than the slack between two
+		// samples on busy many-core hosts, so bracket it between the
+		// smaller and larger psutil sample with slack on both ends.
+		lo, hi := min(before.Iowait, after.Iowait), max(before.Iowait, after.Iowait)
+		pt.AssertBracketedDelta(t, "Iowait", lo, got.Iowait, hi, iowaitDelta)
+	}
+}
+
+func TestTimesPerCPU_Against_Psutil(t *testing.T) {
+	pt.RequirePsutil(t)
+
+	before, err := pt.Eval[[]pyCPUTimes](t, "psutil.cpu_times(percpu=True)")
+	require.NoError(t, err)
+
+	times, err := Times(true)
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+
+	after, err := pt.Eval[[]pyCPUTimes](t, "psutil.cpu_times(percpu=True)")
+	require.NoError(t, err)
+
+	require.Len(t, times, len(before))
+	require.Len(t, after, len(before))
+
+	// Both sides enumerate CPUs in the same order (/proc/stat order on linux).
+	for i, got := range times {
+		pt.AssertBracketedDelta(t, got.CPU+".User", before[i].User, got.User, after[i].User, cpuTimesSlack)
+		pt.AssertBracketedDelta(t, got.CPU+".System", before[i].System, got.System, after[i].System, cpuTimesSlack)
+		pt.AssertBracketedDelta(t, got.CPU+".Idle", before[i].Idle, got.Idle, after[i].Idle, cpuTimesSlack)
+	}
+}

--- a/internal/common/psutiltest/assert.go
+++ b/internal/common/psutiltest/assert.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package psutiltest
+
+import (
+	"cmp"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// DefaultTimeout and DefaultTick are the recommended budgets for
+// require.EventuallyWithT when resampling fluctuating gauges; the
+// timeout spans at least one loadavg update interval (5 seconds).
+const (
+	DefaultTimeout = 10 * time.Second
+	DefaultTick    = 2 * time.Second
+)
+
+// AssertBracketed asserts before <= got <= after. Use it for monotonic
+// counters: sample psutil before and after the gopsutil call and the
+// gopsutil value must fall inside the bracket.
+func AssertBracketed[T cmp.Ordered](tb testing.TB, field string, before, got, after T) {
+	tb.Helper()
+	if got < before || got > after {
+		tb.Errorf("%s: gopsutil value %v not in psutil bracket [%v, %v]", field, got, before, after)
+	}
+}
+
+// AssertBracketedDelta is the float64 form of AssertBracketed with
+// slack for rounding differences: before-slack <= got <= after+slack.
+func AssertBracketedDelta(tb testing.TB, field string, before, got, after, slack float64) {
+	tb.Helper()
+	if got < before-slack || got > after+slack {
+		tb.Errorf("%s: gopsutil value %v not in psutil bracket [%v, %v] (slack %v)", field, got, before, after, slack)
+	}
+}
+
+// CheckWithinTolerance returns an error unless
+// |expected-actual| <= max(rel*|expected|, absFloor). The absolute
+// floor keeps small or zero expected values (e.g. Buffers) from turning
+// a purely relative comparison into a flake. The error form suits
+// assert.NoError inside require.EventuallyWithT callbacks.
+func CheckWithinTolerance(field string, expected, actual, rel, absFloor float64) error {
+	tol := math.Max(rel*math.Abs(expected), absFloor)
+	if diff := math.Abs(expected - actual); diff > tol {
+		return fmt.Errorf("%s: psutil %v vs gopsutil %v differ by %v (tolerance %v)", field, expected, actual, diff, tol)
+	}
+	return nil
+}

--- a/internal/common/psutiltest/psutiltest.go
+++ b/internal/common/psutiltest/psutiltest.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package psutiltest provides helpers for tests that compare gopsutil
+// results against Python psutil, the reference implementation.
+//
+// Tests are skipped when no python interpreter with psutil is
+// available — Eval enforces this on its own, and RequirePsutil does the
+// same up front so a test can skip before doing any gopsutil work.
+// Setting the GOPSUTIL_PSUTIL_TEST environment variable turns those
+// skips into failures (strict mode).
+package psutiltest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// EnvStrict is the environment variable that, when set to a non-empty
+// value, turns "python/psutil not available" skips into test failures.
+// Intended for CI environments where psutil is expected to be installed.
+const EnvStrict = "GOPSUTIL_PSUTIL_TEST"
+
+// EnvPython is the environment variable that overrides python
+// interpreter discovery with an explicit path.
+const EnvPython = "GOPSUTIL_PSUTIL_PYTHON"
+
+const evalTimeout = 30 * time.Second
+
+// pyWrapper converts the result of the python expression given in
+// sys.argv[1] (psutil namedtuples, dicts, lists or scalars) to JSON on
+// stdout.
+const pyWrapper = `
+import json, sys
+import psutil
+
+def conv(o):
+    if hasattr(o, "_asdict"):
+        o = o._asdict()
+    if isinstance(o, dict):
+        return {str(k): conv(v) for k, v in o.items()}
+    if isinstance(o, (list, tuple, set, frozenset)):
+        return [conv(v) for v in o]
+    if isinstance(o, (bool, int, float, str)) or o is None:
+        return o
+    return str(o)
+
+print(json.dumps(conv(eval(sys.argv[1]))))
+`
+
+type pythonInfo struct {
+	path    string
+	version string
+	err     error
+}
+
+var findPython = sync.OnceValue(func() pythonInfo {
+	// "python" after "python3" covers Windows, where the interpreter is
+	// usually named python.exe and "python3" may resolve to the Microsoft
+	// Store shim, which fails the import probe below.
+	candidates := []string{os.Getenv(EnvPython), "python3", "python"}
+	var reasons []string
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		path, err := exec.LookPath(candidate)
+		if err != nil {
+			reasons = append(reasons, err.Error())
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
+		out, err := exec.CommandContext(ctx, path, "-c", "import psutil, sys; sys.stdout.write(psutil.__version__)").Output()
+		cancel()
+		if err != nil {
+			reasons = append(reasons, fmt.Sprintf("%s: %s", path, execErrDetail(err)))
+			continue
+		}
+		return pythonInfo{path: path, version: strings.TrimSpace(string(out))}
+	}
+	return pythonInfo{err: fmt.Errorf("python with psutil not found: %s", strings.Join(reasons, "; "))}
+})
+
+var logVersionOnce sync.Once
+
+// RequirePsutil skips the test (or fails it, in strict mode) unless a
+// python interpreter that can import psutil is available, and logs the
+// interpreter path and psutil version once per test binary. Calling it
+// at the start of a test is recommended so the test skips before doing
+// any gopsutil work, but Eval enforces the same contract by itself.
+func RequirePsutil(tb testing.TB) {
+	tb.Helper()
+	info := requirePython(tb)
+	logVersionOnce.Do(func() {
+		tb.Logf("using %s (psutil %s)", info.path, info.version)
+	})
+}
+
+// requirePython enforces the availability contract: skip by default,
+// fail when strict mode (EnvStrict) is enabled.
+func requirePython(tb testing.TB) pythonInfo {
+	tb.Helper()
+	info := findPython()
+	if info.err != nil {
+		if os.Getenv(EnvStrict) != "" {
+			tb.Fatalf("%s is set but %v", EnvStrict, info.err)
+		}
+		tb.Skipf("%v", info.err)
+	}
+	return info
+}
+
+// Eval evaluates a python expression with psutil pre-imported, converts
+// the result to JSON and decodes it into a T. It skips the test (or
+// fails it, in strict mode) when no python with psutil is available;
+// any other failure is returned as an error so retrying callers
+// (require.EventuallyWithT callbacks) can handle it.
+func Eval[T any](tb testing.TB, expr string) (T, error) {
+	tb.Helper()
+	var out T
+	info := requirePython(tb)
+	ctx, cancel := context.WithTimeout(context.Background(), evalTimeout)
+	defer cancel()
+	// #nosec G204 -- test-only helper; the interpreter is probed above and
+	// expr always comes from test code constants.
+	raw, err := exec.CommandContext(ctx, info.path, "-c", pyWrapper, expr).Output()
+	if err != nil {
+		return out, fmt.Errorf("eval %q: %s", expr, execErrDetail(err))
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("eval %q: unmarshal %q: %w", expr, raw, err)
+	}
+	return out, nil
+}
+
+func execErrDetail(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Sprintf("%v: %s", err, exitErr.Stderr)
+	}
+	return err.Error()
+}

--- a/internal/common/psutiltest/psutiltest_test.go
+++ b/internal/common/psutiltest/psutiltest_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package psutiltest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEval(t *testing.T) {
+	RequirePsutil(t)
+
+	// Round-trip of plain python values through the JSON wrapper.
+	type pyValues struct {
+		A []any   `json:"a"`
+		B *string `json:"b"`
+	}
+	out, err := Eval[pyValues](t, `{"a": [1, 2.5, "x"], "b": None}`)
+	require.NoError(t, err)
+	require.Len(t, out.A, 3)
+	assert.InDelta(t, 1.0, out.A[0], 0.0001)
+	assert.InDelta(t, 2.5, out.A[1], 0.0001)
+	assert.Equal(t, "x", out.A[2])
+	assert.Nil(t, out.B)
+
+	// A psutil scalar.
+	boot, err := Eval[float64](t, "psutil.boot_time()")
+	require.NoError(t, err)
+	assert.Positive(t, boot)
+
+	// A psutil namedtuple decodes via its _asdict() keys.
+	type pyVirtualMemory struct {
+		Total uint64 `json:"total"`
+	}
+	vm, err := Eval[pyVirtualMemory](t, "psutil.virtual_memory()")
+	require.NoError(t, err)
+	assert.Positive(t, vm.Total)
+}
+
+func TestEvalFailure(t *testing.T) {
+	RequirePsutil(t)
+
+	_, err := Eval[any](t, "1/0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ZeroDivisionError")
+}

--- a/load/load_psutil_test.go
+++ b/load/load_psutil_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package load
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+	pt "github.com/shirou/gopsutil/v4/internal/common/psutiltest"
+)
+
+const loadDelta = 0.5 // absolute; loadavg only updates every 5 seconds
+
+func TestAvg_Against_Psutil(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Both sides emulate a load average on windows with background
+		// sampling and different warm-up behavior; not comparable.
+		t.Skip("load average is emulated on windows")
+	}
+	pt.RequirePsutil(t)
+
+	_, err := Avg()
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		v, err := Avg()
+		if !assert.NoError(c, err) {
+			return
+		}
+		py, err := pt.Eval[[]float64](t, "psutil.getloadavg()")
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.Len(c, py, 3) {
+			return
+		}
+		assert.NoError(c, pt.CheckWithinTolerance("Load1", py[0], v.Load1, 0, loadDelta))
+		assert.NoError(c, pt.CheckWithinTolerance("Load5", py[1], v.Load5, 0, loadDelta))
+		assert.NoError(c, pt.CheckWithinTolerance("Load15", py[2], v.Load15, 0, loadDelta))
+	}, pt.DefaultTimeout, pt.DefaultTick)
+}
+
+func TestMiscCtxt_Against_Psutil(t *testing.T) {
+	pt.RequirePsutil(t)
+
+	// ProcsRunning/ProcsBlocked/ProcsCreated are deliberately not compared:
+	// they are instantaneous values with constant churn.
+
+	type pyCPUStats struct {
+		CtxSwitches uint64 `json:"ctx_switches"`
+	}
+
+	before, err := pt.Eval[pyCPUStats](t, "psutil.cpu_stats()")
+	require.NoError(t, err)
+
+	v, err := Misc()
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+	if v.Ctxt == 0 {
+		t.Skip("Ctxt not populated on this platform")
+	}
+	// MiscStat.Ctxt is int; on 32-bit platforms the kernel's cumulative
+	// counter can exceed it and wrap. Surface that clearly instead of
+	// comparing a garbage conversion.
+	require.Positivef(t, v.Ctxt, "Ctxt overflowed int: %d", v.Ctxt)
+
+	after, err := pt.Eval[pyCPUStats](t, "psutil.cpu_stats()")
+	require.NoError(t, err)
+
+	pt.AssertBracketed(t, "Ctxt", before.CtxSwitches, uint64(v.Ctxt), after.CtxSwitches)
+}

--- a/mem/mem_psutil_test.go
+++ b/mem/mem_psutil_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BSD-3-Clause
+package mem
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shirou/gopsutil/v4/internal/common"
+	pt "github.com/shirou/gopsutil/v4/internal/common/psutiltest"
+)
+
+const (
+	memRelTol    = 0.10
+	memAbsFloor  = 64 << 20 // 64 MiB
+	swapRelTol   = 0.05
+	swapAbsFloor = 16 << 20 // 16 MiB
+)
+
+func TestVirtualMemory_Against_Psutil(t *testing.T) {
+	pt.RequirePsutil(t)
+
+	type pyVirtualMemory struct {
+		Total     uint64 `json:"total"`
+		Available uint64 `json:"available"`
+		Free      uint64 `json:"free"`
+		Buffers   uint64 `json:"buffers"`
+		Cached    uint64 `json:"cached"`
+		Shared    uint64 `json:"shared"`
+		Slab      uint64 `json:"slab"`
+	}
+
+	v, err := VirtualMemory()
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+
+	py, err := pt.Eval[pyVirtualMemory](t, "psutil.virtual_memory()")
+	require.NoError(t, err)
+
+	// Total is static and read from the same source on every OS
+	// (linux: MemTotal, darwin: hw.memsize, windows: GlobalMemoryStatusEx).
+	require.Equal(t, py.Total, v.Total)
+
+	// Used and UsedPercent are deliberately not compared: gopsutil defines
+	// Used = Total - Available while psutil uses total - free - buffers - cached.
+
+	// The remaining fields fluctuate, so resample both sides until they agree.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		v, err := VirtualMemory()
+		if !assert.NoError(c, err) {
+			return
+		}
+		py, err := pt.Eval[pyVirtualMemory](t, "psutil.virtual_memory()")
+		if !assert.NoError(c, err) {
+			return
+		}
+		// Available comes from the same source on every OS (linux:
+		// MemAvailable, darwin: free+inactive, windows: AvailPhys).
+		assert.NoError(c, pt.CheckWithinTolerance("Available", float64(py.Available), float64(v.Available), memRelTol, memAbsFloor))
+		if runtime.GOOS != "linux" {
+			// The fields below are only compared on linux. Free is known to
+			// differ on darwin: psutil subtracts speculative pages from the
+			// mach free count while gopsutil reports it raw.
+			return
+		}
+		// Both sides read /proc/meminfo and both fold SReclaimable into Cached.
+		assert.NoError(c, pt.CheckWithinTolerance("Free", float64(py.Free), float64(v.Free), memRelTol, memAbsFloor))
+		assert.NoError(c, pt.CheckWithinTolerance("Buffers", float64(py.Buffers), float64(v.Buffers), memRelTol, memAbsFloor))
+		assert.NoError(c, pt.CheckWithinTolerance("Cached", float64(py.Cached), float64(v.Cached), memRelTol, memAbsFloor))
+		assert.NoError(c, pt.CheckWithinTolerance("Shared", float64(py.Shared), float64(v.Shared), memRelTol, memAbsFloor))
+		assert.NoError(c, pt.CheckWithinTolerance("Slab", float64(py.Slab), float64(v.Slab), memRelTol, memAbsFloor))
+	}, pt.DefaultTimeout, pt.DefaultTick)
+}
+
+func TestSwapMemory_Against_Psutil(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// psutil's swap semantics on windows (pagefile stats) and darwin
+		// (sysctl vm.swapusage granularity) have not been verified to match
+		// gopsutil's yet.
+		t.Skip("swap comparison is only verified on linux")
+	}
+	pt.RequirePsutil(t)
+
+	type pySwapMemory struct {
+		Total uint64 `json:"total"`
+		Used  uint64 `json:"used"`
+		Free  uint64 `json:"free"`
+		Sin   uint64 `json:"sin"`
+		Sout  uint64 `json:"sout"`
+	}
+
+	before, err := pt.Eval[pySwapMemory](t, "psutil.swap_memory()")
+	require.NoError(t, err)
+
+	v, err := SwapMemory()
+	if errors.Is(err, common.ErrNotImplementedError) {
+		t.Skip("not implemented")
+	}
+	require.NoError(t, err)
+
+	require.Equal(t, before.Total, v.Total)
+
+	if v.Total == 0 {
+		t.Skip("no swap configured")
+	}
+
+	// Sin/Sout: both sides multiply pswpin/pswpout from /proc/vmstat by a
+	// hardcoded 4096 (gopsutil mem_linux.go, psutil _pslinux.py), so the
+	// values are directly comparable regardless of the actual page size.
+	after, err := pt.Eval[pySwapMemory](t, "psutil.swap_memory()")
+	require.NoError(t, err)
+	pt.AssertBracketed(t, "Sin", before.Sin, v.Sin, after.Sin)
+	pt.AssertBracketed(t, "Sout", before.Sout, v.Sout, after.Sout)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		v, err := SwapMemory()
+		if !assert.NoError(c, err) {
+			return
+		}
+		py, err := pt.Eval[pySwapMemory](t, "psutil.swap_memory()")
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.NoError(c, pt.CheckWithinTolerance("Used", float64(py.Used), float64(v.Used), swapRelTol, swapAbsFloor))
+		assert.NoError(c, pt.CheckWithinTolerance("Free", float64(py.Free), float64(v.Free), swapRelTol, swapAbsFloor))
+	}, pt.DefaultTimeout, pt.DefaultTick)
+}


### PR DESCRIPTION
## Summary

Compare gopsutil results against Python [psutil](https://github.com/giampaolo/psutil) — the project gopsutil was originally modeled after, and which we continue to look up to as the reference implementation — to catch parser and semantics regressions with real values.

We have already been using this approach in the process package since #1488 (`TestName_Against_Python`). This PR expands it toward all packages, but is just the foundation: a shared helper in `internal/common/psutiltest` plus the first batch of comparisons, covering **cpu**, **mem** and **load**:

- `Eval[T](t, expr)` runs `python -c` with psutil pre-imported and JSON-decodes the result (namedtuples → structs). Tests are skipped when python/psutil is not available; setting `GOPSUTIL_PSUTIL_TEST` turns skips into failures.
- Monotonic counters (cpu times, swap sin/sout, ctx switches) are asserted with a *bracket*: psutil is sampled before and after the gopsutil call and the gopsutil value must fall in between.
- Fluctuating gauges (available memory, load average) are resampled via `require.EventuallyWithT` with a relative tolerance plus an absolute floor.

All test names end in `_Against_Psutil` (`go test -run Against_Psutil ./...`).

## Deliberately not compared (documented in code)

- `VirtualMemoryStat.Used/UsedPercent`: gopsutil uses `Total - Available`,  psutil uses `total - free - buffers - cached`.
- `Percent()`-style instantaneous values.
- Fields that only exist in linux's /proc/stat accounting are gated to linux; darwin `Free` differs by design (psutil subtracts speculative pages).
- Swap comparison is linux-only for now (windows/darwin semantics unverified).

## CI

`test.yml` installs python and a **pinned** psutil (the version these comparisons were verified against) on all runners, with `continue-on-error` so an install failure only skips the comparison tests. Once this proves stable, strict mode (`GOPSUTIL_PSUTIL_TEST: require`) can be enabled to make silent skips impossible.

Follow-ups planned: host, disk, net, and extending the process comparisons.