### PR TITLE
fix(disk/aix): use statfs for UsageWithContext on AIX

### DIFF
--- a/disk/disk_aix.go
+++ b/disk/disk_aix.go
@@ -8,11 +8,26 @@ import (
 	"errors"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 func LabelWithContext(_ context.Context, _ string) (string, error) {
 	return "", common.ErrNotImplementedError
+}
+
+// FSType maps AIX filesystem type numbers (as reported by statfs and perfstat)
+// to their string name. Shared by the cgo and nocgo build variants.
+var FSType = map[int]string{
+	0: "jfs2", 1: "namefs", 2: "nfs", 3: "jfs", 5: "cdrom", 6: "proc",
+	16: "special-fs", 17: "cache-fs", 18: "nfs3", 19: "automount-fs", 20: "pool-fs", 32: "vxfs",
+	33: "veritas-fs", 34: "udfs", 35: "nfs4", 36: "nfs4-pseudo", 37: "smbfs", 38: "mcr-pseudofs",
+	39: "ahafs", 40: "sterm-nfs", 41: "asmfs",
+}
+
+func getFsType(stat unix.Statfs_t) string {
+	return FSType[int(stat.Vfstype)]
 }
 
 // Using lscfg and a device name, we can get the device information

--- a/disk/disk_aix_cgo.go
+++ b/disk/disk_aix_cgo.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/power-devops/perfstat"
 )
@@ -52,17 +51,6 @@ func IOCountersWithContext(_ context.Context, names ...string) (map[string]IOCou
 	return ret, nil
 }
 
-var FSType map[int]string
-
-func init() {
-	FSType = map[int]string{
-		0: "jfs2", 1: "namefs", 2: "nfs", 3: "jfs", 5: "cdrom", 6: "proc",
-		16: "special-fs", 17: "cache-fs", 18: "nfs3", 19: "automount-fs", 20: "pool-fs", 32: "vxfs",
-		33: "veritas-fs", 34: "udfs", 35: "nfs4", 36: "nfs4-pseudo", 37: "smbfs", 38: "mcr-pseudofs",
-		39: "ahafs", 40: "sterm-nfs", 41: "asmfs",
-	}
-}
-
 func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, error) {
 	f, err := perfstat.FileSystemStat()
 	if err != nil {
@@ -84,35 +72,4 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	return ret, err
-}
-
-func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
-	f, err := perfstat.FileSystemStat()
-	if err != nil {
-		return nil, err
-	}
-
-	blocksize := uint64(512)
-	for _, fs := range f {
-		if path == fs.MountPoint {
-			fstyp, exists := FSType[fs.FSType]
-			if !exists {
-				fstyp = "unknown"
-			}
-			info := UsageStat{
-				Path:        path,
-				Fstype:      fstyp,
-				Total:       uint64(fs.TotalBlocks) * blocksize,
-				Free:        uint64(fs.FreeBlocks) * blocksize,
-				Used:        uint64(fs.TotalBlocks-fs.FreeBlocks) * blocksize,
-				InodesTotal: uint64(fs.TotalInodes),
-				InodesFree:  uint64(fs.FreeInodes),
-				InodesUsed:  uint64(fs.TotalInodes - fs.FreeInodes),
-			}
-			info.UsedPercent = (float64(info.Used) / float64(info.Total)) * 100.0
-			info.InodesUsedPercent = (float64(info.InodesUsed) / float64(info.InodesTotal)) * 100.0
-			return &info, nil
-		}
-	}
-	return nil, fmt.Errorf("mountpoint %s not found", path)
 }

--- a/disk/disk_aix_nocgo.go
+++ b/disk/disk_aix_nocgo.go
@@ -5,27 +5,16 @@ package disk
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/sys/unix"
 
 	"github.com/shirou/gopsutil/v4/internal/common"
 )
 
 var startBlank = regexp.MustCompile(`^\s+`)
 
-var (
-	ignoreFSType = map[string]bool{"procfs": true}
-	FSType       = map[int]string{
-		0: "jfs2", 1: "namefs", 2: "nfs", 3: "jfs", 5: "cdrom", 6: "proc",
-		16: "special-fs", 17: "cache-fs", 18: "nfs3", 19: "automount-fs", 20: "pool-fs", 32: "vxfs",
-		33: "veritas-fs", 34: "udfs", 35: "nfs4", 36: "nfs4-pseudo", 37: "smbfs", 38: "mcr-pseudofs",
-		39: "ahafs", 40: "sterm-nfs", 41: "asmfs",
-	}
-)
+var ignoreFSType = map[string]bool{"procfs": true}
 
 func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOCountersStat, error) {
 	out, err := invoke.CommandWithContext(ctx, "iostat", "-d")
@@ -121,129 +110,6 @@ func PartitionsWithContext(ctx context.Context, _ bool) ([]PartitionStat, error)
 	}
 
 	return ret, nil
-}
-
-func getFsType(stat unix.Statfs_t) string {
-	return FSType[int(stat.Vfstype)]
-}
-
-func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
-	out, err := invoke.CommandWithContext(ctx, "df", "-v")
-	if err != nil {
-		return nil, err
-	}
-
-	blocksize := uint64(512)
-	lines := strings.Split(string(out), "\n")
-	if len(lines) < 2 {
-		return nil, common.ErrNotImplementedError
-	}
-
-	hf := strings.Fields(strings.ReplaceAll(lines[0], "Mounted on", "Path")) // headers
-
-	// Find the Path column index once before the loop.
-	pathIdx := -1
-	for i, header := range hf {
-		if header == "Path" {
-			pathIdx = i
-			break
-		}
-	}
-
-	for line := 1; line < len(lines); line++ {
-		fs := strings.Fields(lines[line]) // values
-		if len(fs) < len(hf) {
-			continue
-		}
-
-		if pathIdx < 0 || fs[pathIdx] != path {
-			continue
-		}
-
-		ret := &UsageStat{}
-		for i, header := range hf {
-			if i >= len(fs) {
-				break
-			}
-
-			switch header {
-			case `Path`:
-				ret.Path = fs[i]
-			case `512-blocks`:
-				if fs[i] == "-" {
-					continue
-				}
-				total, err := strconv.ParseUint(fs[i], 10, 64)
-				if err != nil {
-					return nil, err
-				}
-				ret.Total = total * blocksize
-			case `Used`:
-				if fs[i] == "-" {
-					continue
-				}
-				used, err := strconv.ParseUint(fs[i], 10, 64)
-				if err != nil {
-					return nil, err
-				}
-				ret.Used = used * blocksize
-			case `Free`:
-				if fs[i] == "-" {
-					continue
-				}
-				free, err := strconv.ParseUint(fs[i], 10, 64)
-				if err != nil {
-					return nil, err
-				}
-				ret.Free = free * blocksize
-			case `%Used`:
-				if fs[i] == "-" {
-					continue
-				}
-				val, err := strconv.ParseInt(strings.ReplaceAll(fs[i], "%", ""), 10, 32)
-				if err != nil {
-					return nil, err
-				}
-				ret.UsedPercent = float64(val)
-			case `Ifree`:
-				if fs[i] == "-" {
-					continue
-				}
-				ret.InodesFree, err = strconv.ParseUint(fs[i], 10, 64)
-				if err != nil {
-					return nil, err
-				}
-			case `Iused`:
-				if fs[i] == "-" {
-					continue
-				}
-				ret.InodesUsed, err = strconv.ParseUint(fs[i], 10, 64)
-				if err != nil {
-					return nil, err
-				}
-			case `%Iused`:
-				if fs[i] == "-" {
-					continue
-				}
-				val, err := strconv.ParseInt(strings.ReplaceAll(fs[i], "%", ""), 10, 32)
-				if err != nil {
-					return nil, err
-				}
-				ret.InodesUsedPercent = float64(val)
-			}
-		}
-
-		ret.InodesTotal = ret.InodesUsed + ret.InodesFree
-
-		var statfs unix.Statfs_t
-		if err := unix.Statfs(path, &statfs); err == nil {
-			ret.Fstype = getFsType(statfs)
-		}
-
-		return ret, nil
-	}
-
-	return nil, fmt.Errorf("mountpoint %s not found", path)
 }
 
 func GetMountFSTypeWithContext(ctx context.Context, mp string) (string, error) {

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//go:build freebsd || linux || darwin
+//go:build freebsd || linux || darwin || aix
 
 package disk
 


### PR DESCRIPTION
Update `UsageWithContext` on AIX to use the same implementation as other Unix OSes, based on the `statfs` syscall.

- Aligns implementation with other OSes
- Avoids running commands (and parsing the output) in the `CGO_ENABLED=0` case
- Makes `UsageWithContext` work with arbitrary paths. The old implementations (both CGO and no-CGO) only work when `path` is exactly a mountpoint (fails with `mountpoint ... not found` otherwise), while `statfs` works properly no matter what

I confirmed getting the exact same output for real mountpoints, and it now works for non-mountpoints. 