### PR TITLE
Fix CI Lint and pin version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,4 +72,9 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:
           args: --verbose
-          version: latest
+          # Pinned, like the SHA-pinned actions above. With `latest`, a
+          # golangci-lint release turns every open PR red at once, on code
+          # nobody touched, and the breakage lands on whoever pushes next.
+          # dependabot does not track this input, so bump it deliberately
+          # and take the new findings in that same PR.
+          version: v2.13.1

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -524,18 +524,23 @@ func getSMBIOSProcessorInfo() (family uint8, processorId string, err error) {
 
 func getSystemLogicalProcessorInformationEx(relationship relationship) ([]systemLogicalProcessorInformationEx, error) {
 	var length uint32
-	// First call to determine the required buffer size
-	_, _, err := procGetLogicalProcessorInformationEx.Call(uintptr(relationship), 0, uintptr(unsafe.Pointer(&length)))
-	if err != nil && !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
+	// First call to determine the required buffer size. It is expected to
+	// fail with ERROR_INSUFFICIENT_BUFFER; the error returned by Call is
+	// only meaningful once the BOOL return value says the call failed.
+	ret, _, err := procGetLogicalProcessorInformationEx.Call(uintptr(relationship), 0, uintptr(unsafe.Pointer(&length)))
+	if ret == 0 && !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
 		return nil, fmt.Errorf("failed to get buffer size: %w", err)
+	}
+	if length == 0 {
+		return nil, errors.New("failed to get buffer size: reported size is zero")
 	}
 
 	// Allocate the buffer
 	buffer := make([]byte, length)
 
 	// Second call to retrieve the processor information
-	_, _, err = procGetLogicalProcessorInformationEx.Call(uintptr(relationship), uintptr(unsafe.Pointer(&buffer[0])), uintptr(unsafe.Pointer(&length)))
-	if err != nil && !errors.Is(err, windows.NTE_OP_OK) {
+	ret, _, err = procGetLogicalProcessorInformationEx.Call(uintptr(relationship), uintptr(unsafe.Pointer(&buffer[0])), uintptr(unsafe.Pointer(&length)))
+	if ret == 0 {
 		return nil, fmt.Errorf("failed to get logical processor information: %w", err)
 	}
 

--- a/disk/disk_linux.go
+++ b/disk/disk_linux.go
@@ -526,47 +526,47 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 			continue
 		}
 
-		reads, err := strconv.ParseUint((fields[3]), 10, 64)
+		reads, err := strconv.ParseUint(fields[3], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		mergedReads, err := strconv.ParseUint((fields[4]), 10, 64)
+		mergedReads, err := strconv.ParseUint(fields[4], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		rbytes, err := strconv.ParseUint((fields[5]), 10, 64)
+		rbytes, err := strconv.ParseUint(fields[5], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		rtime, err := strconv.ParseUint((fields[6]), 10, 64)
+		rtime, err := strconv.ParseUint(fields[6], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		writes, err := strconv.ParseUint((fields[7]), 10, 64)
+		writes, err := strconv.ParseUint(fields[7], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		mergedWrites, err := strconv.ParseUint((fields[8]), 10, 64)
+		mergedWrites, err := strconv.ParseUint(fields[8], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		wbytes, err := strconv.ParseUint((fields[9]), 10, 64)
+		wbytes, err := strconv.ParseUint(fields[9], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		wtime, err := strconv.ParseUint((fields[10]), 10, 64)
+		wtime, err := strconv.ParseUint(fields[10], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		iopsInProgress, err := strconv.ParseUint((fields[11]), 10, 64)
+		iopsInProgress, err := strconv.ParseUint(fields[11], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		iotime, err := strconv.ParseUint((fields[12]), 10, 64)
+		iotime, err := strconv.ParseUint(fields[12], 10, 64)
 		if err != nil {
 			return ret, err
 		}
-		weightedIO, err := strconv.ParseUint((fields[13]), 10, 64)
+		weightedIO, err := strconv.ParseUint(fields[13], 10, 64)
 		if err != nil {
 			return ret, err
 		}

--- a/disk/disk_netbsd.go
+++ b/disk/disk_netbsd.go
@@ -129,8 +129,8 @@ func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.Blocks) * uint64(bsize)),
 		Free:        (uint64(stat.Bavail) * uint64(bsize)),
-		InodesTotal: (uint64(stat.Files)),
-		InodesFree:  (uint64(stat.Ffree)),
+		InodesTotal: uint64(stat.Files),
+		InodesFree:  uint64(stat.Ffree),
 	}
 
 	ret.InodesUsed = (ret.InodesTotal - ret.InodesFree)

--- a/disk/disk_openbsd.go
+++ b/disk/disk_openbsd.go
@@ -134,8 +134,8 @@ func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.F_blocks) * uint64(bsize)),
 		Free:        (uint64(stat.F_bavail) * uint64(bsize)),
-		InodesTotal: (uint64(stat.F_files)),
-		InodesFree:  (uint64(stat.F_ffree)),
+		InodesTotal: uint64(stat.F_files),
+		InodesFree:  uint64(stat.F_ffree),
 	}
 
 	ret.InodesUsed = (ret.InodesTotal - ret.InodesFree)

--- a/disk/disk_solaris.go
+++ b/disk/disk_solaris.go
@@ -133,22 +133,22 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		// fields[3] is the statistic label, fields[4] is the value
 		switch fields[3] {
 		case "nread":
-			nreadarr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+			nreadarr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "nwritten":
-			nwrittenarr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+			nwrittenarr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "reads":
-			readsarr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+			readsarr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 			if err != nil {
 				return nil, err
 			}
 		case "writes":
-			writesarr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+			writesarr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 			if err != nil {
 				return nil, err
 			}
@@ -156,11 +156,11 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 			if issolaris {
 				// from sec to milli secs
 				var frtime float64
-				frtime, err = strconv.ParseFloat((fields[4]), 64)
+				frtime, err = strconv.ParseFloat(fields[4], 64)
 				rtimearr[moduleName+instance] = uint64(frtime * 1000)
 			} else {
 				// from nano to milli secs
-				rtimearr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+				rtimearr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 				rtimearr[moduleName+instance] = rtimearr[moduleName+instance] / 1000 / 1000
 			}
 			if err != nil {
@@ -170,11 +170,11 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 			if issolaris {
 				// from sec to milli secs
 				var fwtime float64
-				fwtime, err = strconv.ParseFloat((fields[4]), 64)
+				fwtime, err = strconv.ParseFloat(fields[4], 64)
 				wtimearr[moduleName+instance] = uint64(fwtime * 1000)
 			} else {
 				// from nano to milli secs
-				wtimearr[moduleName+instance], err = strconv.ParseUint((fields[4]), 10, 64)
+				wtimearr[moduleName+instance], err = strconv.ParseUint(fields[4], 10, 64)
 				wtimearr[moduleName+instance] = wtimearr[moduleName+instance] / 1000 / 1000
 			}
 			if err != nil {

--- a/disk/disk_unix.go
+++ b/disk/disk_unix.go
@@ -23,8 +23,8 @@ func UsageWithContext(_ context.Context, path string) (*UsageStat, error) {
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.Blocks) * uint64(bsize)),
 		Free:        (uint64(stat.Bavail) * uint64(bsize)),
-		InodesTotal: (uint64(stat.Files)),
-		InodesFree:  (uint64(stat.Ffree)),
+		InodesTotal: uint64(stat.Files),
+		InodesFree:  uint64(stat.Ffree),
 	}
 
 	ret.Used = (uint64(stat.Blocks) - uint64(stat.Bfree)) * uint64(bsize)

--- a/disk/disk_windows.go
+++ b/disk/disk_windows.go
@@ -159,7 +159,7 @@ func processVolumeLoop(ctx context.Context, nextVolHandle uintptr, volNameBuf []
 		if volRet, _, err := procFindNextVolumeW.Call(
 			nextVolHandle,
 			uintptr(unsafe.Pointer(&volNameBuf[0])),
-			uintptr(maxVolumeNameLength)); err != nil && volRet == 0 {
+			uintptr(maxVolumeNameLength)); volRet == 0 {
 			var errno syscall.Errno
 			if errors.As(err, &errno) && errno == windows.ERROR_NO_MORE_FILES {
 				break

--- a/internal/common/common_windows.go
+++ b/internal/common/common_windows.go
@@ -184,7 +184,7 @@ func NewWin32PerformanceCounter(postName, counterName string) (*Win32Performance
 
 func (w *Win32PerformanceCounter) GetValue() (float64, error) {
 	r, _, err := PdhCollectQueryData.Call(uintptr(w.Query))
-	if r != 0 && err != nil {
+	if r != 0 {
 		if r == PDH_NO_DATA {
 			return 0.0, fmt.Errorf("%w: this counter has not data", err)
 		}

--- a/process/process.go
+++ b/process/process.go
@@ -281,7 +281,7 @@ func (p *Process) PercentWithContext(ctx context.Context, interval time.Duration
 	}
 
 	numcpu := runtime.NumCPU()
-	delta := (now.Sub(p.lastCPUTime).Seconds()) * float64(numcpu)
+	delta := now.Sub(p.lastCPUTime).Seconds() * float64(numcpu)
 	ret := calculatePercent(p.lastCPUTimes, cpuTimes, delta, numcpu)
 	p.lastCPUTimes = cpuTimes
 	p.lastCPUTime = now


### PR DESCRIPTION
## Why

`lint.yml` pins the action by SHA but asks it to install `version: latest`, so the
linter running *inside* the pinned action was free to move. It did — [golangci-lint v2.13.0](https://github.com/golangci/golangci-lint/releases/tag/v2.13.0) landed on 2026-08-19 with a new gofumpt and staticcheck 0.8.0 — and the next CI run turned all 29 lint jobs red on code that nobody had touched. #2129 was the PR that happened to be open at the time, which is a confusing place to find out.

This takes the new findings and stops the drift.

## 1. gofumpt: redundant parentheses

The new gofumpt strips parentheses around a single expression. Nothing here has been edited since 2014–2016:

```diff
- strconv.ParseUint((fields[3]), 10, 64)
+ strconv.ParseUint(fields[3], 10, 64)

- InodesTotal: (uint64(stat.Files)),
+ InodesTotal: uint64(stat.Files),

- delta := (now.Sub(p.lastCPUTime).Seconds()) * float64(numcpu)
+ delta := now.Sub(p.lastCPUTime).Seconds() * float64(numcpu)
```

Applied with `golangci-lint fmt` over every `GOOS`/`GOARCH` in the lint matrix rather than only the three files the linux job reported — `disk_netbsd.go`, `disk_openbsd.go` and `disk_solaris.go` are behind build tags and only surface in their own jobs.

## 2. staticcheck SA4023 on windows

`LazyProc.Call` always returns a non-nil error. It hands back a `syscall.Errno`, which is `0` on success but still a non-nil interface value, so `err != nil` is a constant. Four conditions read as if they checked the call result and did not:

| | before | after |
|---|---|---|
| `disk/disk_windows.go:162` | `err != nil && volRet == 0` | `volRet == 0` |
| `internal/common/common_windows.go:187` | `r != 0 && err != nil` | `r != 0` |
| `cpu/cpu_windows.go:538` | `err != nil && !errors.Is(err, NTE_OP_OK)` | `ret == 0` |
| `cpu/cpu_windows.go:529` | `err != nil && !errors.Is(err, ERROR_INSUFFICIENT_BUFFER)` | `ret == 0 && !errors.Is(...)` |

The first three had a second term doing the real work, so behaviour is unchanged. `NTE_OP_OK` is a Cryptography API status that happens to be `0`, so comparing a kernel32 `Errno` against it was an indirect way of asking whether the call succeeded; the `BOOL` return value says so directly.

The sizing call is the one that was actually wrong rather than merely redundant. Had it succeeded, `errors.Is(Errno(0), ERROR_INSUFFICIENT_BUFFER)` is false and the function returned `failed to get buffer size: The operation completed successfully`. Checking `ret` fixes that, and because success no longer short-circuits the function, a zero `length` is now rejected explicitly instead of reaching `&buffer[0]` on an empty slice.

## 3. Pin the version

```yaml
          # Pinned, like the SHA-pinned actions above. With `latest`, a
          # golangci-lint release turns every open PR red at once, on code
          # nobody touched, and the breakage lands on whoever pushes next.
          # dependabot does not track this input, so bump it deliberately
          # and take the new findings in that same PR.
          version: v2.13.1
```

dependabot's `github-actions` ecosystem updates action refs, not inputs, so this one stays manual — the trade is that a linter bump arrives as its own reviewable PR instead of on golangci-lint's release schedule.

## Verification

`golangci-lint v2.13.1` across all 29 `GOOS`/`GOARCH` combinations in the matrix: no findings. `go build` for `windows/amd64`, `windows/386` and `windows/arm64`. The windows behaviour itself is covered by the existing `test.yml` jobs.

## Not included

- `gomodguard` is deprecated since golangci-lint v2.12.0 in favour of `gomodguard_v2`. It only warns today, so it can move on its own.
- Go 1.26's vet has an `inline` analyzer that flags `reflect.Ptr` in `internal/common/common.go:309` (it wants `reflect.Pointer`). CI runs Go 1.24 via `go-version-file: go.mod`, so it does not appear yet; it will the moment go.mod moves to 1.26.