### PR TITLE
process: implement Darwin IOCounters via proc_pid_rusage

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Some code is ported from Ohai. Many thanks.
 |uids                |x      |x        |x        |x      |         |
 |gids                |x      |x        |x        |x      |         |
 |terminal            |x      |x        |x        |       |         |
-|io\_counters        |x      |x        |x        |       |x        |
+|io\_counters        |x      |x        |x        |x      |x        |
 |nice                |x      |x        |x        |x      |x        |
 |num\_fds            |x      |         |         |x      |x        |
 |num\_ctx\_switches  |x      |         |         |       |         |

--- a/internal/common/common_darwin.go
+++ b/internal/common/common_darwin.go
@@ -336,6 +336,16 @@ func (s *SystemLib) ProcPidInfo(pid, flavor int32, arg uint64, buffer uintptr, b
 	return fn(pid, flavor, arg, buffer, bufferSize)
 }
 
+func (s *SystemLib) ProcPidRusage(pid, flavor int32, buffer unsafe.Pointer) int32 {
+	fn := getFunc[ProcPidRusageFunc](s.library, "proc_pid_rusage")
+	return fn(pid, flavor, buffer)
+}
+
+func (s *SystemLib) Errno() int32 {
+	fn := getFunc[ErrnoFunc](s.library, "__error")
+	return *fn()
+}
+
 // status codes
 const (
 	KERN_SUCCESS = 0
@@ -440,14 +450,18 @@ const (
 )
 
 type (
-	ProcPidPathFunc func(pid int32, buffer uintptr, bufferSize uint32) int32
-	ProcPidInfoFunc func(pid, flavor int32, arg uint64, buffer uintptr, bufferSize int32) int32
+	ProcPidPathFunc   func(pid int32, buffer uintptr, bufferSize uint32) int32
+	ProcPidInfoFunc   func(pid, flavor int32, arg uint64, buffer uintptr, bufferSize int32) int32
+	ProcPidRusageFunc func(pid, flavor int32, buffer unsafe.Pointer) int32
+	ErrnoFunc         func() *int32
 )
 
 const (
-	SysctlSym      = "sysctl"
-	ProcPidPathSym = "proc_pidpath"
-	ProcPidInfoSym = "proc_pidinfo"
+	SysctlSym        = "sysctl"
+	ProcPidPathSym   = "proc_pidpath"
+	ProcPidInfoSym   = "proc_pidinfo"
+	ProcPidRusageSym = "proc_pid_rusage"
+	ErrnoSym         = "__error"
 )
 
 const (
@@ -456,6 +470,10 @@ const (
 	PROC_PIDPATHINFO_MAXSIZE = 4 * MAXPATHLEN
 	PROC_PIDTASKINFO         = 4
 	PROC_PIDVNODEPATHINFO    = 9
+
+	// RUSAGE_INFO_V2 is the proc_pid_rusage flavor that includes disk I/O bytes.
+	// See sys/resource.h rusage_info_v2.
+	RUSAGE_INFO_V2 = 2
 )
 
 // SMC represents a SMC instance.

--- a/process/process.go
+++ b/process/process.go
@@ -109,13 +109,15 @@ type IOCountersStat struct {
 	ReadCount uint64 `json:"readCount"`
 	// WriteCount is a number of read I/O operations such as syscalls.
 	WriteCount uint64 `json:"writeCount"`
-	// ReadBytes is a number of all I/O read in bytes. This includes disk I/O on Linux and Windows.
+	// ReadBytes is a number of all I/O read in bytes.
+	// On Darwin, only disk I/O bytes are available.
 	ReadBytes uint64 `json:"readBytes"`
-	// WriteBytes is a number of all I/O write in bytes. This includes disk I/O on Linux and Windows.
+	// WriteBytes is a number of all I/O written in bytes.
+	// On Darwin, only disk I/O bytes are available.
 	WriteBytes uint64 `json:"writeBytes"`
-	// DiskReadBytes is a number of disk I/O write in bytes. Currently only Linux has this value.
+	// DiskReadBytes is a number of disk I/O read in bytes. Currently, Linux and Darwin have this value.
 	DiskReadBytes uint64 `json:"diskReadBytes"`
-	// DiskWriteBytes is a number of disk I/O read in bytes.  Currently only Linux has this value.
+	// DiskWriteBytes is a number of disk I/O written in bytes. Currently, Linux and Darwin have this value.
 	DiskWriteBytes uint64 `json:"diskWriteBytes"`
 }
 

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -179,8 +179,63 @@ func (p *Process) NiceWithContext(_ context.Context) (int32, error) {
 	return int32(k.Proc.P_nice), nil
 }
 
-func (*Process) IOCountersWithContext(_ context.Context) (*IOCountersStat, error) {
-	return nil, common.ErrNotImplementedError
+// rusageInfoV2 mirrors Darwin's struct rusage_info_v2 from sys/resource.h.
+// Only DiskIOBytesRead / DiskIOBytesWritten are used for IOCounters.
+type rusageInfoV2 struct {
+	UUID                [16]byte
+	UserTime            uint64
+	SystemTime          uint64
+	PkgIdleWkups        uint64
+	InterruptWkups      uint64
+	Pageins             uint64
+	WiredSize           uint64
+	ResidentSize        uint64
+	PhysFootprint       uint64
+	ProcStartAbstime    uint64
+	ProcExitAbstime     uint64
+	ChildUserTime       uint64
+	ChildSystemTime     uint64
+	ChildPkgIdleWkups   uint64
+	ChildInterruptWkups uint64
+	ChildPageins        uint64
+	ChildElapsedAbstime uint64
+	DiskIOBytesRead     uint64
+	DiskIOBytesWritten  uint64
+}
+
+// IOCountersWithContext returns cumulative disk I/O bytes for the process via
+// proc_pid_rusage(RUSAGE_INFO_V2). ReadCount/WriteCount are unavailable on
+// Darwin. Access may fail with ErrorNotPermitted for protected processes.
+func (p *Process) IOCountersWithContext(_ context.Context) (*IOCountersStat, error) {
+	funcs, err := loadProcFuncs()
+	if err != nil {
+		return nil, err
+	}
+	defer funcs.Close()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var usage rusageInfoV2
+	ret := funcs.lib.ProcPidRusage(p.Pid, common.RUSAGE_INFO_V2, unsafe.Pointer(&usage))
+	if ret != 0 {
+		errno := unix.Errno(funcs.lib.Errno())
+		switch errno {
+		case unix.EPERM:
+			return nil, ErrorNotPermitted
+		case unix.ESRCH:
+			return nil, ErrorProcessNotRunning
+		default:
+			return nil, fmt.Errorf("proc_pid_rusage failed for pid %d: %w", p.Pid, errno)
+		}
+	}
+
+	return &IOCountersStat{
+		ReadBytes:      usage.DiskIOBytesRead,
+		WriteBytes:     usage.DiskIOBytesWritten,
+		DiskReadBytes:  usage.DiskIOBytesRead,
+		DiskWriteBytes: usage.DiskIOBytesWritten,
+	}, nil
 }
 
 func (p *Process) ChildrenWithContext(ctx context.Context) ([]*Process, error) {

--- a/process/process_darwin_test.go
+++ b/process/process_darwin_test.go
@@ -6,7 +6,9 @@ package process
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,4 +125,43 @@ func BenchmarkNumFDs(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestRusageInfoV2Layout(t *testing.T) {
+	const expectedSize = 160
+	if size := unsafe.Sizeof(rusageInfoV2{}); size != expectedSize {
+		t.Fatalf("rusage_info_v2 size: got %d, want %d", size, expectedSize)
+	}
+}
+
+func TestIOCountersDarwinDiskBytes(t *testing.T) {
+	p, err := NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	before, err := p.IOCounters()
+	require.NoError(t, err)
+	assert.Equal(t, before.ReadBytes, before.DiskReadBytes)
+	assert.Equal(t, before.WriteBytes, before.DiskWriteBytes)
+
+	path := filepath.Join(t.TempDir(), "disk-io-test")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	data := make([]byte, 4*1024*1024)
+	_, err = file.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, file.Sync())
+	require.NoError(t, file.Close())
+
+	after, err := p.IOCounters()
+	require.NoError(t, err)
+	assert.Greater(t, after.WriteBytes, before.WriteBytes)
+	assert.Equal(t, after.ReadBytes, after.DiskReadBytes)
+	assert.Equal(t, after.WriteBytes, after.DiskWriteBytes)
+}
+
+func TestIOCountersDarwinNonExistentProcess(t *testing.T) {
+	p := &Process{Pid: 999999}
+
+	_, err := p.IOCounters()
+	require.ErrorIs(t, err, ErrorProcessNotRunning)
 }


### PR DESCRIPTION
## Summary
  - Implement `process.IOCounters()` on Darwin using `proc_pid_rusage(RUSAGE_INFO_V2)` from
  `libSystem`
  - Add `SystemLib` bindings for `proc_pid_rusage` and thread-local errno via `__error()`
  - Return cumulative disk I/O bytes in both generic (`ReadBytes`/`WriteBytes`) and
  disk-specific (`DiskReadBytes`/`DiskWriteBytes`) fields
  - Map `EPERM` to `ErrorNotPermitted` and `ESRCH` to `ErrorProcessNotRunning`
  - Update `IOCountersStat` docs and the README platform matrix for macOS `io_counters`
  
 ### Notes:
  - Darwin only exposes disk byte totals; `ReadCount`/`WriteCount` remain `0`
  - Protected system processes may still return `ErrorNotPermitted` without elevated privileges