### PR TITLE
Bump perfstat to fix memory leaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ebitengine/purego v0.10.2
 	github.com/google/go-cmp v0.7.0
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0
-	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55
+	github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6
 	github.com/stretchr/testify v1.11.1
 	github.com/tklauser/go-sysconf v0.3.16
 	github.com/yusufpapurcu/wmi v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
-github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6 h1:jL3a8soXdzuTCcRnKhOmtcsVOObdDTFf4O2B403HPRU=
+github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=


### PR DESCRIPTION
Bump perfstat to benefit from https://github.com/power-devops/perfstat/commit/88456608a4f64370a1b43fd5d347e0a5f2d1b18a (last commit on main), which fixes many memory leaks in the library.

I was seeing a significant memory leak over time (~1GiB per day when I reproduced it, more than that for some users), tracked it down to `github.com/power-devops/perfstat`, and noticed the last commit fixed a lot of memory leaks.
The leak was particularly visible for logic getting info about filesystem / disks, but I believe I also had smaller leaks from other functions.