### PR TITLE
Return an error on empty OpenBSD KinfoProc

### DIFF
--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -392,6 +392,9 @@ func callKernProcSyscall(op, arg int32) ([]byte, uint64, error) {
 	if err != 0 {
 		return nil, length, err
 	}
+	if length == 0 {
+		return nil, 0, errors.New("empty KinfoProc")
+	}
 
 	count := int32(length / uint64(sizeOfKinfoProc))
 	mib = []int32{CTLKern, KernProc, op, arg, sizeOfKinfoProc, count}


### PR DESCRIPTION
Fixes #2130

`callKernProcSyscall` queries sysctl for the `KinfoProc` length, allocates a buffer of that size, then passes `&buf[0]` into the second sysctl. When the first query returns `length == 0` (observed under concurrent `Process.Times()` on OpenBSD), `buf` is empty and that dereference panics:

```
panic: runtime error: index out of range [0] with length 0
```

The size check added in #1694 runs only after this function returns, so it cannot prevent the panic. Return an error instead of indexing an empty buffer. Callers already handle errors from `Times()`.