### PR TITLE
Closes #2126 Implement NtQueryInformationProcess to get commandline Windows 8.1+ 

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -6,6 +6,7 @@ package process
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -48,7 +49,10 @@ var (
 	processorArchitecture uint
 )
 
-const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION
+const (
+	processQueryInformation             = windows.PROCESS_QUERY_LIMITED_INFORMATION
+	processCommandLineInformation int32 = 60 // Windows 8.1+ ProcessCommandLineInformation  ntpsapi.h
+)
 
 type systemProcessorInformation struct {
 	ProcessorArchitecture uint16
@@ -1054,48 +1058,6 @@ func getUserProcessParams32(handle windows.Handle) (rtlUserProcessParameters32, 
 	return *(*rtlUserProcessParameters32)(unsafe.Pointer(&buf[0])), nil
 }
 
-func getCmdlineProtected(handle windows.Handle, pid int32) (string, error) {
-	const processCommandLineInformation int32 = 60 // System Informer ntpsapi.h
-	var returnLength uint32
-	// first call is to get the actual returnLength
-	err := windows.NtQueryInformationProcess(
-		handle,
-		processCommandLineInformation,
-		nil,
-		0,
-		&returnLength,
-	)
-	if err != nil && !errors.Is(err, windows.STATUS_INFO_LENGTH_MISMATCH) {
-		return "", fmt.Errorf("querying command line size for pid %d: %w", pid, err)
-	}
-	if returnLength == 0 {
-		return "", fmt.Errorf("process %d returned zero-length command line info", pid)
-	}
-
-	// second call: actually fetch it into a correctly-sized buffer
-	buf := make([]byte, returnLength)
-	err = windows.NtQueryInformationProcess(
-		handle,
-		processCommandLineInformation,
-		unsafe.Pointer(&buf[0]),
-		returnLength,
-		&returnLength,
-	)
-	if err != nil {
-		return "", fmt.Errorf("reading command line for pid %d: %w", pid, err)
-	}
-
-	us := (*windows.NTUnicodeString)(unsafe.Pointer(&buf[0]))
-	if us.Length == 0 {
-		return "", nil
-	}
-	// Compute the offset manually rather than dereferencing us.Buffer
-	// directly — see https://github.com/golang/go/issues/73460
-	strOffset := int(unsafe.Sizeof(windows.NTUnicodeString{}))
-	strEnd := strOffset + int(us.Length)
-	return convertUTF16ToString(buf[strOffset:strEnd]), nil
-}
-
 func getUserProcessParams64(handle windows.Handle) (rtlUserProcessParameters64, error) {
 	pebAddress, err := queryPebAddress(syscall.Handle(handle), false)
 	if err != nil {
@@ -1246,20 +1208,82 @@ func (p *processReader) Read(buf []byte) (int, error) {
 
 func getProcessCommandLine(pid int32) (string, error) {
 	h, err := windows.OpenProcess(processQueryInformation|windows.PROCESS_VM_READ, false, uint32(pid))
-	if errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+	if err == nil {
+		defer syscall.CloseHandle(syscall.Handle(h))
+
+		if cmdLine, err := getProcessCommandLinePEB(h); err == nil {
+			return cmdLine, nil
+		}
+
+		// PEB read failed even though the handle opened. VM_READ may
+		// have been granted but ineffective against this process's
+		// protection driver. Fall back to the native query on the same handle.
+		if cmdLine, err := getProcessCommandLineNative(h, pid); err == nil {
+			return cmdLine, nil
+		}
+
 		return "", nil
 	}
-	if err != nil {
+
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return "", nil
+	}
+	if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 		return "", err
 	}
-	defer syscall.CloseHandle(syscall.Handle(h))
 
-	// Try the native command-line query first succeeds on protected
-	// processes where the PEB-read fallback below gets ACCESS_DENIED.
-	if cmdLine, err := getCmdlineProtected(h, pid); err == nil {
-		return cmdLine, nil
+	// fallback in case it's a genuine PPL process, where
+	// PROCESS_VM_READ itself is denied at OpenProcess time. Retry with
+	// just PROCESS_QUERY_LIMITED_INFORMATION, which PPL still grants.
+	lh, lerr := windows.OpenProcess(processQueryInformation, false, uint32(pid))
+	if lerr != nil {
+		return "", nil
+	}
+	defer syscall.CloseHandle(syscall.Handle(lh))
+
+	return getProcessCommandLineNative(lh, pid)
+}
+
+func getProcessCommandLineNative(handle windows.Handle, pid int32) (string, error) {
+	var returnLength uint32
+	// first call is to get the actual returnLength
+	err := windows.NtQueryInformationProcess(
+		handle,
+		processCommandLineInformation,
+		nil,
+		0,
+		&returnLength,
+	)
+	if err != nil &&
+		!errors.Is(err, windows.STATUS_INFO_LENGTH_MISMATCH) &&
+		!errors.Is(err, windows.STATUS_BUFFER_OVERFLOW) &&
+		!errors.Is(err, windows.STATUS_BUFFER_TOO_SMALL) {
+		return "", fmt.Errorf("querying command line size for pid %d: %w", pid, err)
+	}
+	if returnLength == 0 {
+		return "", fmt.Errorf("process %d returned zero-length command line info", pid)
 	}
 
+	// second call: actually fetch it into a correctly-sized buffer
+	buf := make([]byte, returnLength)
+	err = windows.NtQueryInformationProcess(
+		handle,
+		processCommandLineInformation,
+		unsafe.Pointer(&buf[0]),
+		returnLength,
+		&returnLength,
+	)
+	if err != nil {
+		return "", fmt.Errorf("reading command line for pid %d: %w", pid, err)
+	}
+	cmdLine, err := parseCommandLineInformation(buf)
+	if err != nil {
+		return "", fmt.Errorf("parsing command line for pid %d: %w", pid, err)
+	}
+	return cmdLine, nil
+}
+
+func getProcessCommandLinePEB(h windows.Handle) (string, error) {
 	procIs32Bits := is32BitProcess(h)
 
 	if procIs32Bits {
@@ -1305,4 +1329,20 @@ func convertUTF16ToString(src []byte) string {
 		srcIdx += 2
 	}
 	return syscall.UTF16ToString(codePoints)
+}
+
+func parseCommandLineInformation(buf []byte) (string, error) {
+	if len(buf) < 2 {
+		return "", errors.New("command line buffer too small to read length")
+	}
+	length := binary.LittleEndian.Uint16(buf[0:2])
+	if length == 0 {
+		return "", nil
+	}
+	strOffset := int(unsafe.Sizeof(windows.NTUnicodeString{}))
+	strEnd := strOffset + int(length)
+	if strEnd > len(buf) {
+		return "", errors.New("command line length exceeds buffer size")
+	}
+	return convertUTF16ToString(buf[strOffset:strEnd]), nil
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -49,10 +49,7 @@ var (
 	processorArchitecture uint
 )
 
-const (
-	processQueryInformation             = windows.PROCESS_QUERY_LIMITED_INFORMATION
-	processCommandLineInformation int32 = 60 // Windows 8.1+ ProcessCommandLineInformation  ntpsapi.h
-)
+const processQueryInformation = windows.PROCESS_QUERY_LIMITED_INFORMATION
 
 type systemProcessorInformation struct {
 	ProcessorArchitecture uint16
@@ -1211,7 +1208,8 @@ func getProcessCommandLine(pid int32) (string, error) {
 	if err == nil {
 		defer syscall.CloseHandle(syscall.Handle(h))
 
-		if cmdLine, err := getProcessCommandLinePEB(h); err == nil {
+		cmdLine, pebErr := getProcessCommandLinePEB(h)
+		if pebErr == nil {
 			return cmdLine, nil
 		}
 
@@ -1221,8 +1219,7 @@ func getProcessCommandLine(pid int32) (string, error) {
 		if cmdLine, err := getProcessCommandLineNative(h, pid); err == nil {
 			return cmdLine, nil
 		}
-
-		return "", nil
+		return "", pebErr
 	}
 
 	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
@@ -1240,8 +1237,8 @@ func getProcessCommandLine(pid int32) (string, error) {
 		return "", nil
 	}
 	defer syscall.CloseHandle(syscall.Handle(lh))
-
-	return getProcessCommandLineNative(lh, pid)
+	cmdLine, _ := getProcessCommandLineNative(lh, pid)
+	return cmdLine, nil
 }
 
 func getProcessCommandLineNative(handle windows.Handle, pid int32) (string, error) {
@@ -1249,7 +1246,7 @@ func getProcessCommandLineNative(handle windows.Handle, pid int32) (string, erro
 	// first call is to get the actual returnLength
 	err := windows.NtQueryInformationProcess(
 		handle,
-		processCommandLineInformation,
+		windows.ProcessCommandLineInformation,
 		nil,
 		0,
 		&returnLength,
@@ -1268,7 +1265,7 @@ func getProcessCommandLineNative(handle windows.Handle, pid int32) (string, erro
 	buf := make([]byte, returnLength)
 	err = windows.NtQueryInformationProcess(
 		handle,
-		processCommandLineInformation,
+		windows.ProcessCommandLineInformation,
 		unsafe.Pointer(&buf[0]),
 		returnLength,
 		&returnLength,

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -1053,7 +1053,47 @@ func getUserProcessParams32(handle windows.Handle) (rtlUserProcessParameters32, 
 	}
 	return *(*rtlUserProcessParameters32)(unsafe.Pointer(&buf[0])), nil
 }
+func getCmdlineProtected(handle windows.Handle, pid int32) (string, error) {
+	const processCommandLineInformation int32 = 60 // System Informer ntpsapi.h
+	var returnLength uint32
+	// first call is to get the actual returnLength
+	err := windows.NtQueryInformationProcess(
+		handle,
+		processCommandLineInformation,
+		nil,
+		0,
+		&returnLength,
+	)
+	if err != nil && !errors.Is(err, windows.STATUS_INFO_LENGTH_MISMATCH) {
+		return "", fmt.Errorf("querying command line size for pid %d: %w", pid, err)
+	}
+	if returnLength == 0 {
+		return "", fmt.Errorf("process %d returned zero-length command line info", pid)
+	}
 
+	// second call: actually fetch it into a correctly-sized buffer
+	buf := make([]byte, returnLength)
+	err = windows.NtQueryInformationProcess(
+		handle,
+		processCommandLineInformation,
+		unsafe.Pointer(&buf[0]),
+		returnLength,
+		&returnLength,
+	)
+	if err != nil {
+		return "", fmt.Errorf("reading command line for pid %d: %w", pid, err)
+	}
+
+	us := (*windows.NTUnicodeString)(unsafe.Pointer(&buf[0]))
+	if us.Length == 0 {
+		return "", nil
+	}
+	// Compute the offset manually rather than dereferencing us.Buffer
+	// directly — see https://github.com/golang/go/issues/73460
+	strOffset := int(unsafe.Sizeof(windows.NTUnicodeString{}))
+	strEnd := strOffset + int(us.Length)
+	return convertUTF16ToString(buf[strOffset:strEnd]), nil
+}
 func getUserProcessParams64(handle windows.Handle) (rtlUserProcessParameters64, error) {
 	pebAddress, err := queryPebAddress(syscall.Handle(handle), false)
 	if err != nil {
@@ -1211,6 +1251,12 @@ func getProcessCommandLine(pid int32) (string, error) {
 		return "", err
 	}
 	defer syscall.CloseHandle(syscall.Handle(h))
+
+	// Try the native command-line query first succeeds on protected
+	// processes where the PEB-read fallback below gets ACCESS_DENIED.
+	if cmdLine, err := getCmdlineProtected(h, pid); err == nil {
+		return cmdLine, nil
+	}
 
 	procIs32Bits := is32BitProcess(h)
 

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -1053,6 +1053,7 @@ func getUserProcessParams32(handle windows.Handle) (rtlUserProcessParameters32, 
 	}
 	return *(*rtlUserProcessParameters32)(unsafe.Pointer(&buf[0])), nil
 }
+
 func getCmdlineProtected(handle windows.Handle, pid int32) (string, error) {
 	const processCommandLineInformation int32 = 60 // System Informer ntpsapi.h
 	var returnLength uint32
@@ -1094,6 +1095,7 @@ func getCmdlineProtected(handle windows.Handle, pid int32) (string, error) {
 	strEnd := strOffset + int(us.Length)
 	return convertUTF16ToString(buf[strOffset:strEnd]), nil
 }
+
 func getUserProcessParams64(handle windows.Handle) (rtlUserProcessParameters64, error) {
 	pebAddress, err := queryPebAddress(syscall.Handle(handle), false)
 	if err != nil {

--- a/process/process_windows_test.go
+++ b/process/process_windows_test.go
@@ -1,0 +1,57 @@
+package process
+
+import (
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestParseCommandLineInformation(t *testing.T) {
+	headerSize := int(unsafe.Sizeof(windows.NTUnicodeString{}))
+
+	buildBuf := func(s string) []byte {
+		utf16Data := utf16.Encode([]rune(s))
+		dataBytes := make([]byte, len(utf16Data)*2)
+		for i, u := range utf16Data {
+			binary.LittleEndian.PutUint16(dataBytes[i*2:], u)
+		}
+		buf := make([]byte, headerSize+len(dataBytes))
+		binary.LittleEndian.PutUint16(buf[0:2], uint16(len(dataBytes))) // Length field
+		copy(buf[headerSize:], dataBytes)
+		return buf
+	}
+
+	tests := []struct {
+		name      string
+		buf       []byte
+		expect    string
+		expectErr bool
+	}{
+		{name: "valid command line", buf: buildBuf("notepad.exe file.txt"), expect: "notepad.exe file.txt"},
+		{name: "empty command line", buf: buildBuf(""), expect: ""},
+		{name: "buffer too small for length field", buf: []byte{0x01}, expectErr: true},
+		{
+			name: "truncated buffer (length claims more than available)",
+			buf: func() []byte {
+				b := buildBuf("some command")
+				return b[:len(b)-4] // simulates the panic scenario point 4 guards against
+			}(),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCommandLineInformation(tt.buf)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("unexpected error state: err=%v, expectErr=%v", err, tt.expectErr)
+			}
+			if !tt.expectErr && got != tt.expect {
+				t.Errorf("got %q, expect %q", got, tt.expect)
+			}
+		})
+	}
+}

--- a/process/process_windows_test.go
+++ b/process/process_windows_test.go
@@ -1,43 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
 package process
 
 import (
 	"encoding/binary"
+	"os"
+	"syscall"
 	"testing"
 	"unicode/utf16"
 	"unsafe"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
 
 func TestParseCommandLineInformation(t *testing.T) {
-	headerSize := int(unsafe.Sizeof(windows.NTUnicodeString{}))
+	ntUnicodeStringHeaderSize := int(unsafe.Offsetof(windows.NTUnicodeString{}.Buffer)) +
+		int(unsafe.Sizeof((*uint16)(nil)))
 
-	buildBuf := func(s string) []byte {
+	buildCommandLineInfoBuf := func(s string) []byte {
 		utf16Data := utf16.Encode([]rune(s))
 		dataBytes := make([]byte, len(utf16Data)*2)
 		for i, u := range utf16Data {
 			binary.LittleEndian.PutUint16(dataBytes[i*2:], u)
 		}
-		buf := make([]byte, headerSize+len(dataBytes))
-		binary.LittleEndian.PutUint16(buf[0:2], uint16(len(dataBytes))) // Length field
-		copy(buf[headerSize:], dataBytes)
+		buf := make([]byte, ntUnicodeStringHeaderSize+len(dataBytes))
+		binary.LittleEndian.PutUint16(buf[0:2], uint16(len(dataBytes)))
+		copy(buf[ntUnicodeStringHeaderSize:], dataBytes)
 		return buf
 	}
-
 	tests := []struct {
 		name      string
 		buf       []byte
 		expect    string
 		expectErr bool
 	}{
-		{name: "valid command line", buf: buildBuf("notepad.exe file.txt"), expect: "notepad.exe file.txt"},
-		{name: "empty command line", buf: buildBuf(""), expect: ""},
-		{name: "buffer too small for length field", buf: []byte{0x01}, expectErr: true},
+		{
+			name:   "valid command line",
+			buf:    buildCommandLineInfoBuf("notepad.exe file.txt"),
+			expect: "notepad.exe file.txt",
+		},
+		{
+			name:   "empty command line",
+			buf:    buildCommandLineInfoBuf(""),
+			expect: "",
+		},
+		{
+			name:      "buffer too small for length field",
+			buf:       []byte{0x01},
+			expectErr: true,
+		},
 		{
 			name: "truncated buffer (length claims more than available)",
 			buf: func() []byte {
-				b := buildBuf("some command")
-				return b[:len(b)-4] // simulates the panic scenario point 4 guards against
+				b := buildCommandLineInfoBuf("some command")
+				return b[:len(b)-4]
 			}(),
 			expectErr: true,
 		},
@@ -46,12 +63,33 @@ func TestParseCommandLineInformation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseCommandLineInformation(tt.buf)
-			if (err != nil) != tt.expectErr {
-				t.Fatalf("unexpected error state: err=%v, expectErr=%v", err, tt.expectErr)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
 			}
-			if !tt.expectErr && got != tt.expect {
-				t.Errorf("got %q, expect %q", got, tt.expect)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, got)
 		})
 	}
+}
+
+// TestGetProcessCommandLineNativeMatchesPEB verifies that the native
+// NtQueryInformationProcess path and the PEB read path return the same
+// command line for the current process.
+func TestGetProcessCommandLineNativeMatchesPEB(t *testing.T) {
+	pid := int32(os.Getpid())
+	h, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ,
+		false,
+		uint32(pid),
+	)
+	require.NoError(t, err)
+	defer syscall.CloseHandle(syscall.Handle(h))
+
+	pebCmdline, err := getProcessCommandLinePEB(h)
+	require.NoError(t, err)
+
+	nativeCmdline, err := getProcessCommandLineNative(h, pid)
+	require.NoError(t, err)
+	assert.Equal(t, pebCmdline, nativeCmdline)
 }


### PR DESCRIPTION
Adds `getCmdlineProtected`, which uses  `ProcessCommandLineInformation` ->
`NtQueryInformationProcess` before falling back to the existing PEB memory read
approach in `getProcessCommandLine`. 

If it fails (pre-8.1 version of windows or such) it should fall back to the current implementation of PEB. 
Tested against `LeagueClient.exe` a Vanguard-protected process on Windows 10
this Closes #2126 